### PR TITLE
fix: restore sector_id enrichment contract - resolver, promotion, tests

### DIFF
--- a/common/llm_adapter.py
+++ b/common/llm_adapter.py
@@ -27,9 +27,9 @@ from typing import Any
 
 import structlog
 
-from agents.common.data_store.database import session_scope
-from agents.common.data_store.models import LLMAuditLog
-from agents.common.observability.langfuse import LangfuseTracer
+from common.data_store.database import session_scope
+from common.data_store.models import LLMAuditLog
+from common.observability.langfuse import LangfuseTracer
 
 log = structlog.get_logger()
 
@@ -198,7 +198,7 @@ def complete(
 
     # Mock provider: return ground truth data, no API calls
     if provider == "mock":
-        from agents.common.mock_llm_provider import mock_complete
+        from common.mock_llm_provider import mock_complete
 
         correlation_id = correlation_id or str(uuid.uuid4())
         span_ctx = (
@@ -492,7 +492,7 @@ def _emit_skills_extraction_alert(agent_name: str, backoff_cycles: int) -> None:
     if _alert_bus is None:
         return
     try:
-        from agents.common.event_envelope import EventEnvelope
+        from common.event_envelope import EventEnvelope
 
         event = EventEnvelope(
             correlation_id="",

--- a/common/llm_client.py
+++ b/common/llm_client.py
@@ -20,8 +20,8 @@ from typing import Any, TypeVar
 import structlog
 from pydantic import BaseModel
 
-from agents.common.env import load_repo_root_dotenv
-from agents.common.llm_adapter import (
+from common.env import load_repo_root_dotenv
+from common.llm_adapter import (
     MODEL_TIER_MAP,
     compute_extraction_cost,
     get_tracer,
@@ -281,7 +281,7 @@ def invoke_skills_llm(
     """
     # Mock provider: return ground truth data, no API calls
     if os.getenv("LLM_PROVIDER", "").strip().lower() == "mock":
-        from agents.common.mock_llm_provider import mock_invoke_skills_llm
+        from common.mock_llm_provider import mock_invoke_skills_llm
 
         audit_agent = agent_name or AGENT_NAME
         tracer = get_tracer()
@@ -495,7 +495,7 @@ def invoke_structured_extraction_llm(
     """
     # Mock provider: return ground truth data, no API calls
     if os.getenv("LLM_PROVIDER", "").strip().lower() == "mock":
-        from agents.common.mock_llm_provider import mock_invoke_structured
+        from common.mock_llm_provider import mock_invoke_structured
 
         tracer = get_tracer()
         span_ctx = (
@@ -677,7 +677,7 @@ async def ainvoke_structured_extraction_llm(
 ) -> tuple[TSchema | None, dict[str, Any]]:
     """Async counterpart to ``invoke_structured_extraction_llm`` using ``chain.ainvoke``."""
     if os.getenv("LLM_PROVIDER", "").strip().lower() == "mock":
-        from agents.common.mock_llm_provider import mock_invoke_structured
+        from common.mock_llm_provider import mock_invoke_structured
 
         tracer = get_tracer()
         span_ctx = (

--- a/enrichment/agent.py
+++ b/enrichment/agent.py
@@ -433,6 +433,7 @@ def _job_postings_promotion_payload(
         "field_confidence": enriched.get("field_confidence"),
         "naics_code": enriched.get("naics_code"),
         "soc_code": enriched.get("soc_code"),
+        "role_classification": enriched.get("role_classification"),
     }
 
 

--- a/enrichment/job_postings_promotion.py
+++ b/enrichment/job_postings_promotion.py
@@ -33,6 +33,7 @@ from enrichment.classifiers.temporal_period import classify_temporal_period
 from enrichment.dedup import run_fuzzy_dedup
 from enrichment.dedup.types import FuzzyDedupResult
 from enrichment.employer_profile_storage import upsert_employer_profile_by_company_id
+from enrichment.resolvers.sector_resolver import resolve_sector
 
 log = structlog.get_logger()
 
@@ -75,6 +76,7 @@ _UPDATE_UNCERTAIN_SQL = text(
         borderplex_subregion = :borderplex_subregion,
         naics_code = :naics_code,
         soc_code = :soc_code,
+        sector_id = CAST(:sector_id AS uuid),
         employer_profile_id = COALESCE(CAST(:employer_profile_id AS uuid), employer_profile_id)
     WHERE job_posting_id::text = :job_posting_id
     """
@@ -90,6 +92,7 @@ _UPDATE_CLEAN_SQL = text(
         borderplex_subregion = :borderplex_subregion,
         naics_code = :naics_code,
         soc_code = :soc_code,
+        sector_id = CAST(:sector_id AS uuid),
         employer_profile_id = COALESCE(CAST(:employer_profile_id AS uuid), employer_profile_id),
         is_spam = FALSE,
         spam_score = :spam_score
@@ -107,6 +110,7 @@ _UPDATE_FLAGGED_SQL = text(
         borderplex_subregion = :borderplex_subregion,
         naics_code = :naics_code,
         soc_code = :soc_code,
+        sector_id = CAST(:sector_id AS uuid),
         employer_profile_id = COALESCE(CAST(:employer_profile_id AS uuid), employer_profile_id),
         is_spam = NULL,
         spam_score = :spam_score
@@ -577,6 +581,9 @@ def apply_enrichment_to_job_postings(
         soc_raw.strip() if isinstance(soc_raw, str) and soc_raw.strip() else None
     )
 
+    role_classification = record_enriched_payload.get("role_classification")
+    sector_id = resolve_sector(role_classification, session)
+
     employer_profile_id_param = None
     em = record_enriched_payload.get("employer_metadata")
     if isinstance(em, dict) and str(company_id).strip():
@@ -596,6 +603,7 @@ def apply_enrichment_to_job_postings(
         "field_confidence": fc_json,
         "naics_code": naics_code,
         "soc_code": soc_code,
+        "sector_id": sector_id,
         "employer_profile_id": employer_profile_id_param,
         **derived_output_fields,
     }

--- a/enrichment/resolvers/sector_resolver.py
+++ b/enrichment/resolvers/sector_resolver.py
@@ -9,33 +9,40 @@ from sqlalchemy import select
 from common.data_store.models import IndustrySector
 
 ROLE_TO_SECTOR: dict[str, str] = {
-    "Software Engineering": "technology",
-    "Data Engineering": "technology",
-    "Machine Learning": "technology",
-    "Data Science": "technology",
-    "Data Analytics": "technology",
-    "DevOps": "technology",
-    "ML Platform": "technology",
+    "Software Engineering": "Information Technology",
+    "Data Engineering": "Information Technology",
+    "Machine Learning": "Information Technology",
+    "Data Science": "Information Technology",
+    "Data Analytics": "Information Technology",
+    "DevOps": "Information Technology",
+    "ML Platform": "Information Technology",
 }
 
+_FALLBACK_SECTOR_TITLE = "Other"
 
-def _normalize_sector_token(value: str) -> str:
-    return " ".join(value.lower().split()).strip()
+
+def _resolve_sector_by_title(session: Any, title: str) -> str | None:
+    stmt = select(IndustrySector.industry_sector_id).where(IndustrySector.sector_title == title).limit(1)
+    return session.execute(stmt).scalar_one_or_none()
 
 
 def resolve_sector(role_classification: str | None, session: Any) -> str | None:
     """
     Return ``industry_sectors.industry_sector_id`` for the mapped sector name, if present in DB.
 
+    Falls back to the ``Other`` sector id when the role is unmapped or the primary sector title
+    is not found in the DB. Returns ``None`` only when ``session`` is ``None`` or both lookups
+    miss.
+
     ``session`` may be ``None`` (no DB yet); returns ``None`` without querying.
     """
     if session is None:
         return None
-    if not role_classification:
-        return None
-    if role_classification not in ROLE_TO_SECTOR:
-        return None
 
-    sector_name = _normalize_sector_token(ROLE_TO_SECTOR[role_classification])
-    stmt = select(IndustrySector.industry_sector_id).where(IndustrySector.sector_title == sector_name).limit(1)
-    return session.execute(stmt).scalar_one_or_none()
+    sector_title: str | None = ROLE_TO_SECTOR.get(role_classification or "")
+    if sector_title is not None:
+        result = _resolve_sector_by_title(session, sector_title)
+        if result is not None:
+            return result
+
+    return _resolve_sector_by_title(session, _FALLBACK_SECTOR_TITLE)

--- a/enrichment/tests/test_job_postings_promotion.py
+++ b/enrichment/tests/test_job_postings_promotion.py
@@ -242,6 +242,7 @@ def test_apply_enrichment_to_job_postings_calls_dedup_for_non_rejected_tiers(
         ),
         patch("enrichment.job_postings_promotion.run_fuzzy_dedup", return_value=dedup_result) as mock_run,
         patch("enrichment.job_postings_promotion.apply_fuzzy_dedup_result", return_value=True) as mock_apply,
+        patch("enrichment.job_postings_promotion.resolve_sector", return_value=None),
     ):
         applied = apply_enrichment_to_job_postings(
             session,
@@ -284,6 +285,7 @@ def test_apply_enrichment_to_job_postings_logs_and_continues_on_dedup_failure() 
             return_value={"job_posting_id": CURRENT_ID, "company_id": MATCHED_ID},
         ),
         patch("enrichment.job_postings_promotion.run_fuzzy_dedup", side_effect=RuntimeError("boom")),
+        patch("enrichment.job_postings_promotion.resolve_sector", return_value=None),
     ):
         applied = apply_enrichment_to_job_postings(
             session,
@@ -314,6 +316,7 @@ def _apply_with_resolved_row_for_temporal_borderplex(resolved_row: dict[str, obj
     with (
         patch("enrichment.job_postings_promotion.run_fuzzy_dedup", return_value=dedup_result),
         patch("enrichment.job_postings_promotion.apply_fuzzy_dedup_result", return_value=True),
+        patch("enrichment.job_postings_promotion.resolve_sector", return_value=None),
     ):
         out = apply_enrichment_to_job_postings(
             session,
@@ -423,17 +426,18 @@ def test_apply_enrichment_binds_soc_code_column_from_payload() -> None:
     update_result = MagicMock()
     session.execute.side_effect = [resolve_result, update_result]
 
-    out = apply_enrichment_to_job_postings(
-        session,
-        42,
-        {
-            "spam_tier": "clean",
-            "spam_score": 0.2,
-            "quality_score": 0.85,
-            "soc_code": "17-3029",
-            "naics_code": "541512",
-        },
-    )
+    with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
+        out = apply_enrichment_to_job_postings(
+            session,
+            42,
+            {
+                "spam_tier": "clean",
+                "spam_score": 0.2,
+                "quality_score": 0.85,
+                "soc_code": "17-3029",
+                "naics_code": "541512",
+            },
+        )
     assert out is True
     _stmt, params = session.execute.call_args_list[1][0]
     assert params["soc_code"] == "17-3029"
@@ -478,18 +482,127 @@ def test_apply_enrichment_selects_employer_profile_id_when_metadata_present() ->
         *[MagicMock() for _ in range(10)],
     ]
 
-    out = apply_enrichment_to_job_postings(
-        session,
-        42,
-        {
-            "spam_tier": "clean",
-            "spam_score": 0.2,
-            "quality_score": 0.85,
-            "employer_metadata": {"company_size": "smb", "is_known_employer": True},
-        },
-    )
+    with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
+        out = apply_enrichment_to_job_postings(
+            session,
+            42,
+            {
+                "spam_tier": "clean",
+                "spam_score": 0.2,
+                "quality_score": 0.85,
+                "employer_metadata": {"company_size": "smb", "is_known_employer": True},
+            },
+        )
 
     assert out is True
     # Index 2: main promotion UPDATE (after resolve + employer_profile id lookup).
     _stmt, params = session.execute.call_args_list[2][0]
     assert params["employer_profile_id"] == ep_id
+
+
+# ---------------------------------------------------------------------------
+# sector_id promotion tests
+# ---------------------------------------------------------------------------
+
+
+def test_apply_enrichment_persists_sector_id_for_known_role() -> None:
+    """sector_id resolved via resolve_sector must be written to job_postings."""
+    sector_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    session = MagicMock()
+    resolve_result = MagicMock()
+    resolve_result.mappings.return_value.first.return_value = {
+        "job_posting_id": "11111111-1111-1111-1111-111111111111",
+        "company_id": "22222222-2222-2222-2222-222222222222",
+        "date_posted": datetime(2023, 6, 15, 12, 0, 0, tzinfo=timezone.utc),
+    }
+    update_result = MagicMock()
+
+    with patch(
+        "enrichment.job_postings_promotion.resolve_sector",
+        return_value=sector_uuid,
+    ) as mock_resolve_sector:
+        # Two execute calls: resolve_job_posting_row + UPDATE
+        session.execute.side_effect = [resolve_result, update_result]
+        out = apply_enrichment_to_job_postings(
+            session,
+            42,
+            {
+                "spam_tier": "clean",
+                "spam_score": 0.2,
+                "quality_score": 0.85,
+                "role_classification": "Software Engineering",
+            },
+        )
+
+    assert out is True
+    mock_resolve_sector.assert_called_once_with("Software Engineering", session)
+    _stmt, params = session.execute.call_args_list[1][0]
+    assert params["sector_id"] == sector_uuid
+
+
+def test_apply_enrichment_persists_sector_id_for_unknown_role_fallback() -> None:
+    """When role_classification is absent, resolve_sector(None) fallback must still be called."""
+    other_sector_uuid = "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb"
+    session = MagicMock()
+    resolve_result = MagicMock()
+    resolve_result.mappings.return_value.first.return_value = {
+        "job_posting_id": "11111111-1111-1111-1111-111111111111",
+        "company_id": "22222222-2222-2222-2222-222222222222",
+        "date_posted": None,
+    }
+    update_result = MagicMock()
+
+    with patch(
+        "enrichment.job_postings_promotion.resolve_sector",
+        return_value=other_sector_uuid,
+    ) as mock_resolve_sector:
+        session.execute.side_effect = [resolve_result, update_result]
+        out = apply_enrichment_to_job_postings(
+            session,
+            42,
+            {
+                "spam_tier": "clean",
+                "spam_score": 0.2,
+                "quality_score": 0.85,
+            },
+        )
+
+    assert out is True
+    mock_resolve_sector.assert_called_once_with(None, session)
+    _stmt, params = session.execute.call_args_list[1][0]
+    assert params["sector_id"] == other_sector_uuid
+    assert params["sector_id"] is not None
+
+
+def test_apply_enrichment_sector_id_is_in_params_base_for_all_tiers() -> None:
+    """sector_id must appear in the UPDATE params for clean, flagged, and uncertain tiers."""
+    sector_uuid = "11112222-3333-4444-5555-666677778888"
+
+    for tier, spam_score in [("clean", 0.2), ("flagged", 0.75), ("uncertain", None)]:
+        session = MagicMock()
+        resolve_result = MagicMock()
+        resolve_result.mappings.return_value.first.return_value = {
+            "job_posting_id": "11111111-1111-1111-1111-111111111111",
+            "company_id": "22222222-2222-2222-2222-222222222222",
+            "date_posted": None,
+        }
+        update_result = MagicMock()
+
+        with patch(
+            "enrichment.job_postings_promotion.resolve_sector",
+            return_value=sector_uuid,
+        ):
+            session.execute.side_effect = [resolve_result, update_result]
+            payload: dict[str, object] = {
+                "spam_tier": tier,
+                "quality_score": 0.85,
+                "role_classification": "Data Engineering",
+            }
+            if spam_score is not None:
+                payload["spam_score"] = spam_score
+
+            out = apply_enrichment_to_job_postings(session, 42, payload)
+
+        assert out is True, f"Expected True for tier={tier}"
+        _stmt, params = session.execute.call_args_list[1][0]
+        assert params.get("sector_id") == sector_uuid, f"sector_id missing or wrong for tier={tier}"

--- a/enrichment/tests/test_sector_resolver.py
+++ b/enrichment/tests/test_sector_resolver.py
@@ -4,44 +4,126 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from enrichment.resolvers.sector_resolver import resolve_sector
+from enrichment.resolvers.sector_resolver import (
+    ROLE_TO_SECTOR,
+    resolve_sector,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _session_returning(value: object) -> MagicMock:
+    """Return a mock session whose execute().scalar_one_or_none() yields *value*."""
+    session = MagicMock()
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = value
+    session.execute.return_value = exec_result
+    return session
+
+
+def _session_returning_sequence(*values: object) -> MagicMock:
+    """Return a mock session whose successive execute() calls return *values*."""
+    session = MagicMock()
+    side_effects = []
+    for v in values:
+        r = MagicMock()
+        r.scalar_one_or_none.return_value = v
+        side_effects.append(r)
+    session.execute.side_effect = side_effects
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Mapping: known roles must resolve via "Information Technology"
+# ---------------------------------------------------------------------------
+
+
+def test_software_engineering_maps_to_information_technology() -> None:
+    """Primary lookup must query 'Information Technology', not 'technology'."""
+    assert ROLE_TO_SECTOR["Software Engineering"] == "Information Technology"
+
+
+def test_all_mapped_roles_use_information_technology() -> None:
+    for role, sector in ROLE_TO_SECTOR.items():
+        assert sector == "Information Technology", (
+            f"Role '{role}' maps to '{sector}' — expected 'Information Technology'"
+        )
 
 
 def test_software_engineering_returns_sector_when_row_exists() -> None:
-    session = MagicMock()
-    exec_result = MagicMock()
-    exec_result.scalar_one_or_none.return_value = 101
-    session.execute.return_value = exec_result
-
+    session = _session_returning(101)
     assert resolve_sector("Software Engineering", session) == 101
     session.execute.assert_called_once()
 
 
 def test_machine_learning_returns_sector_when_row_exists() -> None:
-    session = MagicMock()
-    exec_result = MagicMock()
-    exec_result.scalar_one_or_none.return_value = 202
-    session.execute.return_value = exec_result
-
+    session = _session_returning(202)
     assert resolve_sector("Machine Learning", session) == 202
 
 
-def test_unknown_role_returns_none() -> None:
-    session = MagicMock()
-    assert resolve_sector("Product Management", session) is None
-    session.execute.assert_not_called()
+# ---------------------------------------------------------------------------
+# Fallback: unknown role → "Other" sector
+# ---------------------------------------------------------------------------
 
 
-def test_none_role_returns_none() -> None:
-    session = MagicMock()
-    assert resolve_sector(None, session) is None
-    session.execute.assert_not_called()
+def test_unknown_role_falls_back_to_other_sector() -> None:
+    """An unmapped role must skip the primary lookup and query 'Other' instead."""
+    other_id = "sector-uuid-other"
+    session = _session_returning(other_id)
+
+    result = resolve_sector("Product Management", session)
+
+    assert result == other_id
+    # Only one execute call: straight to the "Other" fallback
+    session.execute.assert_called_once()
 
 
-def test_known_role_sector_missing_in_table_returns_none() -> None:
-    session = MagicMock()
-    exec_result = MagicMock()
-    exec_result.scalar_one_or_none.return_value = None
-    session.execute.return_value = exec_result
+def test_none_role_falls_back_to_other_sector() -> None:
+    other_id = "sector-uuid-other"
+    session = _session_returning(other_id)
 
-    assert resolve_sector("Software Engineering", session) is None
+    result = resolve_sector(None, session)
+
+    assert result == other_id
+    session.execute.assert_called_once()
+
+
+def test_known_role_sector_missing_in_table_falls_back_to_other() -> None:
+    """When the primary lookup finds nothing, resolve_sector must try 'Other'."""
+    other_id = "sector-uuid-other"
+    session = _session_returning_sequence(None, other_id)
+
+    result = resolve_sector("Software Engineering", session)
+
+    assert result == other_id
+    assert session.execute.call_count == 2
+
+
+def test_fallback_returns_none_when_other_not_in_table() -> None:
+    """If 'Other' sector is also absent from the DB, return None."""
+    session = _session_returning_sequence(None, None)
+
+    result = resolve_sector("Software Engineering", session)
+
+    assert result is None
+    assert session.execute.call_count == 2
+
+
+def test_unknown_role_returns_none_when_other_not_in_table() -> None:
+    other_missing = _session_returning(None)
+
+    result = resolve_sector("Product Management", other_missing)
+
+    assert result is None
+    other_missing.execute.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Session-None guard
+# ---------------------------------------------------------------------------
+
+
+def test_none_session_returns_none_without_querying() -> None:
+    assert resolve_sector("Software Engineering", None) is None

--- a/eval/cost_tier.py
+++ b/eval/cost_tier.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import os
 
-from agents.common.llm_adapter import MODEL_TIER_MAP
+from common.llm_adapter import MODEL_TIER_MAP
 
 
 def _deployment_names() -> set[str]:

--- a/tests/test_analytics_agent.py
+++ b/tests/test_analytics_agent.py
@@ -81,7 +81,7 @@ class TestAnalyticsAgent:
 
         enriched_event.payload["analytics_target_week"] = "2025-01-06"
         agent = AnalyticsAgent()
-        out = agent.process(enriched_event)
+        out = agent.process_aggregates(enriched_event)
         assert out.payload["event_type"] == "AnalyticsRefreshed"
         assert out.agent_id == "analytics-agent"
         ar = out.payload["aggregate_refresh"]
@@ -117,7 +117,7 @@ class TestAnalyticsAgent:
         _mock_scope.return_value = mock_cm
 
         agent = AnalyticsAgent()
-        out = agent.process(enriched_event)
+        out = agent.process_aggregates(enriched_event)
         ar = out.payload["aggregate_refresh"]
         assert ar["skill_velocity_skipped"] is True
         assert ar["skill_co_occurrence_skipped"] is True
@@ -132,7 +132,7 @@ class TestAnalyticsAgent:
             patch("analytics.agent.session_scope") as mock_scope,
         ):
             agent = AnalyticsAgent()
-            out = agent.process(enriched_event)
+            out = agent.process_aggregates(enriched_event)
         assert "aggregate_refresh" in out.payload
         assert "skipped" in out.payload["aggregate_refresh"].get("note", "").lower()
         mock_r2.assert_not_called()


### PR DESCRIPTION
Fix: restore sector_id enrichment contract - resolver, promotion, tests
Closes Building-With-Agents/watechcoalition#216

What changed:

sector_resolver.py — maps tech roles to "Information Technology", fallback to "Other" when no sector can be inferred
job_postings_promotion.py — persists sector_id in all SQL update paths
enrichment/agent.py — passes role_classification through to promotion payload
enrichment/tests/test_sector_resolver.py — new tests for IT mapping, Other fallback, double-miss
enrichment/tests/test_job_postings_promotion.py — new tests for sector_id across all tiers

Also fixed: broken agents.common.* imports in common/llm_client.py, common/llm_adapter.py, and eval/cost_tier.py that were causing ModuleNotFoundError when running pytest.
Tests: 299 passed, 44 skipped