### PR TITLE
docs: add Week 7-8 processing loop technical diagram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,9 @@ docs/planning/*
 !docs/planning/ARCHITECTURE_HIGH_LEVEL.md
 !docs/planning/component-diagram.html
 !docs/planning/component-diagram-walking-skeleton.html
+!docs/planning/processing-loop-diagram.html
+!docs/planning/processing-loop-technical-diagram.html
+!docs/planning/processing-loop-technical-diagram-weeks7-8.html
 docs/planning/curriculum/
 docs/lesson-framework/
 

--- a/docs/planning/processing-loop-technical-diagram-weeks7-8.html
+++ b/docs/planning/processing-loop-technical-diagram-weeks7-8.html
@@ -1,0 +1,647 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Processing Loop — Technical Pipeline Diagram</title>
+<style>
+  body { margin: 0; padding: 32px; background: #F8FAFC; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #0F172A; }
+  h1 { font-size: 20px; font-weight: 700; margin: 0 0 6px 0; letter-spacing: -0.3px; }
+  p.subtitle { font-size: 12px; color: #64748B; margin: 0 0 20px 0; }
+  code { font-family: 'SF Mono','Consolas',monospace; font-size: 10px; }
+  .ref-table { width: 100%; border-collapse: collapse; font-size: 11px; margin-top: 24px; }
+  .ref-table th { text-align: left; background: #1E293B; color: #F8FAFC; padding: 6px 10px; }
+  .ref-table td { padding: 6px 10px; border: 1px solid #E2E8F0; vertical-align: top; }
+  .ref-table code { background: #F1F5F9; padding: 1px 3px; border-radius: 3px; }
+  .ref-table tr:hover { background: #F8FAFC; }
+  .ref-table .gap { background: #FEF2F2; }
+</style>
+</head>
+<body>
+<h1>Processing Loop — Technical Pipeline Diagram (Weeks 7–8)</h1>
+<p class="subtitle">
+  Flywheel pattern: Loop 1 (<code>batch_ingest.py</code>) stages raw records —
+  Loop 2 (<code>run_processing_loop.py</code>) processes them through 4 agents.
+  Week 7 adds Analytics Agent (13-step aggregation). Week 8 adds Workforce Intelligence Q&amp;A.
+  Cost: ~$0.021/job (Azure gpt-4.1-mini, verified April 2026).
+  Ref: <code>ARCHITECTURE_DEEP.md §5</code>, <code>CLAUDE.md Part B</code>
+</p>
+
+<svg width="1200" height="2400" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+<defs>
+  <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M0 0L10 5L0 10z" fill="#374151"/></marker>
+  <marker id="ag" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M0 0L10 5L0 10z" fill="#059669"/></marker>
+  <marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M0 0L10 5L0 10z" fill="#DC2626"/></marker>
+  <marker id="ab" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M0 0L10 5L0 10z" fill="#2563EB"/></marker>
+  <marker id="ao" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M0 0L10 5L0 10z" fill="#D97706"/></marker>
+  <marker id="ap" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M0 0L10 5L0 10z" fill="#7C3AED"/></marker>
+</defs>
+
+<!-- ══════════════════════════════════════════════════════
+     LOOP 1 — INGESTION
+══════════════════════════════════════════════════════ -->
+<rect x="20" y="10" width="1160" height="190" rx="12" fill="#EFF6FF" stroke="#93C5FD" stroke-width="1.5"/>
+<text x="35" y="30" font-size="11" fill="#1D4ED8" font-weight="700" letter-spacing="1">LOOP 1 — INGESTION (NO LLM · $0)</text>
+<text x="280" y="30" font-size="9" fill="#64748B">scripts/batch_ingest.py → ingestion/agent.py::process()</text>
+
+<!-- Config box -->
+<rect x="40" y="48" width="170" height="42" rx="6" fill="#DBEAFE" stroke="#93C5FD"/>
+<text x="125" y="65" text-anchor="middle" font-size="10" fill="#1E40AF" font-weight="600">ingestion_queries.yaml</text>
+<text x="125" y="80" text-anchor="middle" font-size="8" fill="#64748B">47 queries · keywords · pages</text>
+
+<!-- JSearch -->
+<rect x="230" y="48" width="110" height="42" rx="6" fill="#0D9488"/>
+<text x="285" y="65" text-anchor="middle" font-size="10" fill="white" font-weight="600">JSearch API</text>
+<text x="285" y="80" text-anchor="middle" font-size="8" fill="#CCFBF1">httpx · paginated</text>
+
+<!-- Arrow: config → JSearch -->
+<path d="M210 69 L228 69" stroke="#374151" stroke-width="1.5" marker-end="url(#a)" fill="none"/>
+
+<!-- Ingestion Agent -->
+<rect x="360" y="48" width="250" height="42" rx="6" fill="#1D4ED8"/>
+<text x="485" y="65" text-anchor="middle" font-size="11" fill="white" font-weight="700">IngestionAgent.process()</text>
+<text x="485" y="80" text-anchor="middle" font-size="8" fill="#BFDBFE">SHA-256 dedup · provenance tags · source priority</text>
+
+<!-- Arrow: JSearch → Agent -->
+<path d="M340 69 L358 69" stroke="#374151" stroke-width="1.5" marker-end="url(#a)" fill="none"/>
+
+<!-- Key rotation box -->
+<rect x="360" y="100" width="250" height="38" rx="6" fill="#F1F5F9" stroke="#CBD5E1"/>
+<text x="485" y="115" text-anchor="middle" font-size="9" fill="#475569" font-weight="600">--start-query N · --queries name1,name2 · --start-key K</text>
+<text x="485" y="130" text-anchor="middle" font-size="8" fill="#64748B">Key rotation: 200 req budget/key · 7 keys available</text>
+
+<!-- DB tables for ingestion (right side, inline) -->
+<rect x="660" y="44" width="210" height="32" rx="5" fill="#059669"/>
+<text x="765" y="65" text-anchor="middle" font-size="10" fill="white" font-weight="600">raw_ingested_jobs</text>
+<!-- Arrow: Agent → raw_ingested_jobs (horizontal) -->
+<path d="M610 62 L658 62" stroke="#059669" stroke-width="2" marker-end="url(#ag)" fill="none"/>
+<!-- Label with background -->
+<rect x="616" y="51" width="36" height="14" rx="3" fill="#F0FDF4"/>
+<text x="634" y="62" text-anchor="middle" font-size="8" fill="#059669" font-weight="600">WRITE</text>
+
+<rect x="660" y="84" width="210" height="32" rx="5" fill="#047857"/>
+<text x="765" y="105" text-anchor="middle" font-size="10" fill="white" font-weight="600">job_ingestion_runs</text>
+<!-- Arrow: Agent → job_ingestion_runs (right then down) -->
+<path d="M610 72 L640 72 L640 100 L658 100" stroke="#059669" stroke-width="1.5" marker-end="url(#ag)" fill="none"/>
+
+<!-- Status badge -->
+<rect x="890" y="44" width="140" height="32" rx="5" fill="#FEF2F2" stroke="#FECACA"/>
+<text x="960" y="60" text-anchor="middle" font-size="8" fill="#991B1B" font-weight="600">PERMANENT AUDIT TABLE</text>
+<text x="960" y="72" text-anchor="middle" font-size="7" fill="#991B1B">never truncate · dedup fingerprints</text>
+
+<!-- ══════════════════════════════════════════════════════
+     GAP BETWEEN LOOPS
+══════════════════════════════════════════════════════ -->
+<rect x="350" y="155" width="310" height="36" rx="6" fill="#FEF2F2" stroke="#FECACA" stroke-dasharray="6,3"/>
+<text x="505" y="170" text-anchor="middle" font-size="10" fill="#DC2626" font-weight="700">⚠ GAP — No EventEnvelope between loops</text>
+<text x="505" y="183" text-anchor="middle" font-size="8" fill="#991B1B">Loop 2 discovers pending records via DB query, not IngestBatch event</text>
+
+<!-- Arrow down from Loop 1 to gap -->
+<path d="M505 140 L505 153" stroke="#374151" stroke-width="1.5" marker-end="url(#a)" fill="none"/>
+
+<!-- ══════════════════════════════════════════════════════
+     LOOP 2 — PROCESSING
+══════════════════════════════════════════════════════ -->
+<rect x="20" y="210" width="1160" height="1280" rx="12" fill="#F5F3FF" stroke="#C4B5FD" stroke-width="1.5"/>
+<text x="35" y="230" font-size="11" fill="#6D28D9" font-weight="700" letter-spacing="1">LOOP 2 — PROCESSING (LLM CALLS · ~$0.021/JOB)</text>
+<text x="340" y="230" font-size="9" fill="#64748B">scripts/run_processing_loop.py::main() — iterates until pending=0 and unextracted=0</text>
+
+<!-- Pre-iteration queries -->
+<rect x="40" y="248" width="420" height="55" rx="6" fill="#EDE9FE" stroke="#C4B5FD"/>
+<text x="50" y="264" font-size="10" fill="#5B21B6" font-weight="700">Pre-iteration DB queries (per iteration)</text>
+<text x="50" y="278" font-size="8" fill="#64748B">_count_pending() → SELECT COUNT(*) FROM raw_ingested_jobs WHERE status='pending'</text>
+<text x="50" y="290" font-size="8" fill="#64748B">_count_unextracted() → normalized_jobs LEFT JOIN extracted_intelligence WHERE ei.id IS NULL</text>
+
+<!-- Read arrows from pre-iteration (short horizontal + label) -->
+<rect x="468" y="258" width="80" height="14" rx="3" fill="#EFF6FF"/>
+<text x="508" y="268" text-anchor="middle" font-size="8" fill="#2563EB" font-weight="600">DB READ ×2</text>
+
+<!-- Langfuse trace -->
+<rect x="540" y="248" width="220" height="55" rx="6" fill="#FFF7ED" stroke="#FED7AA"/>
+<text x="650" y="264" text-anchor="middle" font-size="9" fill="#92400E" font-weight="700">Langfuse Parent Trace</text>
+<text x="650" y="278" text-anchor="middle" font-size="8" fill="#64748B">_tracer.start_trace(f"iter-{n}")</text>
+<text x="650" y="290" text-anchor="middle" font-size="8" fill="#64748B">All agent spans nest under this trace</text>
+
+<!-- ══════════════════════════════════════════════════════
+     STAGE 1 — NORMALIZATION
+══════════════════════════════════════════════════════ -->
+<rect x="40" y="320" width="720" height="165" rx="8" fill="#EEF2FF" stroke="#6366F1" stroke-width="2"/>
+<text x="55" y="340" font-size="11" fill="#4338CA" font-weight="700">STAGE 1 — NormalizationAgent.process(trigger)</text>
+<text x="390" y="340" font-size="9" fill="#64748B">normalization/agent.py:383 | $0 (no LLM) | batch_size from NORM_BATCH_SIZE</text>
+
+<!-- Steps row 1 -->
+<rect x="55" y="352" width="160" height="40" rx="4" fill="#DBEAFE"/>
+<text x="135" y="368" text-anchor="middle" font-size="9" fill="#1E40AF" font-weight="600">1. Fetch pending raw</text>
+<text x="135" y="381" text-anchor="middle" font-size="8" fill="#64748B">query(RawIngestedJob)</text>
+
+<rect x="225" y="352" width="155" height="40" rx="4" fill="#F1F5F9"/>
+<text x="302" y="368" text-anchor="middle" font-size="9" fill="#374151" font-weight="600">2. Field mapping</text>
+<text x="302" y="381" text-anchor="middle" font-size="8" fill="#64748B">per-source mappers</text>
+
+<rect x="390" y="352" width="155" height="40" rx="4" fill="#DCFCE7"/>
+<text x="467" y="368" text-anchor="middle" font-size="9" fill="#166534" font-weight="600">3a. Write pass</text>
+<text x="467" y="381" text-anchor="middle" font-size="8" fill="#64748B">→ normalized_jobs</text>
+
+<rect x="555" y="352" width="155" height="40" rx="4" fill="#FEE2E2"/>
+<text x="632" y="368" text-anchor="middle" font-size="9" fill="#991B1B" font-weight="600">3b. Write quarantine</text>
+<text x="632" y="381" text-anchor="middle" font-size="8" fill="#64748B">→ normalization_quarantine</text>
+
+<!-- Steps row 2 -->
+<rect x="55" y="402" width="340" height="32" rx="4" fill="#FEF3C7"/>
+<text x="225" y="422" text-anchor="middle" font-size="9" fill="#92400E" font-weight="600">4. Update raw_ingested_jobs.processing_status = 'processed' | 'quarantined'</text>
+
+<!-- DB tables for normalization (right side, stacked) -->
+<rect x="790" y="322" width="210" height="30" rx="5" fill="#059669"/>
+<text x="895" y="342" text-anchor="middle" font-size="10" fill="white" font-weight="600">normalized_jobs</text>
+<!-- Arrow 3a → normalized_jobs -->
+<path d="M545 372 L760 372 L760 337 L788 337" stroke="#059669" stroke-width="2" marker-end="url(#ag)" fill="none"/>
+<rect x="722" y="360" width="36" height="14" rx="3" fill="#EEF2FF"/>
+<text x="740" y="370" text-anchor="middle" font-size="7" fill="#059669" font-weight="600">WRITE</text>
+
+<rect x="790" y="362" width="210" height="30" rx="5" fill="#B91C1C"/>
+<text x="895" y="382" text-anchor="middle" font-size="10" fill="white" font-weight="600">normalization_quarantine</text>
+<!-- Arrow 3b → quarantine -->
+<path d="M710 372 L760 372 L760 377 L788 377" stroke="#DC2626" stroke-width="1.5" marker-end="url(#ar)" fill="none"/>
+
+<rect x="790" y="402" width="210" height="30" rx="5" fill="#D97706"/>
+<text x="895" y="422" text-anchor="middle" font-size="10" fill="white" font-weight="600">raw_ingested_jobs (UPDATE)</text>
+<!-- Arrow 4 → raw (status update) -->
+<path d="M395 418 L760 418 L760 417 L788 417" stroke="#D97706" stroke-width="1.5" marker-end="url(#ao)" fill="none"/>
+
+<!-- Read arrow: step 1 reads raw_ingested_jobs -->
+<rect x="1020" y="322" width="100" height="30" rx="5" fill="#EFF6FF" stroke="#93C5FD"/>
+<text x="1070" y="340" text-anchor="middle" font-size="8" fill="#2563EB" font-weight="600">READ from</text>
+<text x="1070" y="350" text-anchor="middle" font-size="8" fill="#2563EB">raw_ingested_jobs</text>
+
+<!-- ══════════════════════════════════════════════════════
+     EVENT: NormalizationComplete
+══════════════════════════════════════════════════════ -->
+<path d="M400 485 L400 500" stroke="#7C3AED" stroke-width="2" marker-end="url(#ap)" fill="none"/>
+<rect x="275" y="502" width="250" height="24" rx="12" fill="#7C3AED"/>
+<text x="400" y="518" text-anchor="middle" font-size="10" fill="white" font-weight="700">EventEnvelope: NormalizationComplete</text>
+<text x="540" y="518" font-size="8" fill="#6D28D9">{normalized_count, quarantined_count, batch_id}</text>
+
+<!-- ══════════════════════════════════════════════════════
+     GAP: Extraction loads from DB not event
+══════════════════════════════════════════════════════ -->
+<rect x="275" y="536" width="450" height="22" rx="4" fill="#FEF2F2" stroke="#FECACA"/>
+<text x="500" y="551" text-anchor="middle" font-size="8" fill="#DC2626" font-weight="600">⚠ GAP: Extraction loads work items from DB (LEFT JOIN), not from NormalizationComplete payload</text>
+
+<!-- ══════════════════════════════════════════════════════
+     STAGE 2 — SKILLS EXTRACTION
+══════════════════════════════════════════════════════ -->
+<rect x="40" y="572" width="720" height="195" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="2"/>
+<text x="55" y="592" font-size="11" fill="#92400E" font-weight="700">STAGE 2 — SkillsExtractionAgent.process(norm_out | trigger)</text>
+<text x="455" y="592" font-size="9" fill="#64748B">skills_extraction/agent.py:568 | ~$0.015/job (3 LLM) | CONCURRENCY=5</text>
+
+<!-- Steps row 1 -->
+<rect x="55" y="604" width="165" height="40" rx="4" fill="#DBEAFE"/>
+<text x="137" y="620" text-anchor="middle" font-size="9" fill="#1E40AF" font-weight="600">1. Load unextracted</text>
+<text x="137" y="633" text-anchor="middle" font-size="8" fill="#64748B">DB LEFT JOIN loader</text>
+
+<rect x="230" y="604" width="148" height="40" rx="4" fill="#FEF3C7"/>
+<text x="304" y="620" text-anchor="middle" font-size="9" fill="#92400E" font-weight="600">2a. LLM: Skills ($)</text>
+<text x="304" y="633" text-anchor="middle" font-size="8" fill="#64748B">invoke_skills_llm()</text>
+
+<rect x="388" y="604" width="148" height="40" rx="4" fill="#FEF3C7"/>
+<text x="462" y="620" text-anchor="middle" font-size="9" fill="#92400E" font-weight="600">2b. LLM: Tasks ($)</text>
+<text x="462" y="633" text-anchor="middle" font-size="8" fill="#64748B">invoke_structured…()</text>
+
+<rect x="546" y="604" width="170" height="40" rx="4" fill="#FEF3C7"/>
+<text x="631" y="620" text-anchor="middle" font-size="9" fill="#92400E" font-weight="600">2c. LLM: Responsibilities ($)</text>
+<text x="631" y="633" text-anchor="middle" font-size="8" fill="#64748B">invoke_structured…()</text>
+
+<!-- Parallel badge -->
+<rect x="230" y="648" width="486" height="16" rx="3" fill="#F5F3FF" stroke="#C4B5FD"/>
+<text x="473" y="660" text-anchor="middle" font-size="8" fill="#6D28D9" font-weight="600">↕ asyncio.gather() — 2a + 2b + 2c run in parallel per job · up to SKILLS_EXTRACTION_CONCURRENCY=5 jobs in flight</text>
+
+<!-- Steps row 2 -->
+<rect x="55" y="672" width="165" height="40" rx="4" fill="#F1F5F9"/>
+<text x="137" y="688" text-anchor="middle" font-size="9" fill="#374151" font-weight="600">3. Taxonomy resolution</text>
+<text x="137" y="701" text-anchor="middle" font-size="8" fill="#64748B">6-step GenAI/ESCO/O*NET</text>
+
+<rect x="230" y="672" width="165" height="40" rx="4" fill="#DCFCE7"/>
+<text x="312" y="688" text-anchor="middle" font-size="9" fill="#166534" font-weight="600">4. Save to DB</text>
+<text x="312" y="701" text-anchor="middle" font-size="8" fill="#64748B">ExtractionStore.save()</text>
+
+<rect x="405" y="672" width="165" height="40" rx="4" fill="#FFF7ED" stroke="#FED7AA"/>
+<text x="487" y="688" text-anchor="middle" font-size="9" fill="#92400E" font-weight="600">5. Audit log (per call)</text>
+<text x="487" y="701" text-anchor="middle" font-size="8" fill="#64748B">→ llm_audit_log</text>
+
+<rect x="580" y="672" width="145" height="40" rx="4" fill="#FFF7ED" stroke="#FED7AA"/>
+<text x="652" y="688" text-anchor="middle" font-size="9" fill="#92400E" font-weight="600">6. Langfuse spans</text>
+<text x="652" y="701" text-anchor="middle" font-size="8" fill="#64748B">per LLM generation</text>
+
+<!-- DB tables for extraction (right side) -->
+<rect x="790" y="572" width="210" height="30" rx="5" fill="#059669"/>
+<text x="895" y="592" text-anchor="middle" font-size="10" fill="white" font-weight="600">extracted_intelligence</text>
+<!-- Arrow: step 4 → extracted_intelligence -->
+<path d="M395 692 L760 692 L760 587 L788 587" stroke="#059669" stroke-width="2" marker-end="url(#ag)" fill="none"/>
+<rect x="722" y="680" width="36" height="14" rx="3" fill="#FFFBEB"/>
+<text x="740" y="690" text-anchor="middle" font-size="7" fill="#059669" font-weight="600">WRITE</text>
+
+<rect x="790" y="612" width="210" height="30" rx="5" fill="#78350F"/>
+<text x="895" y="632" text-anchor="middle" font-size="10" fill="white" font-weight="600">llm_audit_log</text>
+<!-- Arrow: step 5 → llm_audit_log -->
+<path d="M570 692 L770 692 L770 627 L788 627" stroke="#D97706" stroke-width="1.5" marker-end="url(#ao)" fill="none"/>
+
+<!-- Read badges -->
+<rect x="790" y="652" width="100" height="26" rx="5" fill="#EFF6FF" stroke="#93C5FD"/>
+<text x="840" y="667" text-anchor="middle" font-size="8" fill="#2563EB" font-weight="600">READS</text>
+<text x="840" y="676" text-anchor="middle" font-size="7" fill="#2563EB">normalized_jobs</text>
+
+<rect x="900" y="652" width="100" height="26" rx="5" fill="#EFF6FF" stroke="#93C5FD"/>
+<text x="950" y="667" text-anchor="middle" font-size="8" fill="#2563EB" font-weight="600">READS</text>
+<text x="950" y="676" text-anchor="middle" font-size="7" fill="#2563EB">skills (taxonomy)</text>
+
+<!-- Permanent badge -->
+<rect x="1020" y="572" width="100" height="30" rx="5" fill="#FEF2F2" stroke="#FECACA"/>
+<text x="1070" y="590" text-anchor="middle" font-size="8" fill="#991B1B" font-weight="600">PERMANENT</text>
+
+<!-- ══════════════════════════════════════════════════════
+     EVENT: SkillsExtracted
+══════════════════════════════════════════════════════ -->
+<path d="M400 767 L400 782" stroke="#7C3AED" stroke-width="2" marker-end="url(#ap)" fill="none"/>
+<rect x="290" y="784" width="220" height="24" rx="12" fill="#7C3AED"/>
+<text x="400" y="800" text-anchor="middle" font-size="10" fill="white" font-weight="700">EventEnvelope: SkillsExtracted</text>
+<text x="525" y="800" font-size="8" fill="#6D28D9">{records: [...], avg_per_job_ms, failed_jobs}</text>
+
+<!-- ══════════════════════════════════════════════════════
+     STAGE 3 — ENRICHMENT
+══════════════════════════════════════════════════════ -->
+<rect x="40" y="822" width="720" height="240" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="2"/>
+<text x="55" y="842" font-size="11" fill="#047857" font-weight="700">STAGE 3 — EnrichmentAgent.process(extract_out | trigger)</text>
+<text x="430" y="842" font-size="9" fill="#64748B">enrichment/agent.py:828 | ~$0.006/job (3 LLM) | ENRICHMENT_CONCURRENCY=5</text>
+
+<!-- Steps row 1 -->
+<rect x="55" y="854" width="120" height="40" rx="4" fill="#FEE2E2"/>
+<text x="115" y="870" text-anchor="middle" font-size="9" fill="#991B1B" font-weight="600">0. Spam gate</text>
+<text x="115" y="883" text-anchor="middle" font-size="8" fill="#64748B">>0.9 reject</text>
+
+<rect x="185" y="854" width="145" height="40" rx="4" fill="#FEF3C7"/>
+<text x="257" y="870" text-anchor="middle" font-size="9" fill="#92400E" font-weight="600">1a. LLM: SOC ($)</text>
+<text x="257" y="883" text-anchor="middle" font-size="8" fill="#64748B">classify_soc()</text>
+
+<rect x="340" y="854" width="145" height="40" rx="4" fill="#FEF3C7"/>
+<text x="412" y="870" text-anchor="middle" font-size="9" fill="#92400E" font-weight="600">1b. LLM: NAICS ($)</text>
+<text x="412" y="883" text-anchor="middle" font-size="8" fill="#64748B">classify_naics_async()</text>
+
+<rect x="495" y="854" width="165" height="40" rx="4" fill="#FEF3C7"/>
+<text x="577" y="870" text-anchor="middle" font-size="9" fill="#92400E" font-weight="600">1c. LLM: Employer ($)</text>
+<text x="577" y="883" text-anchor="middle" font-size="8" fill="#64748B">build_employer_profile_async()</text>
+
+<!-- Parallel badge -->
+<rect x="55" y="898" width="660" height="16" rx="3" fill="#F5F3FF" stroke="#C4B5FD"/>
+<text x="385" y="910" text-anchor="middle" font-size="8" fill="#6D28D9" font-weight="600">↕ asyncio.gather() — 1a + 1b + 1c in parallel per job · up to ENRICHMENT_CONCURRENCY=5 jobs in flight</text>
+
+<!-- Steps row 2 -->
+<rect x="55" y="922" width="130" height="40" rx="4" fill="#F1F5F9"/>
+<text x="120" y="938" text-anchor="middle" font-size="9" fill="#374151" font-weight="600">2. Quality score</text>
+<text x="120" y="951" text-anchor="middle" font-size="8" fill="#64748B">score_quality() · no LLM</text>
+
+<rect x="195" y="922" width="155" height="40" rx="4" fill="#F1F5F9"/>
+<text x="272" y="938" text-anchor="middle" font-size="9" fill="#374151" font-weight="600">3. Company resolution</text>
+<text x="272" y="951" text-anchor="middle" font-size="8" fill="#64748B">match or create placeholder</text>
+
+<rect x="360" y="922" width="195" height="40" rx="4" fill="#DCFCE7"/>
+<text x="457" y="938" text-anchor="middle" font-size="9" fill="#166534" font-weight="600">4. Promotion → job_postings</text>
+<text x="457" y="951" text-anchor="middle" font-size="8" fill="#64748B">apply_enrichment_to_job_postings()</text>
+
+<rect x="565" y="922" width="150" height="40" rx="4" fill="#DCFCE7"/>
+<text x="640" y="938" text-anchor="middle" font-size="9" fill="#166534" font-weight="600">5. Write profiles</text>
+<text x="640" y="951" text-anchor="middle" font-size="8" fill="#64748B">employer_profiles, companies</text>
+
+<!-- Steps row 3 -->
+<rect x="55" y="970" width="660" height="30" rx="4" fill="#FFF7ED" stroke="#FED7AA"/>
+<text x="385" y="989" text-anchor="middle" font-size="8" fill="#92400E" font-weight="600">6. enrichment_progress log every 10 jobs: completed/total/in_flight/job_ms · All LLM calls → llm_audit_log</text>
+
+<!-- Gap note -->
+<rect x="55" y="1008" width="660" height="22" rx="4" fill="#FEF2F2" stroke="#FECACA"/>
+<text x="385" y="1023" text-anchor="middle" font-size="8" fill="#DC2626" font-weight="600">⚠ GAP: Enrichment reads records from SkillsExtracted event payload, NOT from extracted_intelligence table — falls back to trigger if extract_count=0</text>
+
+<!-- DB tables for enrichment (right side) -->
+<rect x="790" y="822" width="210" height="35" rx="5" fill="#1D4ED8"/>
+<text x="895" y="842" text-anchor="middle" font-size="11" fill="white" font-weight="700">job_postings</text>
+<text x="895" y="854" text-anchor="middle" font-size="7" fill="#93C5FD">PRODUCTION · final destination</text>
+<!-- Arrow: step 4 → job_postings -->
+<path d="M555 942 L760 942 L760 840 L788 840" stroke="#059669" stroke-width="2" marker-end="url(#ag)" fill="none"/>
+<rect x="722" y="930" width="36" height="14" rx="3" fill="#ECFDF5"/>
+<text x="740" y="940" text-anchor="middle" font-size="7" fill="#059669" font-weight="600">WRITE</text>
+
+<rect x="790" y="867" width="210" height="30" rx="5" fill="#059669"/>
+<text x="895" y="887" text-anchor="middle" font-size="10" fill="white" font-weight="600">employer_profiles</text>
+
+<rect x="790" y="907" width="100" height="26" rx="5" fill="#047857"/>
+<text x="840" y="924" text-anchor="middle" font-size="9" fill="white" font-weight="600">companies</text>
+
+<rect x="900" y="907" width="100" height="26" rx="5" fill="#78350F"/>
+<text x="950" y="924" text-anchor="middle" font-size="9" fill="white" font-weight="600">llm_audit_log</text>
+
+<!-- Arrow: step 5 → employer_profiles + companies -->
+<path d="M715 942 L760 942 L760 882 L788 882" stroke="#059669" stroke-width="1.5" marker-end="url(#ag)" fill="none"/>
+<path d="M760 882 L760 920 L788 920" stroke="#059669" stroke-width="1.2" marker-end="url(#ag)" fill="none"/>
+
+<!-- Arrow: audit → llm_audit_log -->
+<path d="M760 920 L900 920" stroke="#D97706" stroke-width="1.2" marker-end="url(#ao)" fill="none"/>
+
+<!-- Read badges for enrichment -->
+<rect x="790" y="945" width="70" height="22" rx="5" fill="#EFF6FF" stroke="#93C5FD"/>
+<text x="825" y="959" text-anchor="middle" font-size="7" fill="#2563EB" font-weight="600">READ naics</text>
+
+<rect x="870" y="945" width="60" height="22" rx="5" fill="#EFF6FF" stroke="#93C5FD"/>
+<text x="900" y="959" text-anchor="middle" font-size="7" fill="#2563EB" font-weight="600">READ socc</text>
+
+<rect x="940" y="945" width="90" height="22" rx="5" fill="#EFF6FF" stroke="#93C5FD"/>
+<text x="985" y="959" text-anchor="middle" font-size="7" fill="#2563EB" font-weight="600">READ companies</text>
+
+<rect x="1040" y="945" width="100" height="22" rx="5" fill="#EFF6FF" stroke="#93C5FD"/>
+<text x="1090" y="959" text-anchor="middle" font-size="7" fill="#2563EB" font-weight="600">READ ind_sectors</text>
+
+<!-- ══════════════════════════════════════════════════════
+     EVENT: RecordEnriched
+══════════════════════════════════════════════════════ -->
+<path d="M400 1062 L400 1078" stroke="#7C3AED" stroke-width="2" marker-end="url(#ap)" fill="none"/>
+<rect x="290" y="1080" width="220" height="24" rx="12" fill="#7C3AED"/>
+<text x="400" y="1096" text-anchor="middle" font-size="10" fill="white" font-weight="700">EventEnvelope: RecordEnriched</text>
+<text x="525" y="1096" font-size="8" fill="#6D28D9">{enriched_count, spam_rejected_count} → Analytics Agent</text>
+
+<!-- ══════════════════════════════════════════════════════
+     STAGE 4 — ANALYTICS AGENT (Week 7)  ref: ARCHITECTURE_DEEP.md §5
+══════════════════════════════════════════════════════ -->
+<rect x="40" y="1120" width="1120" height="850" rx="10" fill="none" stroke="#7C3AED" stroke-width="1.5" stroke-dasharray="6,3"/>
+<text x="55" y="1145" font-size="13" fill="#7C3AED" font-weight="800">STAGE 4 — AnalyticsAgent.process(enriched_out | trigger)</text>
+<text x="540" y="1145" font-size="9" fill="#64748B">analytics/agent.py:593 | Step 12 uses LLM</text>
+
+<!-- Pre-iteration DB read -->
+<rect x="55" y="1158" width="700" height="28" rx="4" fill="#DBEAFE" stroke="#93C5FD"/>
+<text x="70" y="1176" font-size="8" fill="#1E40AF" font-weight="600">Step 1: Data validation + freshness check</text>
+<text x="280" y="1176" font-size="8" fill="#64748B">COUNT(*) FROM job_postings WHERE created_at > watermark AND spam_score &lt; 0.9 — requires ≥ 50 rows</text>
+
+<rect x="790" y="1152" width="130" height="26" rx="5" fill="#EFF6FF" stroke="#93C5FD"/>
+<text x="855" y="1169" text-anchor="middle" font-size="8" fill="#2563EB" font-weight="600">DB READ ×3</text>
+
+<!-- Row 1: Steps 2-3 (Pair A — no LLM) -->
+<rect x="55" y="1195" width="160" height="40" rx="4" fill="#DCFCE7"/>
+<text x="135" y="1211" text-anchor="middle" font-size="9" fill="#166534" font-weight="600">2. Skill demand weekly</text>
+<text x="135" y="1224" text-anchor="middle" font-size="8" fill="#64748B">Pair A → skill_demand_weekly</text>
+
+<rect x="225" y="1195" width="155" height="40" rx="4" fill="#DCFCE7"/>
+<text x="302" y="1211" text-anchor="middle" font-size="9" fill="#166534" font-weight="600">3. Tool demand weekly</text>
+<text x="302" y="1224" text-anchor="middle" font-size="8" fill="#64748B">Pair A → tool_demand_weekly</text>
+
+<!-- Row 2: Steps 4-7 -->
+<rect x="55" y="1245" width="170" height="40" rx="4" fill="#DCFCE7"/>
+<text x="140" y="1261" text-anchor="middle" font-size="9" fill="#166534" font-weight="600">4. Role clustering</text>
+<text x="140" y="1274" text-anchor="middle" font-size="8" fill="#64748B">Pair C · HDBSCAN → canonical_roles</text>
+
+<rect x="235" y="1245" width="170" height="40" rx="4" fill="#DCFCE7"/>
+<text x="320" y="1261" text-anchor="middle" font-size="9" fill="#166534" font-weight="600">5. Role snapshot weekly</text>
+<text x="320" y="1274" text-anchor="middle" font-size="8" fill="#64748B">Pair C → role_snapshot_weekly</text>
+
+<rect x="415" y="1245" width="170" height="40" rx="4" fill="#DCFCE7"/>
+<text x="500" y="1261" text-anchor="middle" font-size="9" fill="#166534" font-weight="600">6. Sector summary</text>
+<text x="500" y="1274" text-anchor="middle" font-size="8" fill="#64748B">Pair B → sector_summary_weekly</text>
+
+<rect x="595" y="1245" width="150" height="40" rx="4" fill="#DCFCE7"/>
+<text x="670" y="1261" text-anchor="middle" font-size="9" fill="#166534" font-weight="600">7. Geo demand</text>
+<text x="670" y="1274" text-anchor="middle" font-size="8" fill="#64748B">Pair B → geo_demand_weekly</text>
+
+<!-- Row 3: Steps 8-9 (depend on Step 2) -->
+<rect x="55" y="1298" width="700" height="16" rx="3" fill="#F5F3FF" stroke="#C4B5FD"/>
+<text x="405" y="1310" text-anchor="middle" font-size="8" fill="#6D28D9" font-weight="600">Steps 8–9 depend on Step 2 (skill_demand_weekly) — only run if Step 2 succeeds</text>
+
+<rect x="55" y="1320" width="175" height="40" rx="4" fill="#DCFCE7"/>
+<text x="142" y="1336" text-anchor="middle" font-size="9" fill="#166534" font-weight="600">8. Skill velocity</text>
+<text x="142" y="1349" text-anchor="middle" font-size="8" fill="#64748B">Pair A · WoW → skill_velocity</text>
+
+<rect x="240" y="1320" width="195" height="40" rx="4" fill="#DCFCE7"/>
+<text x="337" y="1336" text-anchor="middle" font-size="9" fill="#166534" font-weight="600">9. Skill co-occurrence</text>
+<text x="337" y="1349" text-anchor="middle" font-size="8" fill="#64748B">Pair A · pairs → skill_co_occurrence</text>
+
+<!-- Row 4: Steps 10-11 (guardrails + scaffold) -->
+<rect x="55" y="1370" width="195" height="40" rx="4" fill="#FFF7ED" stroke="#FED7AA"/>
+<text x="152" y="1386" text-anchor="middle" font-size="9" fill="#92400E" font-weight="600">10. Posting freshness</text>
+<text x="152" y="1399" text-anchor="middle" font-size="8" fill="#64748B">Pair D · staleness + cardinality</text>
+
+<rect x="260" y="1370" width="175" height="40" rx="4" fill="#F1F5F9" stroke="#E2E8F0"/>
+<text x="347" y="1386" text-anchor="middle" font-size="9" fill="#374151" font-weight="600">11. Trajectory scaffold</text>
+<text x="347" y="1399" text-anchor="middle" font-size="8" fill="#64748B">Phase 2 stub (in-memory)</text>
+
+<!-- Row 5: Step 12 (LLM!) + Step 13 (event) -->
+<rect x="55" y="1420" width="260" height="40" rx="4" fill="#FEF3C7"/>
+<text x="185" y="1436" text-anchor="middle" font-size="9" fill="#92400E" font-weight="600">12. LLM Insight Summaries ($)</text>
+<text x="185" y="1449" text-anchor="middle" font-size="8" fill="#64748B">Pair D · Sonnet-class · fallback on failure</text>
+
+<rect x="325" y="1420" width="240" height="40" rx="4" fill="#F1F5F9"/>
+<text x="445" y="1436" text-anchor="middle" font-size="9" fill="#374151" font-weight="600">13. Emit AnalyticsRefreshed</text>
+<text x="445" y="1449" text-anchor="middle" font-size="8" fill="#64748B">batch_id, freshness, trajectory, summaries</text>
+
+<!-- DB tables for analytics (right side) -->
+<rect x="790" y="1195" width="180" height="26" rx="5" fill="#059669"/>
+<text x="880" y="1212" text-anchor="middle" font-size="9" fill="white" font-weight="600">skill_demand_weekly</text>
+<rect x="790" y="1228" width="180" height="26" rx="5" fill="#059669"/>
+<text x="880" y="1245" text-anchor="middle" font-size="9" fill="white" font-weight="600">tool_demand_weekly</text>
+<rect x="790" y="1261" width="180" height="26" rx="5" fill="#059669"/>
+<text x="880" y="1278" text-anchor="middle" font-size="9" fill="white" font-weight="600">canonical_roles</text>
+<rect x="790" y="1294" width="180" height="26" rx="5" fill="#059669"/>
+<text x="880" y="1311" text-anchor="middle" font-size="9" fill="white" font-weight="600">role_snapshot_weekly</text>
+<rect x="790" y="1327" width="180" height="26" rx="5" fill="#059669"/>
+<text x="880" y="1344" text-anchor="middle" font-size="9" fill="white" font-weight="600">sector_summary_weekly</text>
+<rect x="790" y="1360" width="180" height="26" rx="5" fill="#059669"/>
+<text x="880" y="1377" text-anchor="middle" font-size="9" fill="white" font-weight="600">geo_demand_weekly</text>
+<rect x="790" y="1393" width="180" height="26" rx="5" fill="#059669"/>
+<text x="880" y="1410" text-anchor="middle" font-size="9" fill="white" font-weight="600">skill_velocity</text>
+<rect x="790" y="1426" width="180" height="26" rx="5" fill="#059669"/>
+<text x="880" y="1443" text-anchor="middle" font-size="9" fill="white" font-weight="600">skill_co_occurrence</text>
+<rect x="790" y="1459" width="180" height="26" rx="5" fill="#059669"/>
+<text x="880" y="1476" text-anchor="middle" font-size="9" fill="white" font-weight="600">posting_freshness</text>
+<rect x="790" y="1495" width="180" height="18" rx="4" fill="#ECFDF5"/>
+<text x="880" y="1508" text-anchor="middle" font-size="8" fill="#059669" font-weight="600">ALL WRITE (idempotent refresh)</text>
+<rect x="790" y="1520" width="180" height="22" rx="5" fill="#EFF6FF" stroke="#93C5FD"/>
+<text x="880" y="1535" text-anchor="middle" font-size="8" fill="#2563EB" font-weight="600">READ: job_postings, extracted_intel</text>
+
+<!-- Arrow from steps to DB tables -->
+<path d="M755 1215 L788 1208" stroke="#059669" stroke-width="1.2" marker-end="url(#ag)" fill="none"/>
+
+<!-- EventEnvelope: AnalyticsRefreshed -->
+<path d="M400 1460 L400 1570" stroke="#7C3AED" stroke-width="2" marker-end="url(#ap)" fill="none"/>
+<rect x="275" y="1570" width="250" height="24" rx="12" fill="#7C3AED"/>
+<text x="400" y="1586" text-anchor="middle" font-size="10" fill="white" font-weight="700">EventEnvelope: AnalyticsRefreshed</text>
+<text x="540" y="1586" font-size="8" fill="#6D28D9">{refreshed_at, summaries_count} → Viz Agent</text>
+
+<!-- ══════════════════════════════════════════════════════
+     WEEK 8 — WORKFORCE INTELLIGENCE Q&A  ref: ARCHITECTURE_DEEP.md §5
+══════════════════════════════════════════════════════ -->
+<rect x="40" y="1610" width="1120" height="130" rx="10" fill="none" stroke="#D97706" stroke-width="1.5" stroke-dasharray="6,3"/>
+<text x="55" y="1635" font-size="13" fill="#D97706" font-weight="800">WEEK 8 — Workforce Intelligence Q&amp;A (scaffolded)</text>
+<text x="470" y="1635" font-size="9" fill="#64748B">analytics/query_engine/ — 4 pairs building · POST /analytics/query</text>
+
+<rect x="55" y="1650" width="130" height="40" rx="4" fill="#FEF3C7" stroke="#FDE68A"/>
+<text x="120" y="1666" text-anchor="middle" font-size="9" fill="#92400E" font-weight="600">Intent classify ($)</text>
+<text x="120" y="1679" text-anchor="middle" font-size="8" fill="#64748B">Pair B · Haiku-class</text>
+
+<text x="195" y="1672" font-size="12" fill="#D97706">→</text>
+
+<rect x="205" y="1650" width="115" height="40" rx="4" fill="#F1F5F9"/>
+<text x="262" y="1666" text-anchor="middle" font-size="9" fill="#374151" font-weight="600">Route + SQL</text>
+<text x="262" y="1679" text-anchor="middle" font-size="8" fill="#64748B">Pair B · guardrails</text>
+
+<text x="330" y="1672" font-size="12" fill="#D97706">→</text>
+
+<rect x="340" y="1650" width="100" height="40" rx="4" fill="#DBEAFE"/>
+<text x="390" y="1666" text-anchor="middle" font-size="9" fill="#1E40AF" font-weight="600">Execute SQL</text>
+<text x="390" y="1679" text-anchor="middle" font-size="8" fill="#64748B">Pair D · FastAPI</text>
+
+<text x="450" y="1672" font-size="12" fill="#D97706">→</text>
+
+<rect x="460" y="1650" width="130" height="40" rx="4" fill="#FEF3C7" stroke="#FDE68A"/>
+<text x="525" y="1666" text-anchor="middle" font-size="9" fill="#92400E" font-weight="600">Synthesize ($)</text>
+<text x="525" y="1679" text-anchor="middle" font-size="8" fill="#64748B">Pair C · Sonnet-class</text>
+
+<text x="600" y="1672" font-size="12" fill="#D97706">→</text>
+
+<rect x="610" y="1650" width="140" height="40" rx="4" fill="#F1F5F9"/>
+<text x="680" y="1666" text-anchor="middle" font-size="9" fill="#374151" font-weight="600">Cite + Follow-ups</text>
+<text x="680" y="1679" text-anchor="middle" font-size="8" fill="#64748B">Pair C · evidence</text>
+
+<rect x="55" y="1700" width="700" height="18" rx="3" fill="#FEF3C7" stroke="#FDE68A"/>
+<text x="405" y="1714" text-anchor="middle" font-size="8" fill="#92400E" font-weight="600">POST /analytics/query → intent.py → router.py → SQL validator → synthesis.py → response with citations + follow-ups</text>
+
+<!-- ══════════════════════════════════════════════════════
+     ITERATION LOOP
+══════════════════════════════════════════════════════ -->
+<path d="M400 1594 L400 1760 L30 1760 L30 260 L38 260" stroke="#6D28D9" stroke-width="2" stroke-dasharray="6,4" marker-end="url(#ap)" fill="none"/>
+<rect x="33" y="680" width="16" height="200" rx="3" fill="#F5F3FF"/>
+<text x="18" y="790" font-size="9" fill="#6D28D9" font-weight="600" transform="rotate(-90,18,790)">sleep(delay) → next iteration or break</text>
+
+<!-- ══════════════════════════════════════════════════════
+     LEGEND
+══════════════════════════════════════════════════════ -->
+<rect x="40" y="1790" width="1120" height="110" rx="8" fill="#F1F5F9" stroke="#E2E8F0"/>
+<text x="55" y="1812" font-size="10" fill="#374151" font-weight="700">LEGEND</text>
+
+<line x1="55" y1="1830" x2="85" y2="1830" stroke="#059669" stroke-width="2" marker-end="url(#ag)"/>
+<text x="93" y="1834" font-size="9" fill="#374151">DB write</text>
+
+<line x1="155" y1="1830" x2="185" y2="1830" stroke="#DC2626" stroke-width="1.5" marker-end="url(#ar)"/>
+<text x="193" y="1834" font-size="9" fill="#374151">DB write (error path)</text>
+
+<line x1="305" y1="1830" x2="335" y2="1830" stroke="#D97706" stroke-width="1.5" marker-end="url(#ao)"/>
+<text x="343" y="1834" font-size="9" fill="#374151">Audit write / status update</text>
+
+<rect x="490" y="1822" width="16" height="16" rx="3" fill="#EFF6FF" stroke="#93C5FD"/>
+<text x="514" y="1834" font-size="9" fill="#374151">DB read badge</text>
+
+<rect x="590" y="1822" width="40" height="16" rx="8" fill="#7C3AED"/>
+<text x="638" y="1834" font-size="9" fill="#374151">EventEnvelope</text>
+
+<rect x="730" y="1822" width="40" height="16" rx="4" fill="#FEF3C7"/>
+<text x="778" y="1834" font-size="9" fill="#374151">LLM call (costs $)</text>
+
+<rect x="870" y="1822" width="40" height="16" rx="4" fill="#FEF2F2" stroke="#FECACA"/>
+<text x="918" y="1834" font-size="9" fill="#374151">Architecture gap</text>
+
+<line x1="55" y1="1860" x2="85" y2="1860" stroke="#6D28D9" stroke-width="2" stroke-dasharray="6,4"/>
+<text x="93" y="1864" font-size="9" fill="#374151">Iteration loop (back to pre-iteration queries on completion)</text>
+
+<rect x="300" y="1852" width="36" height="16" rx="3" fill="#DCFCE7"/>
+<text x="345" y="1864" font-size="9" fill="#374151">DB write step</text>
+
+<rect x="430" y="1852" width="36" height="16" rx="3" fill="#DBEAFE"/>
+<text x="475" y="1864" font-size="9" fill="#374151">DB read step</text>
+
+<rect x="540" y="1852" width="36" height="16" rx="3" fill="#F1F5F9"/>
+<text x="585" y="1864" font-size="9" fill="#374151">Deterministic step (no LLM)</text>
+
+</svg>
+
+<!-- ══════════════════════════════════════════════════════════
+     REFERENCE TABLE
+══════════════════════════════════════════════════════════ -->
+<h2 style="margin-top:32px; font-size:16px;">Code Reference — File → Method → DB → Events</h2>
+<table class="ref-table">
+<thead>
+  <tr><th>#</th><th>Stage</th><th>File</th><th>Entry Method</th><th>Internal Methods</th><th>DB Reads</th><th>DB Writes</th><th>LLM</th><th>Event In</th><th>Event Out</th></tr>
+</thead>
+<tbody>
+  <tr>
+    <td>0</td><td><strong>Loop Orchestration</strong></td>
+    <td><code>scripts/run_processing_loop.py</code></td>
+    <td><code>main()</code></td>
+    <td><code>_count_pending()</code>, <code>_count_unextracted()</code>, <code>_count_enriched()</code>, <code>_init_tracer()</code></td>
+    <td><code>raw_ingested_jobs</code>, <code>normalized_jobs</code>, <code>extracted_intelligence</code>, <code>job_postings</code></td>
+    <td>—</td>
+    <td>0</td>
+    <td>—</td>
+    <td>ProcessingTrigger (synthetic)</td>
+  </tr>
+  <tr>
+    <td>L1</td><td><strong>Ingestion</strong></td>
+    <td><code>scripts/batch_ingest.py</code><br><code>ingestion/agent.py</code></td>
+    <td><code>IngestionAgent.process()</code></td>
+    <td><code>ingestion/deduplicator.py</code>, <code>ingestion/sources/jsearch_source.py</code></td>
+    <td><code>raw_ingested_jobs</code> (dedup)</td>
+    <td><code>raw_ingested_jobs</code>, <code>job_ingestion_runs</code></td>
+    <td>0</td>
+    <td>—</td>
+    <td>IngestBatch</td>
+  </tr>
+  <tr class="gap">
+    <td>—</td><td colspan="9"><strong>⚠ GAP:</strong> No IngestBatch event passes to Loop 2. Processing loop discovers pending records via <code>_count_pending()</code> DB query.</td>
+  </tr>
+  <tr>
+    <td>S1</td><td><strong>Normalization</strong></td>
+    <td><code>normalization/agent.py</code></td>
+    <td><code>NormalizationAgent.process(trigger)</code></td>
+    <td><code>normalization/field_mappers/*.py</code>, <code>normalization/schema/validator.py</code></td>
+    <td><code>raw_ingested_jobs</code></td>
+    <td><code>normalized_jobs</code>, <code>normalization_quarantine</code>, <code>raw_ingested_jobs</code> (status)</td>
+    <td>0</td>
+    <td>ProcessingTrigger</td>
+    <td>NormalizationComplete</td>
+  </tr>
+  <tr class="gap">
+    <td>—</td><td colspan="9"><strong>⚠ GAP:</strong> Extraction loads work items from DB (<code>normalized_jobs LEFT JOIN extracted_intelligence</code>), not from NormalizationComplete payload.</td>
+  </tr>
+  <tr>
+    <td>S2</td><td><strong>Skills Extraction</strong></td>
+    <td><code>skills_extraction/agent.py</code><br><code>common/llm_client.py</code></td>
+    <td><code>SkillsExtractionAgent.process()</code></td>
+    <td><code>invoke_skills_llm()</code>, <code>invoke_structured_extraction_llm()</code>, <code>SQLAlchemyExtractionStore.save()</code>, <code>skills_extraction/taxonomy/*.py</code></td>
+    <td><code>normalized_jobs</code>, <code>extracted_intelligence</code> (JOIN), <code>skills</code> (taxonomy)</td>
+    <td><code>extracted_intelligence</code>, <code>llm_audit_log</code></td>
+    <td>3/job</td>
+    <td>NormalizationComplete</td>
+    <td>SkillsExtracted</td>
+  </tr>
+  <tr>
+    <td>S3</td><td><strong>Enrichment</strong></td>
+    <td><code>enrichment/agent.py</code><br><code>enrichment/classifiers/*.py</code><br><code>enrichment/resolvers/*.py</code><br><code>enrichment/job_postings_promotion.py</code></td>
+    <td><code>EnrichmentAgent.process()</code></td>
+    <td><code>enrich_record_async()</code>, <code>classify_soc()</code>, <code>classify_naics_async()</code>, <code>build_employer_profile_async()</code>, <code>score_quality()</code>, <code>apply_enrichment_to_job_postings()</code></td>
+    <td><code>naics</code>, <code>socc</code>, <code>companies</code>, <code>industry_sectors</code></td>
+    <td><code>job_postings</code>, <code>employer_profiles</code>, <code>companies</code>, <code>llm_audit_log</code></td>
+    <td>3/job</td>
+    <td>SkillsExtracted</td>
+    <td>RecordEnriched</td>
+  </tr>
+  <tr>
+    <td>—</td><td><strong>Audit / Tracing</strong></td>
+    <td><code>common/llm_adapter.py</code><br><code>common/observability/langfuse.py</code></td>
+    <td><code>log_extraction_event()</code></td>
+    <td><code>compute_extraction_cost()</code>, <code>resolve_model_tier()</code>, <code>LangfuseTracer.start_span()</code></td>
+    <td>—</td>
+    <td><code>llm_audit_log</code></td>
+    <td>0</td>
+    <td>—</td>
+    <td>—</td>
+  </tr>
+</tbody>
+</table>
+
+<p style="margin-top:24px; font-size:11px; color:#94A3B8;">
+  Cost: ~$0.021/job verified against Azure Cost Management (<code>resumejobmatch</code> resource, April 2026).
+  100 jobs ≈ $2.10 | 500 jobs ≈ $10.50 | 1,000 jobs ≈ $21.00 | 30,000 jobs/month ≈ $630/month.
+  Config: <code>config/ingestion_queries.yaml</code> (47 query groups) | <code>.env</code> (all env vars documented in diagram).
+</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- New `processing-loop-technical-diagram-weeks7-8.html` extending the existing pipeline diagram with:
  - **Stage 4:** Analytics Agent 13-step pipeline with pair attributions (A: skill/tool demand + velocity + co-occurrence, B: sector/geo, C: clustering + role snapshot, D: freshness + LLM summaries)
  - **9 aggregate DB tables** on right side (skill_demand_weekly through posting_freshness)
  - **Step dependency** callout (Steps 8-9 depend on Step 2)
  - **LLM marker** on Step 12 (Sonnet-class insight summaries with fallback)
  - **AnalyticsRefreshed** event emission to Visualization Agent
  - **Week 8:** Workforce Intelligence Q&A pipeline (scaffolded) — Intent classify → Route + SQL → Execute → Synthesize → Cite + Follow-ups
- Fixed ENRICHMENT_CONCURRENCY from 30 to 5 (proven stable config)
- Widened overflow boxes (asyncio.gather badge, progress log, GAP note)
- Aligned all section borders (Stage 4, Week 8, Legend) to full width
- Gitignore: whitelisted processing-loop diagram HTML files

## Test plan
- [x] Verified in browser via preview server — all sections render correctly
- [x] Stage 4 border encompasses DB tables on right
- [x] Week 8 border aligned with Stage 4
- [x] Legend fits within bounding box
- [x] CONCURRENCY=5 displayed correctly
- [ ] Final visual review in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)