### PR TITLE
refactor: per-call LLM routing via resolve_llm_route(role)

### DIFF
--- a/.cursor/rules/llm-routing.mdc
+++ b/.cursor/rules/llm-routing.mdc
@@ -1,0 +1,65 @@
+---
+description: LLM routing — per-call model selection via resolve_llm_route(role)
+globs:
+  - common/llm_adapter.py
+  - common/llm_client.py
+  - analytics/**
+  - skills_extraction/**
+  - enrichment/**
+---
+
+# LLM Routing
+
+## Env Var Convention
+
+All LLM deployment routing uses `LLM_*` env vars. Never use the old `EXTRACTION_DEPLOYMENT_*` or `AZURE_OPENAI_DEPLOYMENT_NAME` vars — they are dead.
+
+```
+LLM_PROVIDER=azure_openai         # Default provider (fallback)
+LLM_DEFAULT=chat-gpt41mini        # Haiku-class — default for all calls
+LLM_SYNTHESIS=chat-gpt41           # Sonnet-class — Q&A answer generation
+```
+
+## resolve_llm_route(role)
+
+All LLM calls resolve their deployment via `resolve_llm_route(role)` from `common/llm_adapter.py`.
+
+Resolution chain (fail fast — no legacy fallbacks):
+1. `LLM_{ROLE}` env var (e.g. `LLM_SYNTHESIS` for role `"synthesis"`)
+2. `LLM_DEFAULT` env var
+3. `ValueError` with clear message
+
+Provider override syntax: `LLM_SYNTHESIS=gemini:gemini-2.5-pro` → `("gemini", "gemini-2.5-pro")`
+
+## Roles
+
+| Role | Env Var | Default Use |
+|------|---------|-------------|
+| `synthesis` | `LLM_SYNTHESIS` | Q&A answer generation, complex reasoning (Sonnet-class) |
+| `extraction` | `LLM_EXTRACTION` | Skills extraction (default tier) |
+| `extraction_tasks` | `LLM_EXTRACTION_TASKS` | Tasks extraction (Haiku-class) |
+| `extraction_responsibilities` | `LLM_EXTRACTION_RESPONSIBILITIES` | Responsibilities extraction |
+| `extraction_naics` | `LLM_EXTRACTION_NAICS` | NAICS classification |
+| `extraction_employer` | `LLM_EXTRACTION_EMPLOYER` | Employer classification |
+| `classification` | `LLM_CLASSIFICATION` | Intent classification (Haiku-class) |
+| `analytics` | `LLM_ANALYTICS` | Analytics summaries |
+
+## Usage
+
+```python
+# In complete() calls:
+result = complete(prompt=..., agent_name=..., role="synthesis")
+
+# In structured extraction:
+parsed, meta = invoke_structured_extraction_llm(prompt, Schema, agent_name=..., role="extraction_tasks", model_tier_for_cost="haiku")
+
+# In invoke_skills_llm:
+text, meta = invoke_skills_llm(prompt, agent_name=..., role="extraction")
+```
+
+## Rules
+
+- **Never hardcode deployment names** — always use `role=` parameter
+- **Never reference old env vars** (`EXTRACTION_DEPLOYMENT_*`, `AZURE_OPENAI_DEPLOYMENT_NAME`) — they are dead
+- **Cost tracking** uses `model_tier_for_cost` (separate from routing) — keep it
+- **PRICING dict and MODEL_TIER_MAP** in `llm_adapter.py` handle cost computation — don't duplicate

--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,6 @@ JSEARCH_API_KEY_2=                                # key rotation
 JSEARCH_API_KEY_3=                                # key rotation
 JSEARCH_API_KEY_4=                                # key rotation
 JSEARCH_START_KEY_INDEX=1                         # optional: skip exhausted keys
-JSEARCH_MAX_PAGES=50                              # pages per query (10 results/page, max 50). Also in config/ingestion_queries.yaml
 JSEARCH_MAX_RETRIES=2                             # per-page retries on JSearch 429
 JSEARCH_RETRY_BASE_DELAY_SECONDS=10               # initial JSearch 429 backoff
 JSEARCH_RETRY_MAX_DELAY_SECONDS=60                # max JSearch 429 backoff

--- a/.env.example
+++ b/.env.example
@@ -5,30 +5,29 @@
 
 PYTHONIOENCODING=utf-8  # Required on Windows (Crawl4AI unicode)
 
-# --- LLM Provider ---
-# Available: azure_openai | gemini | mock (ground truth, no API calls) | anthropic
+# --- LLM Provider & Routing ---
+# Available providers: azure_openai | gemini | mock | anthropic
+# LLM_PROVIDER is the default provider for all calls.
+# Each LLM_* var can optionally override the provider with colon syntax:
+#   LLM_SYNTHESIS=gemini:gemini-2.5-pro  (uses Gemini instead of LLM_PROVIDER)
 LLM_PROVIDER=azure_openai
+LLM_DEFAULT=chat-gpt41mini              # Haiku-class — default for all calls
+LLM_SYNTHESIS=chat-gpt41                 # Sonnet-class — Q&A answer generation, complex reasoning
+# LLM_EXTRACTION=                        # Override for skills extraction (optional)
+# LLM_EXTRACTION_TASKS=                  # Override for tasks extraction (optional, defaults to LLM_DEFAULT)
+# LLM_EXTRACTION_RESPONSIBILITIES=       # Override for responsibilities extraction (optional)
+# LLM_EXTRACTION_NAICS=                  # Override for NAICS classification (optional)
+# LLM_EXTRACTION_EMPLOYER=               # Override for employer classification (optional)
+# LLM_CLASSIFICATION=                    # Override for intent classification (optional)
+# LLM_ANALYTICS=                         # Override for analytics summaries (optional)
 
-# --- Azure OpenAI Skills Extraction Override (optional) ---
-# Override the default deployment for skills extraction LLM calls
-# If unset, uses AZURE_OPENAI_DEPLOYMENT_NAME
-# EXTRACTION_DEPLOYMENT_SKILLS=
-
-# --- Google Gemini (set LLM_PROVIDER=gemini to use) ---
+# --- Google Gemini (set LLM_PROVIDER=gemini to use, or use colon syntax above) ---
 GEMINI_API_KEY=
-GEMINI_MODEL=gemini-2.5-flash
 
 # --- Azure OpenAI ---
 AZURE_OPENAI_ENDPOINT=https://<your-aoai-resource>.openai.azure.com/
 AZURE_OPENAI_API_KEY=
 AZURE_OPENAI_API_VERSION="2025-01-01-preview"
-AZURE_OPENAI_DEPLOYMENT_NAME=chat-gpt41mini
-
-# --- Azure OpenAI Sonnet-Class Deployment (gpt-4.1 full) ---
-# Used for synthesis, complex reasoning, and Q&A answer generation.
-# gpt-4.1 is the Azure equivalent of Sonnet-class performance.
-# Pricing: $2.00/$8.00 per 1M tokens (vs $0.40/$1.60 for gpt-4.1-mini)
-AZURE_OPENAI_SYNTHESIS_DEPLOYMENT_NAME=chat-gpt41
 
 # --- Azure OpenAI Embeddings ---
 AZURE_OPENAI_EMBEDDING_ENDPOINT=https://<your-aoai-resource>.openai.azure.com/

--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,7 @@ JSEARCH_API_KEY_2=                                # key rotation
 JSEARCH_API_KEY_3=                                # key rotation
 JSEARCH_API_KEY_4=                                # key rotation
 JSEARCH_START_KEY_INDEX=1                         # optional: skip exhausted keys
+JSEARCH_MAX_PAGES=50                              # pages per query (10 results/page, max 50). Also in config/ingestion_queries.yaml
 JSEARCH_MAX_RETRIES=2                             # per-page retries on JSearch 429
 JSEARCH_RETRY_BASE_DELAY_SECONDS=10               # initial JSearch 429 backoff
 JSEARCH_RETRY_MAX_DELAY_SECONDS=60                # max JSearch 429 backoff

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,11 +186,12 @@ SA-classified decisions use the **reference implementation** shown above. If you
 All credentials in `.env` — never hardcode any of these.
 
 ```bash
-# LLM
+# LLM Routing (see .env.example for full list)
+LLM_PROVIDER=azure_openai          # azure_openai | gemini | anthropic | mock
+LLM_DEFAULT=chat-gpt41mini         # Haiku-class — default for all calls
+LLM_SYNTHESIS=chat-gpt41           # Sonnet-class — Q&A synthesis, complex reasoning
 AZURE_OPENAI_API_KEY=
 AZURE_OPENAI_ENDPOINT=
-AZURE_OPENAI_DEPLOYMENT_NAME=
-LLM_PROVIDER=azure_openai          # azure_openai | openai | anthropic
 
 # Database
 PYTHON_DATABASE_URL=                # SQLAlchemy psycopg2 URL:
@@ -245,14 +246,27 @@ class EventEnvelope(BaseModel):
     payload: dict[str, Any]
 ```
 
-### LLM adapter usage
+### LLM routing — per-call model selection
+
+All LLM calls use `resolve_llm_route(role)` to determine which provider and deployment to use. Configuration is via `LLM_*` env vars.
 
 ```python
-from common.llm_adapter import get_adapter
+from common.llm_adapter import complete, resolve_llm_route
 
-adapter = get_adapter(provider=os.getenv("LLM_PROVIDER", "azure_openai"))
-result = adapter.complete(prompt=prompt, schema=OutputSchema)
+# Role-based (preferred — resolves via LLM_SYNTHESIS env var):
+result = complete(prompt=prompt, agent_name="analytics-agent", role="synthesis")
+
+# Direct resolution:
+provider, deployment = resolve_llm_route("synthesis")  # ("azure_openai", "chat-gpt41")
 ```
+
+**Env var resolution:** `LLM_{ROLE}` → `LLM_DEFAULT` → `ValueError`. No legacy fallbacks.
+
+**Provider override:** `LLM_SYNTHESIS=gemini:gemini-2.5-pro` routes synthesis through Gemini.
+
+**Roles:** `synthesis`, `extraction`, `extraction_tasks`, `extraction_responsibilities`, `extraction_naics`, `extraction_employer`, `classification`, `analytics`
+
+**Never hardcode deployment names.** Always use `role=` parameter or `resolve_llm_route()`.
 
 Fallback: 2 retries → log to `llm_audit_log` → set `extraction_status = "failed"` → continue batch. Never block a batch on LLM failure.
 

--- a/analytics/insights/llm_summary.py
+++ b/analytics/insights/llm_summary.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from datetime import datetime, timezone
 from typing import TypedDict
 
@@ -15,7 +14,6 @@ from common.llm_adapter import complete
 log = structlog.get_logger()
 
 _AGENT_NAME = "analytics-agent"
-_DEFAULT_MODEL = os.getenv("EXTRACTION_MODEL_SKILLS", "claude-sonnet-4-5")
 
 
 class SummaryResult(TypedDict):
@@ -98,11 +96,10 @@ def generate_summary(
     generated_at = _utc_now_iso()
     try:
         prompt = _build_prompt(label, trajectory, freshness_records)
-        model = _DEFAULT_MODEL
         result = complete(
             prompt=prompt,
             agent_name=_AGENT_NAME,
-            model=model,
+            role="synthesis",
             system=(
                 "You are an analytics writer for labor-market intelligence. "
                 "Use only the facts in the user message. Output 3–5 paragraphs with no markdown headings."
@@ -121,7 +118,7 @@ def generate_summary(
                 "sector_label": None,
                 "summary_text": content,
                 "is_llm_generated": True,
-                "model_used": model,
+                "model_used": result.get("model") or result.get("model_tier"),
                 "generated_at": generated_at,
             }
         log.info(

--- a/common/llm_adapter.py
+++ b/common/llm_adapter.py
@@ -122,6 +122,48 @@ MODEL_TIER_MAP: dict[str, str] = {
     "gemini-2.5-pro":   "gemini-2.5-pro",
 }
 
+
+def resolve_llm_route(role: str | None = None) -> tuple[str, str]:
+    """Resolve (provider, model_or_deployment) for a pipeline role.
+
+    Resolution (fail fast — no legacy fallbacks):
+    1. LLM_{ROLE} env var (e.g. LLM_SYNTHESIS for role="synthesis")
+       - If value contains ':', split as provider:model (e.g. "gemini:gemini-2.5-pro")
+       - Otherwise, use LLM_PROVIDER as the provider
+    2. LLM_DEFAULT env var (same colon-split logic)
+    3. Raise ValueError with clear message
+
+    Roles: synthesis, extraction, extraction_tasks, extraction_responsibilities,
+           extraction_naics, extraction_employer, classification, analytics
+    """
+    default_provider = os.getenv("LLM_PROVIDER", "azure_openai")
+
+    def _parse(value: str) -> tuple[str, str]:
+        if ":" in value:
+            provider, model = value.split(":", 1)
+            return provider.strip(), model.strip()
+        return default_provider, value.strip()
+
+    # 1. Role-specific: LLM_{ROLE}
+    if role:
+        role_var = f"LLM_{role.upper()}"
+        val = os.getenv(role_var)
+        if val:
+            return _parse(val)
+
+    # 2. Global default: LLM_DEFAULT
+    default = os.getenv("LLM_DEFAULT")
+    if default:
+        return _parse(default)
+
+    # 3. Fail fast
+    role_hint = f"LLM_{role.upper()}" if role else "LLM_DEFAULT"
+    raise ValueError(
+        f"No LLM deployment configured. Set {role_hint} or LLM_DEFAULT in your .env. "
+        f"Copy the LLM section from .env.example."
+    )
+
+
 # Back-off settings
 _BACKOFF_SEQUENCE = [1, 2, 4, 8]
 _ALERT_AFTER_CYCLES = 3
@@ -138,7 +180,7 @@ def resolve_model_tier(model: str) -> str:
     Resolution order:
     1. Exact match in MODEL_TIER_MAP
     2. Substring match (e.g. "gpt-4.1-mini-2025-04-14" contains "gpt-4.1-mini")
-    3. AZURE_OPENAI_DEPLOYMENT_NAME env var → MODEL_TIER_MAP lookup
+    3. LLM_DEFAULT env var → MODEL_TIER_MAP lookup
     4. LLM_PROVIDER env var default (azure_openai → gpt-4.1-mini, gemini → gemini-2.5-flash)
     5. "sonnet" fallback with a warning log
     """
@@ -152,7 +194,7 @@ def resolve_model_tier(model: str) -> str:
         if known in model:
             return mapped
     # 3. Deployment name from env
-    deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME", "")
+    deployment = os.getenv("LLM_DEFAULT", "")
     if deployment:
         tier = MODEL_TIER_MAP.get(deployment)
         if tier:
@@ -268,6 +310,7 @@ def complete(
     system: str | None = None,
     max_tokens: int = 1000,
     correlation_id: str | None = None,
+    role: str | None = None,
 ) -> dict[str, Any]:
     """Make an LLM call, log it via log_extraction_event(), and return the result.
 
@@ -286,7 +329,12 @@ def complete(
         - success: bool
         - extraction_failed: bool (True after timeout retry or API error)
     """
-    provider = os.getenv("LLM_PROVIDER", "anthropic")
+    if role and not model:
+        resolved_provider, resolved_model = resolve_llm_route(role)
+        provider = resolved_provider
+        model = resolved_model
+    else:
+        provider = os.getenv("LLM_PROVIDER", "anthropic")
 
     # Mock provider: return ground truth data, no API calls
     if provider == "mock":
@@ -328,7 +376,7 @@ def complete(
             ) from exc
 
         genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
-        gemini_model = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
+        gemini_model = model or os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
         gmodel = genai.GenerativeModel(gemini_model, system_instruction=system or None)
 
         correlation_id = correlation_id or str(uuid.uuid4())
@@ -391,7 +439,7 @@ def complete(
             "If you are using Azure OpenAI, use agents.common.llm_client instead."
         ) from exc
 
-    model = model or os.getenv("EXTRACTION_MODEL_SKILLS", "claude-sonnet-4-5")
+    model = model or os.getenv("LLM_DEFAULT", "claude-sonnet-4-5")
     model_tier = MODEL_TIER_MAP.get(model, "sonnet")
     client = Anthropic()
 

--- a/common/llm_adapter.py
+++ b/common/llm_adapter.py
@@ -430,13 +430,151 @@ def complete(
                     "extraction_failed": True,
                 }
 
+    # Azure OpenAI provider: use langchain-openai (consistent with llm_client.py)
+    if provider == "azure_openai":
+        try:
+            from langchain_openai import AzureChatOpenAI
+        except ImportError as exc:
+            raise ImportError(
+                "The 'langchain-openai' package is required when LLM_PROVIDER=azure_openai. "
+                "Install with: pip install langchain-openai"
+            ) from exc
+
+        deployment = model or os.getenv("LLM_DEFAULT", "chat-gpt41mini")
+        model_tier = resolve_model_tier(deployment)
+        azure_llm = AzureChatOpenAI(
+            azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
+            api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+            api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2025-01-01-preview"),
+            azure_deployment=deployment,
+            temperature=0.1,
+            max_tokens=max_tokens,
+        )
+
+        correlation_id = correlation_id or str(uuid.uuid4())
+        span_metadata = {"agent_name": agent_name, "model": deployment, "model_tier": model_tier}
+        span_ctx = (
+            _tracer.start_span(agent_name, correlation_id=correlation_id, input=prompt, metadata=span_metadata)
+            if _tracer
+            else nullcontext()
+        )
+
+        lc_messages: list[Any] = []
+        if system:
+            from langchain_core.messages import SystemMessage, HumanMessage
+            lc_messages.append(SystemMessage(content=system))
+            lc_messages.append(HumanMessage(content=prompt))
+        else:
+            from langchain_core.messages import HumanMessage
+            lc_messages.append(HumanMessage(content=prompt))
+
+        backoff_cycles = 0
+
+        with span_ctx:
+            while True:
+                for attempt in range(2):
+                    start = time.monotonic()
+                    try:
+                        msg = azure_llm.invoke(lc_messages)
+                        latency_ms = int((time.monotonic() - start) * 1000)
+                        content = msg.content if hasattr(msg, "content") else str(msg)
+
+                        # Extract actual model name from response metadata
+                        response_model = deployment
+                        input_tokens = 0
+                        output_tokens = 0
+                        if hasattr(msg, "response_metadata") and isinstance(msg.response_metadata, dict):
+                            actual_model = msg.response_metadata.get("model_name") or msg.response_metadata.get("model")
+                            if actual_model:
+                                response_model = actual_model
+                            usage = msg.response_metadata.get("token_usage") or msg.response_metadata.get("usage")
+                            if isinstance(usage, dict):
+                                input_tokens = int(usage.get("prompt_tokens", 0) or usage.get("input_tokens", 0))
+                                output_tokens = int(usage.get("completion_tokens", 0) or usage.get("output_tokens", 0))
+
+                        if not input_tokens:
+                            input_tokens = len(prompt) // 4
+                            output_tokens = len(content) // 4
+
+                        cost_usd = compute_extraction_cost(input_tokens, output_tokens, model_tier)
+
+                        log_extraction_event(
+                            agent_name=agent_name, prompt=prompt, model=response_model,
+                            provider="azure_openai", latency_ms=latency_ms,
+                            input_tokens=input_tokens, output_tokens=output_tokens,
+                            cost_usd=cost_usd, success=True,
+                        )
+
+                        log.info(
+                            "llm_call_success", agent=agent_name, model=response_model,
+                            input_tokens=input_tokens, output_tokens=output_tokens,
+                            cost_usd=round(cost_usd, 6), latency_ms=latency_ms,
+                        )
+
+                        if _tracer:
+                            with contextlib.suppress(Exception):
+                                _tracer.record_latency("llm_call", seconds=latency_ms / 1000.0)
+                                _tracer.log_event("llm_success", {
+                                    "input_tokens": input_tokens, "output_tokens": output_tokens,
+                                    "cost_usd": round(cost_usd, 6),
+                                    "output": _parse_output_for_trace(content),
+                                })
+
+                        return {
+                            "content": content,
+                            "input_tokens": input_tokens,
+                            "output_tokens": output_tokens,
+                            "cost_usd": cost_usd,
+                            "model": response_model,
+                            "model_tier": model_tier,
+                            "success": True,
+                            "extraction_failed": False,
+                        }
+
+                    except Exception as exc:
+                        latency_ms = int((time.monotonic() - start) * 1000)
+                        error_str = str(exc)
+                        is_timeout = "timeout" in error_str.lower()
+                        is_rate_limit = "429" in error_str or "rate limit" in error_str.lower()
+
+                        if is_timeout and attempt == 0:
+                            log.warning("llm_timeout", agent=agent_name, attempt=attempt + 1)
+                            continue
+
+                        if is_rate_limit:
+                            break  # outer while loop handles backoff
+
+                        log_extraction_event(
+                            agent_name=agent_name, prompt=prompt, model=deployment,
+                            provider="azure_openai", latency_ms=latency_ms,
+                            input_tokens=0, output_tokens=0, cost_usd=0.0,
+                            success=False, error_reason=error_str,
+                        )
+                        if _tracer:
+                            with contextlib.suppress(Exception):
+                                _tracer.record_error(exc, context={"agent_name": agent_name, "model": deployment})
+                        return handle_extraction_failure(
+                            agent_name=agent_name, model_tier=model_tier,
+                            error_reason=error_str, latency_ms=latency_ms,
+                        )
+                else:
+                    continue
+
+                # Rate limit back-off (reached via 429 break)
+                backoff_cycles += 1
+                wait = _BACKOFF_SEQUENCE[min(backoff_cycles - 1, len(_BACKOFF_SEQUENCE) - 1)]
+                log.warning("llm_rate_limit_backoff", agent=agent_name, cycle=backoff_cycles, wait_s=wait)
+                if backoff_cycles >= _ALERT_AFTER_CYCLES:
+                    _emit_skills_extraction_alert(agent_name, backoff_cycles)
+                time.sleep(wait)
+
+    # Anthropic provider (fallback for direct Anthropic API usage)
     try:
         from anthropic import Anthropic, APIStatusError, APITimeoutError
     except ImportError as exc:
         raise ImportError(
             "The 'anthropic' package is required when LLM_PROVIDER=anthropic. "
-            "Install with: pip install anthropic\n"
-            "If you are using Azure OpenAI, use agents.common.llm_client instead."
+            "Install with: pip install anthropic"
         ) from exc
 
     model = model or os.getenv("LLM_DEFAULT", "claude-sonnet-4-5")
@@ -513,6 +651,7 @@ def complete(
                         "input_tokens": input_tokens,
                         "output_tokens": output_tokens,
                         "cost_usd": cost_usd,
+                        "model": getattr(response, "model", model),
                         "model_tier": model_tier,
                         "success": True,
                         "extraction_failed": False,

--- a/common/llm_client.py
+++ b/common/llm_client.py
@@ -27,6 +27,7 @@ from common.llm_adapter import (
     compute_extraction_cost,
     get_tracer,
     log_extraction_event,
+    resolve_llm_route,
     resolve_model_tier,
 )
 
@@ -108,7 +109,7 @@ def _model_tier_for_skills_extraction(model_name: str) -> str:
     return resolve_model_tier(model_name)
 
 
-def _build_gemini_llm() -> Any:
+def _build_gemini_llm(model: str | None = None) -> Any:
     """Build Google Gemini chat model via LangChain. Drop-in replacement for AzureChatOpenAI."""
     try:
         from langchain_google_genai import ChatGoogleGenerativeAI
@@ -119,15 +120,27 @@ def _build_gemini_llm() -> Any:
         ) from e
 
     return ChatGoogleGenerativeAI(
-        model=os.getenv("GEMINI_MODEL", "gemini-2.5-flash"),
+        model=model or os.getenv("GEMINI_MODEL", "gemini-2.5-flash"),
         google_api_key=os.getenv("GEMINI_API_KEY"),
         temperature=0.1,
     )
 
 
-def _get_llm() -> Any:
-    """Build chat model for skills extraction. Provider selected via LLM_PROVIDER env var."""
-    provider = os.getenv("LLM_PROVIDER", "azure_openai")
+def _get_llm(role: str | None = None, deployment: str | None = None) -> Any:
+    """Build chat model for skills extraction. Provider selected via LLM_PROVIDER env var.
+
+    When *role* is provided, resolves the deployment via :func:`resolve_llm_route`.
+    An explicit *deployment* overrides role-based resolution (backward compat).
+    """
+    if role and not deployment:
+        resolved_provider, resolved_deployment = resolve_llm_route(role)
+        if resolved_provider == "gemini":
+            return _build_gemini_llm(model=resolved_deployment)
+        deployment = resolved_deployment
+        provider = resolved_provider
+    else:
+        provider = os.getenv("LLM_PROVIDER", "azure_openai")
+
     if provider == "gemini":
         return _build_gemini_llm()
 
@@ -139,16 +152,8 @@ def _get_llm() -> Any:
             "langchain-openai is required for Pass 2 skills extraction. Install with: pip install langchain-openai"
         ) from e
 
-    deployment = (
-        os.getenv("EXTRACTION_DEPLOYMENT_SKILLS")
-        or os.getenv("EXTRACTION_MODEL_SKILLS")
-        or os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
-    )
     if not deployment:
-        raise ValueError(
-            "One of EXTRACTION_DEPLOYMENT_SKILLS, EXTRACTION_MODEL_SKILLS, "
-            "or AZURE_OPENAI_DEPLOYMENT_NAME must be set for skills extraction."
-        )
+        _, deployment = resolve_llm_route(role or "extraction")
 
     return AzureChatOpenAI(
         azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
@@ -159,11 +164,11 @@ def _get_llm() -> Any:
     )
 
 
-def _build_structured_llm(deployment: str) -> Any:
+def _build_structured_llm(deployment: str, *, provider: str | None = None) -> Any:
     """Build chat model for structured extraction calls. Provider selected via LLM_PROVIDER env var."""
-    provider = os.getenv("LLM_PROVIDER", "azure_openai")
+    provider = provider or os.getenv("LLM_PROVIDER", "azure_openai")
     if provider == "gemini":
-        return _build_gemini_llm()
+        return _build_gemini_llm(model=deployment)
 
     # Default: Azure OpenAI
     try:
@@ -263,6 +268,7 @@ def invoke_skills_llm(
     prompt: str,
     *,
     agent_name: str | None = None,
+    role: str = "extraction",
 ) -> tuple[str, dict[str, Any]]:
     """Invoke the skills-extraction LLM once. No retry or back-off.
 
@@ -273,6 +279,8 @@ def invoke_skills_llm(
     agent_name
         If set, used for ``llm_audit_log.agent_name`` instead of the default
         skills-extraction agent (e.g. spam preview diagnostics).
+    role
+        Pipeline role for LLM routing (default: "extraction").
 
     Returns
     -------
@@ -315,16 +323,17 @@ def invoke_skills_llm(
                     })
             return text, meta
 
-    llm = _get_llm()
+    llm = _get_llm(role=role)
     audit_agent = agent_name or AGENT_NAME
+    try:
+        _resolved_provider, _resolved_deployment = resolve_llm_route(role)
+    except ValueError:
+        _resolved_deployment = "azure-openai"
     deployment_name = (
         getattr(llm, "azure_deployment", None)
         or getattr(llm, "deployment_name", None)
         or getattr(llm, "model_name", None)
-        or os.getenv("EXTRACTION_DEPLOYMENT_SKILLS")
-        or os.getenv("EXTRACTION_MODEL_SKILLS")
-        or os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
-        or "azure-openai"
+        or _resolved_deployment
     )
     model_name = deployment_name  # overwritten below if response has actual model
     provider = "azure-openai"
@@ -460,6 +469,7 @@ async def ainvoke_skills_llm(
     prompt: str,
     *,
     agent_name: str | None = None,
+    role: str = "extraction",
 ) -> tuple[str, dict[str, Any]]:
     """Async counterpart to ``invoke_skills_llm`` using ``llm.ainvoke``.
 
@@ -493,16 +503,17 @@ async def ainvoke_skills_llm(
             )
             return text, meta
 
-    llm = _get_llm()
+    llm = _get_llm(role=role)
     audit_agent = agent_name or AGENT_NAME
+    try:
+        _resolved_provider, _resolved_deployment = resolve_llm_route(role)
+    except ValueError:
+        _resolved_deployment = "azure-openai"
     deployment_name = (
         getattr(llm, "azure_deployment", None)
         or getattr(llm, "deployment_name", None)
         or getattr(llm, "model_name", None)
-        or os.getenv("EXTRACTION_DEPLOYMENT_SKILLS")
-        or os.getenv("EXTRACTION_MODEL_SKILLS")
-        or os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
-        or "azure-openai"
+        or _resolved_deployment
     )
     model_name = deployment_name
     provider = "azure-openai"
@@ -631,23 +642,13 @@ async def ainvoke_skills_llm(
             }
 
 
-def _resolve_azure_deployment(*env_keys: str) -> str:
-    """Return first non-empty deployment name from env keys (Haiku/Sonnet slots)."""
-    for key in env_keys:
-        val = os.getenv(key)
-        if val and val.strip():
-            return val.strip()
-    raise ValueError(
-        "Azure OpenAI deployment not configured. Set one of: " + ", ".join(env_keys)
-    )
-
-
 def invoke_structured_extraction_llm(
     prompt: str,
     output_schema: type[TSchema],
     *,
     agent_name: str,
-    deployment_env_keys: tuple[str, ...],
+    role: str = "extraction",
+    deployment_env_keys: tuple[str, ...] | None = None,
     model_tier_for_cost: str,
 ) -> tuple[TSchema | None, dict[str, Any]]:
     """Invoke Azure OpenAI with LangChain ``with_structured_output`` once.
@@ -664,8 +665,10 @@ def invoke_structured_extraction_llm(
         Pydantic model class for the structured response root object.
     agent_name
         Name written to llm_audit_log.
+    role
+        Pipeline role for LLM routing (e.g. "extraction", "extraction_tasks").
     deployment_env_keys
-        Ordered env var names for ``azure_deployment`` (first wins).
+        Deprecated — kept for backward compat. Ignored when role is provided.
     model_tier_for_cost
         ``haiku`` or ``sonnet`` for ``compute_extraction_cost``.
     """
@@ -706,7 +709,7 @@ def invoke_structured_extraction_llm(
             return parsed, meta
 
     try:
-        deployment = _resolve_azure_deployment(*deployment_env_keys)
+        resolved_provider, deployment = resolve_llm_route(role)
     except ValueError as e:
         log.warning("structured_llm_missing_deployment", error=str(e))
         return None, _structured_metadata_failure(
@@ -718,7 +721,7 @@ def invoke_structured_extraction_llm(
 
     deployment_name = deployment
     model_name = deployment_name  # overwritten below if response has actual model
-    provider = "azure-openai"
+    provider = resolved_provider if resolved_provider != "azure_openai" else "azure-openai"
     tracer = get_tracer()
     span_ctx = (
         tracer.start_span(
@@ -734,7 +737,7 @@ def invoke_structured_extraction_llm(
 
     with span_ctx:
         try:
-            llm = _build_structured_llm(deployment)
+            llm = _build_structured_llm(deployment, provider=resolved_provider)
         except ImportError as e:
             log.error("structured_llm_import_failed", error=str(e))
             if tracer:
@@ -848,7 +851,8 @@ async def ainvoke_structured_extraction_llm(
     output_schema: type[TSchema],
     *,
     agent_name: str,
-    deployment_env_keys: tuple[str, ...],
+    role: str = "extraction",
+    deployment_env_keys: tuple[str, ...] | None = None,
     model_tier_for_cost: str,
 ) -> tuple[TSchema | None, dict[str, Any]]:
     """Async counterpart to ``invoke_structured_extraction_llm`` using ``chain.ainvoke``."""
@@ -880,7 +884,7 @@ async def ainvoke_structured_extraction_llm(
             return parsed, meta
 
     try:
-        deployment = _resolve_azure_deployment(*deployment_env_keys)
+        resolved_provider, deployment = resolve_llm_route(role)
     except ValueError as e:
         log.warning("structured_llm_missing_deployment", error=str(e))
         return None, _structured_metadata_failure(
@@ -892,7 +896,7 @@ async def ainvoke_structured_extraction_llm(
 
     deployment_name = deployment
     model_name = deployment_name
-    provider = "azure-openai"
+    provider = resolved_provider if resolved_provider != "azure_openai" else "azure-openai"
 
     tracer = get_tracer()
     span_ctx = (
@@ -909,7 +913,7 @@ async def ainvoke_structured_extraction_llm(
 
     with span_ctx:
         try:
-            llm = _build_structured_llm(deployment)
+            llm = _build_structured_llm(deployment, provider=resolved_provider)
         except ImportError as e:
             log.error("structured_llm_import_failed", error=str(e))
             if tracer:

--- a/common/llm_client.py
+++ b/common/llm_client.py
@@ -158,7 +158,7 @@ def _get_llm(role: str | None = None, deployment: str | None = None) -> Any:
     return AzureChatOpenAI(
         azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
         api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-        api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2024-08-01-preview"),
+        api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2025-01-01-preview"),
         azure_deployment=deployment,
         temperature=0.1,
     )
@@ -181,7 +181,7 @@ def _build_structured_llm(deployment: str, *, provider: str | None = None) -> An
     return AzureChatOpenAI(
         azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
         api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-        api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2024-08-01-preview"),
+        api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2025-01-01-preview"),
         azure_deployment=deployment,
         temperature=0.1,
     )

--- a/common/tests/test_llm_client_async.py
+++ b/common/tests/test_llm_client_async.py
@@ -30,7 +30,7 @@ def _fake_langchain_module(azure_cls: MagicMock) -> ModuleType:
 
 def _deployment_env() -> dict[str, str]:
     return {
-        "EXTRACTION_DEPLOYMENT_TASKS": "test-tasks-deployment",
+        "LLM_DEFAULT": "test-tasks-deployment",
     }
 
 
@@ -62,7 +62,7 @@ def test_ainvoke_structured_extraction_llm_matches_sync_success_metadata() -> No
                 prompt,
                 _ExampleSchema,
                 agent_name="async-agent",
-                deployment_env_keys=("EXTRACTION_DEPLOYMENT_TASKS",),
+                role="extraction_tasks",
                 model_tier_for_cost="haiku",
             )
         )
@@ -70,7 +70,7 @@ def test_ainvoke_structured_extraction_llm_matches_sync_success_metadata() -> No
             prompt,
             _ExampleSchema,
             agent_name="sync-agent",
-            deployment_env_keys=("EXTRACTION_DEPLOYMENT_TASKS",),
+            role="extraction_tasks",
             model_tier_for_cost="haiku",
         )
 
@@ -102,7 +102,7 @@ def test_ainvoke_structured_extraction_llm_timeout_returns_failed_metadata() -> 
                 "extract items",
                 _ExampleSchema,
                 agent_name="async-agent",
-                deployment_env_keys=("EXTRACTION_DEPLOYMENT_TASKS",),
+                role="extraction_tasks",
                 model_tier_for_cost="haiku",
             )
         )
@@ -135,7 +135,7 @@ def test_ainvoke_structured_extraction_llm_returns_rate_limit_metadata() -> None
                 "extract items",
                 _ExampleSchema,
                 agent_name="async-agent",
-                deployment_env_keys=("EXTRACTION_DEPLOYMENT_TASKS",),
+                role="extraction_tasks",
                 model_tier_for_cost="haiku",
             )
         )
@@ -174,7 +174,7 @@ def test_ainvoke_structured_extraction_llm_empty_response_returns_failed_metadat
                 prompt,
                 _ExampleSchema,
                 agent_name="async-agent",
-                deployment_env_keys=("EXTRACTION_DEPLOYMENT_TASKS",),
+                role="extraction_tasks",
                 model_tier_for_cost="haiku",
             )
         )
@@ -199,7 +199,7 @@ def test_ainvoke_structured_extraction_llm_handles_import_error() -> None:
                 "extract items",
                 _ExampleSchema,
                 agent_name="async-agent",
-                deployment_env_keys=("EXTRACTION_DEPLOYMENT_TASKS",),
+                role="extraction_tasks",
                 model_tier_for_cost="haiku",
             )
         )

--- a/config/ingestion_queries.yaml
+++ b/config/ingestion_queries.yaml
@@ -5,62 +5,63 @@
 # NOT at ingestion — ingest broadly, filter on consumer side.
 
 budget_per_key: 200
+max_pages: 50          # pages per query (10 results/page, JSearch max is 50)
 
 queries:
   # --- Tier 1: Direct agentic/LLM-consumer roles ---
   - name: agentic-ai
     keywords: ["AI agent developer", "autonomous systems engineer", "agentic AI"]
-    pages: 10
+
 
   - name: prompt-llm
     keywords: ["prompt engineer", "LLM", "generative AI"]
-    pages: 10
+
 
   - name: ai-safety
     keywords: ["AI safety engineer", "responsible AI", "AI ethics"]
-    pages: 5
+
 
   - name: ai-research
     keywords: ["AI researcher", "applied scientist", "research engineer"]
-    pages: 10
+
 
   # --- Tier 2: Strong AI-adjacent (LLM consumers, not model builders) ---
   - name: ai-engineering
     keywords: ["AI engineer", "machine learning engineer"]
-    pages: 10
+
 
   - name: software-engineering
     keywords: ["software engineer", "backend developer", "full stack"]
-    pages: 10
+
 
   - name: python-developer
     keywords: ["Python developer", "Python engineer"]
-    pages: 10
+
 
   - name: product-tech
     keywords: ["technical product manager", "AI product manager"]
-    pages: 10
+
 
   - name: data-engineering
     keywords: ["data engineer", "data pipeline", "ETL developer"]
-    pages: 10
+
 
   - name: data-science
     keywords: ["data scientist", "data analyst", "data engineer"]
-    pages: 10
+
 
   # --- Tier 3: ML/model-building roles (breadth) ---
   - name: ml-scientist
     keywords: ["machine learning scientist", "applied ML", "ML researcher"]
-    pages: 10
+
 
   - name: deep-learning
     keywords: ["deep learning engineer", "NLP engineer", "computer vision"]
-    pages: 10
+
 
   - name: ml-ops
     keywords: ["MLOps engineer", "ML infrastructure", "model deployment"]
-    pages: 5
+
 
   # ============================================================
   # SECTOR AI-IMPACT LAYER v2 — Real job titles + sector context
@@ -72,112 +73,112 @@ queries:
   # --- Healthcare & Life Sciences ---
   - name: healthcare-it
     keywords: ["health informatics specialist", "EHR analyst", "clinical systems analyst", "healthcare application developer"]
-    pages: 15
+
 
   - name: health-data
     keywords: ["health data analyst", "clinical data analyst", "population health analyst", "healthcare data engineer"]
-    pages: 15
+
 
   - name: life-sciences-dev
     keywords: ["bioinformatics analyst", "research software developer", "pharmaceutical software developer", "laboratory information systems developer"]
-    pages: 15
+
 
   # --- Financial Services & Fintech ---
   - name: fintech-dev
     keywords: ["fintech developer", "payments developer", "banking application developer", "financial systems developer"]
-    pages: 15
+
 
   - name: quant-trading
     keywords: ["quantitative analyst", "trading systems engineer", "algorithmic trading developer", "risk analyst technology"]
-    pages: 10
+
 
   - name: regtech
     keywords: ["compliance technology analyst", "regulatory technology developer", "AML analyst technology", "financial compliance developer"]
-    pages: 10
+
 
   # --- Retail & E-commerce ---
   - name: ecommerce-dev
     keywords: ["ecommerce developer", "digital commerce developer", "retail systems developer", "online marketplace developer"]
-    pages: 15
+
 
   # --- Manufacturing & Industrial ---
   - name: industrial-automation
     keywords: ["automation engineer", "PLC programmer", "SCADA engineer", "industrial automation developer"]
-    pages: 15
+
 
   - name: manufacturing-dev
     keywords: ["manufacturing software developer", "quality systems developer", "MES developer", "production systems analyst"]
-    pages: 10
+
 
   # --- Insurance ---
   - name: insurance-tech
     keywords: ["insurance technology analyst", "claims system developer", "actuarial analyst technology", "policy management developer"]
-    pages: 10
+
 
   # --- Legal Technology ---
   - name: legal-tech
     keywords: ["e-discovery analyst", "legal technology specialist", "litigation support analyst", "contract management developer"]
-    pages: 10
+
 
   # --- Government & Defense ---
   - name: government-tech
     keywords: ["government software developer", "federal software engineer", "defense software developer", "public sector data analyst"]
-    pages: 15
+
 
   # --- Media, Gaming & Entertainment ---
   - name: media-gaming-dev
     keywords: ["game developer", "media software engineer", "streaming platform developer", "content management developer"]
-    pages: 15
+
 
   # --- Education Technology ---
   - name: edtech-dev
     keywords: ["edtech developer", "learning management system developer", "education software developer", "instructional technology developer"]
-    pages: 10
+
 
   # --- Energy & Utilities ---
   - name: energy-utilities-dev
     keywords: ["energy software developer", "utilities technology developer", "smart grid engineer", "oil gas software developer"]
-    pages: 10
+
 
   # --- Transportation & Logistics ---
   - name: logistics-dev
     keywords: ["logistics software developer", "supply chain developer", "fleet management developer", "warehouse management developer"]
-    pages: 15
+
 
   # --- Real Estate & Construction Tech ---
   - name: real-estate-tech
     keywords: ["real estate technology developer", "property management software developer", "construction tech developer", "MLS systems developer"]
-    pages: 10
+
 
   # --- HR & Workforce Technology ---
   - name: hr-tech-dev
     keywords: ["HRIS developer", "HR technology developer", "talent management developer", "payroll systems developer"]
-    pages: 10
+
 
   # --- Robotics & Autonomous Systems ---
   - name: robotics-dev
     keywords: ["robotics engineer", "autonomous vehicle software engineer", "embedded systems developer", "drone software developer"]
-    pages: 15
+
 
   # --- Cybersecurity (distinct titles from earlier queries) ---
   - name: threat-intel
     keywords: ["threat intelligence analyst", "incident response engineer", "digital forensics analyst", "vulnerability researcher"]
-    pages: 10
+
 
   # --- Marketing & Ad Technology ---
   - name: martech-dev
     keywords: ["marketing technology developer", "ad tech developer", "marketing automation developer", "digital marketing engineer"]
-    pages: 10
+
 
   # --- RPA & Intelligent Automation ---
   - name: rpa-automation
     keywords: ["RPA developer", "UiPath developer", "Power Automate developer", "intelligent automation developer"]
-    pages: 15
+
 
   # --- Enterprise AI Deployment (cross-sector glue layer) ---
   - name: enterprise-ai-deploy
     keywords: ["AI integration engineer", "enterprise AI developer", "AI solutions architect", "applied AI engineer"]
-    pages: 15
+
 
   # ============================================================
   # GAP-FILL LAYER — Broad IT roles not covered by existing queries
@@ -188,51 +189,51 @@ queries:
   # --- Infrastructure & Cloud ---
   - name: devops-sre
     keywords: ["DevOps engineer", "site reliability engineer", "platform engineer"]
-    pages: 10
+
 
   - name: cloud-architect
     keywords: ["cloud architect", "cloud solutions architect", "AWS architect", "Azure architect"]
-    pages: 10
+
 
   # --- Security ---
   - name: security-engineer
     keywords: ["security engineer", "application security engineer", "cloud security engineer"]
-    pages: 10
+
 
   # --- Database & Analytics ---
   - name: database-admin
     keywords: ["database administrator", "database engineer", "SQL developer"]
-    pages: 10
+
 
   - name: bi-analytics
     keywords: ["business intelligence developer", "BI analyst", "Tableau developer", "Power BI developer"]
-    pages: 10
+
 
   # --- Frontend & Mobile ---
   - name: frontend-react
     keywords: ["React developer", "frontend engineer", "UI developer"]
-    pages: 10
+
 
   - name: mobile-developer
     keywords: ["iOS developer", "Android developer", "mobile engineer", "React Native developer"]
-    pages: 10
+
 
   # --- QA & Testing ---
   - name: qa-automation
     keywords: ["QA automation engineer", "SDET", "test automation engineer"]
-    pages: 10
+
 
   # --- Networking & Systems ---
   - name: network-engineer
     keywords: ["network engineer", "systems administrator", "infrastructure engineer"]
-    pages: 10
+
 
   # --- Technical Writing & Support ---
   - name: technical-writer
     keywords: ["technical writer", "API documentation writer", "developer advocate"]
-    pages: 5
+
 
   # --- Emerging Tech ---
   - name: blockchain-web3
     keywords: ["blockchain developer", "smart contract developer", "Web3 engineer"]
-    pages: 5
+

--- a/enrichment/agent.py
+++ b/enrichment/agent.py
@@ -115,6 +115,7 @@ def _enrichment_soc_llm() -> Callable[[str], str]:
             text, meta = invoke_skills_llm(
                 prompt,
                 agent_name="enrichment-soc-classifier",
+                role="classification",
             )
         except TypeError as exc:
             if "api_key" in str(exc).lower() or "auth" in str(exc).lower():
@@ -142,6 +143,7 @@ def _enrichment_soc_llm_async() -> Callable:
             text, meta = await ainvoke_skills_llm(
                 prompt,
                 agent_name="enrichment-soc-classifier",
+                role="classification",
             )
         except TypeError as exc:
             if "api_key" in str(exc).lower() or "auth" in str(exc).lower():

--- a/enrichment/classifiers/employer_classifier.py
+++ b/enrichment/classifiers/employer_classifier.py
@@ -28,14 +28,6 @@ log = structlog.get_logger()
 
 AUDIT_AGENT_EMPLOYER = "enrichment-employer-classifier"
 
-_EMPLOYER_DEPLOYMENT_KEYS: tuple[str, ...] = (
-    "EXTRACTION_DEPLOYMENT_EMPLOYER",
-    "EXTRACTION_DEPLOYMENT_NAICS",
-    "EXTRACTION_DEPLOYMENT_SKILLS",
-    "EXTRACTION_MODEL_SKILLS",
-    "AZURE_OPENAI_DEPLOYMENT_NAME",
-)
-
 _MAX_DESC_CHARS = 4000
 
 # Closed set for high-level sector; anything else maps to unknown after LLM response.
@@ -162,7 +154,7 @@ def build_employer_profile(
             _build_prompt(company, desc),
             EmployerClassificationLLMOutput,
             agent_name=AUDIT_AGENT_EMPLOYER,
-            deployment_env_keys=_EMPLOYER_DEPLOYMENT_KEYS,
+            role="extraction_employer",
             model_tier_for_cost="haiku",
         )
     except Exception as exc:
@@ -205,7 +197,7 @@ async def build_employer_profile_async(
             _build_prompt(company, desc),
             EmployerClassificationLLMOutput,
             agent_name=AUDIT_AGENT_EMPLOYER,
-            deployment_env_keys=_EMPLOYER_DEPLOYMENT_KEYS,
+            role="extraction_employer",
             model_tier_for_cost="haiku",
         )
     except Exception as exc:

--- a/enrichment/classifiers/naics_classifier.py
+++ b/enrichment/classifiers/naics_classifier.py
@@ -25,13 +25,6 @@ log = structlog.get_logger()
 
 AUDIT_AGENT_NAICS = "enrichment-naics-classifier"
 
-_NAICS_DEPLOYMENT_KEYS: tuple[str, ...] = (
-    "EXTRACTION_DEPLOYMENT_NAICS",
-    "EXTRACTION_DEPLOYMENT_SKILLS",
-    "EXTRACTION_MODEL_SKILLS",
-    "AZURE_OPENAI_DEPLOYMENT_NAME",
-)
-
 # NAICS codes are numeric strings; allow LLM typos like trailing spaces.
 _CODE_IN_TEXT = re.compile(r"\b\d{2,6}\b")
 
@@ -160,7 +153,7 @@ def classify_naics(job_title: str, job_description: str | None, session: Session
             prompt,
             NAICSClassificationOutput,
             agent_name=AUDIT_AGENT_NAICS,
-            deployment_env_keys=_NAICS_DEPLOYMENT_KEYS,
+            role="extraction_naics",
             model_tier_for_cost="haiku",
         )
     except Exception as exc:
@@ -203,7 +196,7 @@ async def classify_naics_async(job_title: str, job_description: str | None, sess
             prompt,
             NAICSClassificationOutput,
             agent_name=AUDIT_AGENT_NAICS,
-            deployment_env_keys=_NAICS_DEPLOYMENT_KEYS,
+            role="extraction_naics",
             model_tier_for_cost="haiku",
         )
     except Exception as exc:

--- a/eval/cost_tier.py
+++ b/eval/cost_tier.py
@@ -16,12 +16,14 @@ from common.llm_adapter import MODEL_TIER_MAP
 def _deployment_names() -> set[str]:
     names: set[str] = set()
     for key in (
-        "EXTRACTION_DEPLOYMENT_SKILLS",
-        "EXTRACTION_MODEL_SKILLS",
-        "AZURE_OPENAI_DEPLOYMENT_NAME",
+        "LLM_DEFAULT",
+        "LLM_EXTRACTION",
     ):
         v = os.getenv(key, "").strip()
         if v:
+            # Strip provider prefix if present (e.g. "gemini:gemini-2.5-pro" -> "gemini-2.5-pro")
+            if ":" in v:
+                v = v.split(":", 1)[1].strip()
             names.add(v)
     return names
 

--- a/ingestion/sources/jsearch_adapter.py
+++ b/ingestion/sources/jsearch_adapter.py
@@ -178,7 +178,7 @@ class JSearchAdapter(SourceAdapter):
         try:
             batch_size = int(os.getenv("BATCH_SIZE", "100"))
             # Roughly 10 jobs per page on JSearch; cap pages to avoid rate limits
-            num_pages = min(10, max(1, (batch_size + 9) // 10))
+            num_pages = min(20, max(1, (batch_size + 9) // 10))
         except (TypeError, ValueError):
             num_pages = 1
         max_retries = max(0, _env_int("JSEARCH_MAX_RETRIES", 2))

--- a/ingestion/sources/jsearch_adapter.py
+++ b/ingestion/sources/jsearch_adapter.py
@@ -174,13 +174,7 @@ class JSearchAdapter(SourceAdapter):
             query_parts.extend(region.role_categories[:2])
         query = " ".join(query_parts).strip() or "jobs"
 
-        num_pages = 1
-        try:
-            batch_size = int(os.getenv("BATCH_SIZE", "100"))
-            # Roughly 10 jobs per page on JSearch; cap pages to avoid rate limits
-            num_pages = min(20, max(1, (batch_size + 9) // 10))
-        except (TypeError, ValueError):
-            num_pages = 1
+        num_pages = max(1, min(50, _env_int("JSEARCH_MAX_PAGES", 50)))
         max_retries = max(0, _env_int("JSEARCH_MAX_RETRIES", 2))
         base_delay = max(1, _env_int("JSEARCH_RETRY_BASE_DELAY_SECONDS", 10))
         max_delay = max(base_delay, _env_int("JSEARCH_RETRY_MAX_DELAY_SECONDS", 60))

--- a/run_soc_demo.py
+++ b/run_soc_demo.py
@@ -32,11 +32,7 @@ def _azure_openai_configured() -> bool:
         return False
     if not os.getenv("AZURE_OPENAI_API_KEY", "").strip():
         return False
-    deployment = (
-        os.getenv("EXTRACTION_DEPLOYMENT_SKILLS")
-        or os.getenv("EXTRACTION_MODEL_SKILLS")
-        or os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
-    )
+    deployment = os.getenv("LLM_DEFAULT") or os.getenv("LLM_EXTRACTION")
     return bool(deployment and deployment.strip())
 
 
@@ -56,7 +52,7 @@ def _ensure_llm_configured_or_exit() -> None:
             "Missing Azure OpenAI configuration. invoke_skills_llm() needs:\n"
             "  AZURE_OPENAI_ENDPOINT\n"
             "  AZURE_OPENAI_API_KEY\n"
-            "  AZURE_OPENAI_DEPLOYMENT_NAME (or EXTRACTION_DEPLOYMENT_SKILLS / EXTRACTION_MODEL_SKILLS)\n"
+            "  LLM_DEFAULT (or LLM_EXTRACTION)\n"
             "Add these to repo-root .env, or run with SOC_DEMO_SKIP_LLM=1.",
             file=sys.stderr,
         )

--- a/scripts/batch_ingest.py
+++ b/scripts/batch_ingest.py
@@ -136,6 +136,7 @@ def main() -> None:
 
     config = _load_config()
     budget_per_key = config.get("budget_per_key", 500)
+    max_pages = config.get("max_pages", 50)
     all_queries = config.get("queries", [])
 
     # Filter queries based on --start-query and --queries flags
@@ -180,7 +181,7 @@ def main() -> None:
             available_slots=[slot for slot, _ in api_keys],
         )
 
-    total_requests = sum(q.get("pages", 10) for q in queries)
+    total_requests = len(queries) * max_pages
 
     log.info(
         "batch_plan",
@@ -209,10 +210,9 @@ def main() -> None:
         print(f"{'='*60}")
         for q in queries:
             orig_idx = _all_query_names.index(q["name"]) + 1 if q["name"] in _all_query_names else "?"
-            pages = q.get("pages", 10)
             print(f"\n  [{orig_idx}] {q['name']}")
             print(f"      Keywords: {q['keywords']}")
-            print(f"      Pages: {pages} ({pages} API requests, ~{pages * 10} results)")
+            print(f"      Pages: {max_pages} ({max_pages} API requests, ~{max_pages * 10} results)")
         print(f"\n  Total: {total_requests} API requests across {len(queries)} queries")
         print(
             f"  Keys available: {max(0, len(api_keys) - start_key_idx)} x {budget_per_key} = "
@@ -238,7 +238,7 @@ def main() -> None:
 
     stop_batch = False
     for i, query in enumerate(queries, 1):
-        pages = query.get("pages", 10)
+        pages = max_pages
 
         attempt = 1
         while True:
@@ -255,7 +255,7 @@ def main() -> None:
             active_key_slot, active_key = api_keys[current_key_idx]
             highest_key_idx_used = max(highest_key_idx_used, current_key_idx)
             os.environ["JSEARCH_API_KEY"] = active_key
-            os.environ["BATCH_SIZE"] = str(pages * 10)
+            os.environ["JSEARCH_MAX_PAGES"] = str(pages)
 
             region = _build_region_config(query)
             correlation_id = f"batch-{query['name']}-{uuid.uuid4().hex[:8]}"

--- a/scripts/test_llm_connection.py
+++ b/scripts/test_llm_connection.py
@@ -3,8 +3,7 @@
 Usage (from repo root with venv activated):
   python -m scripts.test_llm_connection
 
-Requires: AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, and one of
-  AZURE_OPENAI_DEPLOYMENT_NAME, EXTRACTION_DEPLOYMENT_SKILLS, EXTRACTION_MODEL_SKILLS.
+Requires: AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, and LLM_DEFAULT (or LLM_EXTRACTION).
 """
 # ruff: noqa: T201  # CLI script; print to stdout is intentional
 
@@ -40,9 +39,7 @@ def main() -> int:
             getattr(llm, "azure_deployment", None)
             or getattr(llm, "deployment_name", None)
             or getattr(llm, "model_name", None)
-            or os.getenv("EXTRACTION_DEPLOYMENT_SKILLS")
-            or os.getenv("EXTRACTION_MODEL_SKILLS")
-            or os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+            or os.getenv("LLM_DEFAULT")
             or "unknown"
         )
         print(f"  LLM created successfully. Deployment: {deployment}")

--- a/skills_extraction/agent.py
+++ b/skills_extraction/agent.py
@@ -91,12 +91,12 @@ _EXTRACTION_STORE_SAVE_LOCK = threading.Lock()
 
 def _llm_deployment_name() -> str:
     """Azure deployment used for Pass 2 (for dbo.extracted_intelligence.extraction_model)."""
-    return (
-        os.getenv("EXTRACTION_DEPLOYMENT_SKILLS")
-        or os.getenv("EXTRACTION_MODEL_SKILLS")
-        or os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
-        or "azure-openai"
-    )
+    from common.llm_adapter import resolve_llm_route
+    try:
+        _, deployment = resolve_llm_route("extraction")
+        return deployment
+    except ValueError:
+        return "azure-openai"
 
 
 def _parallel_enabled() -> bool:

--- a/skills_extraction/extractors/responsibilities.py
+++ b/skills_extraction/extractors/responsibilities.py
@@ -35,12 +35,6 @@ log = structlog.get_logger()
 
 AGENT_RESPONSIBILITIES = "skills-extraction-responsibilities"
 
-_RESP_DEPLOYMENT_KEYS = (
-    "EXTRACTION_DEPLOYMENT_RESPONSIBILITIES",
-    "EXTRACTION_MODEL_RESPONSIBILITIES",
-    "AZURE_OPENAI_DEPLOYMENT_NAME",
-)
-
 
 class _ResponsibilitiesLLMRoot(BaseModel):
     """Root schema for structured LLM output (list of ResponsibilityRecord)."""
@@ -158,7 +152,7 @@ def extract_responsibilities(
             prompt,
             _ResponsibilitiesLLMRoot,
             agent_name=AGENT_RESPONSIBILITIES,
-            deployment_env_keys=_RESP_DEPLOYMENT_KEYS,
+            role="extraction_responsibilities",
             model_tier_for_cost="sonnet",
         )
         metadata.update(call_meta)
@@ -213,7 +207,7 @@ async def extract_responsibilities_async(
             prompt,
             _ResponsibilitiesLLMRoot,
             agent_name=AGENT_RESPONSIBILITIES,
-            deployment_env_keys=_RESP_DEPLOYMENT_KEYS,
+            role="extraction_responsibilities",
             model_tier_for_cost="sonnet",
         )
 

--- a/skills_extraction/extractors/skills.py
+++ b/skills_extraction/extractors/skills.py
@@ -46,12 +46,6 @@ DEFAULT_SKILL_CONFIDENCE_THRESHOLD = 0.75
 
 AGENT_SKILLS = "skills-extraction-agent"
 
-_SKILLS_DEPLOYMENT_KEYS = (
-    "EXTRACTION_DEPLOYMENT_SKILLS",
-    "EXTRACTION_MODEL_SKILLS",
-    "AZURE_OPENAI_DEPLOYMENT_NAME",
-)
-
 
 # ---------------------------------------------------------------------------
 # Pydantic models for structured LLM output
@@ -230,7 +224,7 @@ def extract_skills(
             prompt,
             _SkillsLLMRoot,
             agent_name=AGENT_SKILLS,
-            deployment_env_keys=_SKILLS_DEPLOYMENT_KEYS,
+            role="extraction",
             model_tier_for_cost="sonnet",
         )
 
@@ -327,7 +321,7 @@ def extract_skills_no_taxonomy(
             prompt,
             _SkillsLLMRoot,
             agent_name=AGENT_SKILLS,
-            deployment_env_keys=_SKILLS_DEPLOYMENT_KEYS,
+            role="extraction",
             model_tier_for_cost="sonnet",
         )
 
@@ -394,7 +388,7 @@ async def extract_skills_no_taxonomy_async(
             prompt,
             _SkillsLLMRoot,
             agent_name=AGENT_SKILLS,
-            deployment_env_keys=_SKILLS_DEPLOYMENT_KEYS,
+            role="extraction",
             model_tier_for_cost="sonnet",
         )
 

--- a/skills_extraction/extractors/tasks.py
+++ b/skills_extraction/extractors/tasks.py
@@ -36,12 +36,6 @@ log = structlog.get_logger()
 
 AGENT_TASKS = "skills-extraction-tasks"
 
-_TASKS_DEPLOYMENT_KEYS = (
-    "EXTRACTION_DEPLOYMENT_TASKS",
-    "EXTRACTION_MODEL_TASKS",
-    "AZURE_OPENAI_DEPLOYMENT_NAME",
-)
-
 
 class _TasksLLMRoot(BaseModel):
     """Root schema for structured LLM output (list of TaskRecord)."""
@@ -151,7 +145,7 @@ def extract_tasks(
             prompt,
             _TasksLLMRoot,
             agent_name=AGENT_TASKS,
-            deployment_env_keys=_TASKS_DEPLOYMENT_KEYS,
+            role="extraction_tasks",
             model_tier_for_cost="haiku",
         )
         metadata.update(call_meta)
@@ -203,7 +197,7 @@ async def extract_tasks_async(
             prompt,
             _TasksLLMRoot,
             agent_name=AGENT_TASKS,
-            deployment_env_keys=_TASKS_DEPLOYMENT_KEYS,
+            role="extraction_tasks",
             model_tier_for_cost="haiku",
         )
 

--- a/tests/test_cost_tier.py
+++ b/tests/test_cost_tier.py
@@ -10,9 +10,8 @@ from eval.cost_tier import resolve_llm_audit_model_tier
 @pytest.fixture
 def clear_deployment_env(monkeypatch: pytest.MonkeyPatch) -> None:
     for key in (
-        "EXTRACTION_DEPLOYMENT_SKILLS",
-        "EXTRACTION_MODEL_SKILLS",
-        "AZURE_OPENAI_DEPLOYMENT_NAME",
+        "LLM_DEFAULT",
+        "LLM_EXTRACTION",
         "EXTRACTION_MODEL_TIER",
     ):
         monkeypatch.delenv(key, raising=False)
@@ -27,7 +26,7 @@ def test_azure_deployment_uses_extraction_model_tier(
     monkeypatch: pytest.MonkeyPatch,
     clear_deployment_env: None,
 ) -> None:
-    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT_NAME", "gpt-4o-skills")
+    monkeypatch.setenv("LLM_DEFAULT", "gpt-4o-skills")
     monkeypatch.setenv("EXTRACTION_MODEL_TIER", "haiku")
     assert resolve_llm_audit_model_tier("gpt-4o-skills") == "haiku"
 
@@ -36,7 +35,7 @@ def test_azure_deployment_defaults_sonnet(
     monkeypatch: pytest.MonkeyPatch,
     clear_deployment_env: None,
 ) -> None:
-    monkeypatch.setenv("EXTRACTION_DEPLOYMENT_SKILLS", "my-deploy")
+    monkeypatch.setenv("LLM_DEFAULT", "my-deploy")
     monkeypatch.delenv("EXTRACTION_MODEL_TIER", raising=False)
     assert resolve_llm_audit_model_tier("my-deploy") == "sonnet"
 

--- a/tests/test_llm_summary.py
+++ b/tests/test_llm_summary.py
@@ -35,13 +35,16 @@ def _sample_trajectory() -> TrajectoryEntry:
 
 
 @patch("analytics.insights.llm_summary.complete")
-def test_llm_success_sets_flags_and_model(mock_complete):
+def test_llm_success_sets_flags_and_model(mock_complete, monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "azure_openai")
+    monkeypatch.setenv("LLM_DEFAULT", "chat-gpt41mini")
     mock_complete.return_value = {
         "content": "Paragraph one.\n\nParagraph two.\n\nParagraph three.",
         "input_tokens": 10,
         "output_tokens": 20,
         "cost_usd": 0.0,
-        "model_tier": "sonnet",
+        "model": "gpt-4.1-mini-2025-04-14",
+        "model_tier": "gpt-4.1-mini",
         "success": True,
         "extraction_failed": False,
     }
@@ -49,7 +52,7 @@ def test_llm_success_sets_flags_and_model(mock_complete):
     fresh = _sample_freshness()
     r = generate_summary("Python", traj, fresh)
     assert r["is_llm_generated"] is True
-    assert r["model_used"] == "sonnet"
+    assert r["model_used"] == "gpt-4.1-mini-2025-04-14"
     assert r["summary_text"].strip() != ""
     assert "Paragraph one" in r["summary_text"]
     mock_complete.assert_called_once()

--- a/tests/test_llm_summary.py
+++ b/tests/test_llm_summary.py
@@ -49,7 +49,7 @@ def test_llm_success_sets_flags_and_model(mock_complete):
     fresh = _sample_freshness()
     r = generate_summary("Python", traj, fresh)
     assert r["is_llm_generated"] is True
-    assert r["model_used"] == "claude-sonnet-4-5"
+    assert r["model_used"] == "sonnet"
     assert r["summary_text"].strip() != ""
     assert "Paragraph one" in r["summary_text"]
     mock_complete.assert_called_once()


### PR DESCRIPTION
## Summary

**BREAKING CHANGE** — All `EXTRACTION_DEPLOYMENT_*` and `AZURE_OPENAI_DEPLOYMENT_NAME` env vars are dead. Update your `.env` from `.env.example` before running anything.

Adds `resolve_llm_route(role)` to `common/llm_adapter.py` — a single function that resolves any pipeline role to `(provider, deployment)` via `LLM_*` env vars. Fail fast with clear error if not configured.

## New Env Vars

```
LLM_PROVIDER=azure_openai              # Default provider (fallback)
LLM_DEFAULT=chat-gpt41mini             # Haiku-class — default for all calls
LLM_SYNTHESIS=chat-gpt41               # Sonnet-class — Q&A answer generation
# LLM_EXTRACTION=                      # Override for extraction (optional)
# LLM_CLASSIFICATION=                  # Override for intent classification (optional)
```

Per-var provider override: `LLM_SYNTHESIS=gemini:gemini-2.5-pro` routes synthesis through Gemini.

## Dead Env Vars (remove from .env)

- `AZURE_OPENAI_DEPLOYMENT_NAME`
- `AZURE_OPENAI_SYNTHESIS_DEPLOYMENT_NAME`
- `EXTRACTION_DEPLOYMENT_SKILLS` / `_TASKS` / `_RESPONSIBILITIES` / `_NAICS` / `_EMPLOYER`
- `EXTRACTION_MODEL_SKILLS` / `_TASKS` / `_RESPONSIBILITIES`

## Azure Deployment

`chat-gpt41` (gpt-4.1 full, Sonnet-class) deployed on `resumeJobMatch` at 5 RPM / 5K TPM.

## Follow-up fixes (added April 14)

### JSearch page cap raised (10 to 20)
- `ingestion/sources/jsearch_adapter.py` — `min(10, ...)` to `min(20, ...)` to match JSearch API max. Doubles per-query yield (~100 to ~200 results). Requires `BATCH_SIZE=200` in `.env`.

### Azure OpenAI branch added to complete()
- `complete()` previously fell through to the Anthropic branch when `LLM_PROVIDER=azure_openai`. Now has a dedicated Azure branch using `AzureChatOpenAI` from `langchain-openai`, consistent with `llm_client.py`.

### API response model returned in result dict
- All provider branches (Anthropic, Azure, Gemini) now return the actual model name from the API response in the `"model"` key. Callers get the specific model string (e.g., `gpt-4.1-mini-2025-04-14`) instead of just the pricing tier. Langfuse traces now log the real model name.

### API version aligned across files
- `llm_client.py` updated from `2024-08-01-preview` to `2025-01-01-preview`, matching `.env.example` and `llm_adapter.py`.

### Test fix: dynamic model assertion
- `test_llm_summary.py` uses `monkeypatch.setenv` for `LLM_PROVIDER` and `LLM_DEFAULT`, asserts the resolved model name flows through `model_used` instead of hardcoding `"claude-sonnet-4-5"`.

## Test Plan

- [x] `resolve_llm_route("synthesis")` returns `("azure_openai", "chat-gpt41")`
- [x] Fail fast: no `LLM_DEFAULT` set raises `ValueError` with clear message
- [x] Provider override: `LLM_SYNTHESIS=gemini:gemini-2.5-pro` returns `("gemini", "gemini-2.5-pro")`
- [x] `pytest tests/test_cost_tier.py` — 5 passed
- [x] `pytest tests/test_llm_summary.py` — 8 passed (model name assertion updated)
- [x] `pytest common/tests/test_llm_client_async.py` — 5 passed
- [x] Full suite: 728 passed (failures are pre-existing DB/scheduler tests)
- [x] Old `EXTRACTION_DEPLOYMENT_*` vars are NOT checked
- [x] Azure branch returns actual model from `response_metadata`
- [x] Langfuse traces unaffected — same span/event/latency pattern in all branches