### PR TITLE
chore(rules): llm-provider policy — Azure OpenAI default

### DIFF
--- a/.cursor/rules/llm-provider.mdc
+++ b/.cursor/rules/llm-provider.mdc
@@ -1,0 +1,53 @@
+---
+description: LLM provider policy — Azure OpenAI is the default. No hardcoded Anthropic model IDs in agent code, rules, docs, or curriculum material.
+alwaysApply: true
+---
+
+# LLM Provider Policy
+
+## Azure OpenAI is the default provider
+
+All LLM calls in agent code route through the provider-agnostic adapter
+(`common.llm_adapter.complete` — see `llm-routing.mdc` for the `role`-based
+resolution chain). Do not hardcode Anthropic model IDs in agent code,
+`.cursor/rules/*.mdc` contracts, runbooks, documentation, slide decks,
+or speaker notes.
+
+## Capability tier → Azure deployment
+
+| Tier | Azure deployment | Env var | Use for |
+|---|---|---|---|
+| Haiku-class | `chat-gpt41mini` | `LLM_DEFAULT` | Intent classification, labelling, routing decisions |
+| Sonnet-class | `chat-gpt41` | `LLM_SYNTHESIS` | Q&A answer generation, multi-step reasoning, evidence citation |
+| Embeddings | `embeddings-te3small` | `AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME` | pgvector / semantic search |
+
+Environment defaults: `LLM_PROVIDER=azure_openai`,
+`LLM_DEFAULT=chat-gpt41mini`, `LLM_SYNTHESIS=chat-gpt41`.
+
+## Forbidden in agent code, rules, and docs
+
+- `model = "claude-haiku-4-5"`
+- `model = "claude-sonnet-4-6"`, `"claude-opus-4-6"`, `"claude-3-5-sonnet-*"`, `"claude-3-*"`
+- Rule or runbook text: "use Haiku" / "use Sonnet" without clarifying these are capability **tiers**, mapped to Azure deployments above
+- `.mdc` contracts that require a specific Anthropic model
+
+## Correct patterns
+
+- Agent code: `complete(prompt=..., agent_name=..., role="classification")` — go through the adapter
+- If a literal default is unavoidable: `os.getenv("LLM_DEFAULT", "chat-gpt41mini")`
+- Docs / curriculum: "Haiku-tier (Azure OpenAI `chat-gpt41mini` via `LLM_DEFAULT`)"
+
+## Relationship to other rules
+
+- `llm-routing.mdc` — the canonical routing spec (role-based resolution, env var contract, cost tracking). This rule (`llm-provider.mdc`) enforces the provider policy at a higher level and applies repo-wide via `alwaysApply: true`.
+- Violations in `llm-routing.mdc` scope (hardcoded deployment names) are already forbidden there. This rule adds: no Anthropic model IDs anywhere.
+
+## Exceptions (narrow)
+
+- ADRs and changelogs documenting the Anthropic → Azure migration
+- Test files exercising the `anthropic` provider fallback path in the adapter
+- Claude Code tooling itself — orthogonal to the pipeline
+
+## Rationale
+
+Negotiated Azure OpenAI contract, data residency in the same Azure subscription as the JIE Postgres database, and consistency with the wfd-os production deployment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,29 @@ This repo was extracted from `job-intelligence-engine/` into a standalone reposi
 
 ---
 
+## LLM Model References — Azure OpenAI Is the Default Provider
+
+All LLM calls route through the provider-agnostic adapter
+(`common.llm_adapter.complete`) with role-based resolution. Do not hardcode
+Anthropic model IDs (`claude-haiku-4-5`, `claude-sonnet-4-6`,
+`claude-opus-4-6`, etc.) in agent code, `.cursor/rules/*.mdc` contracts,
+runbooks, or documentation.
+
+**Deployment map:**
+
+| Tier | Azure deployment | Env var |
+|---|---|---|
+| Haiku-class | `chat-gpt41mini` | `LLM_DEFAULT` |
+| Sonnet-class | `chat-gpt41` | `LLM_SYNTHESIS` |
+| Embeddings | `embeddings-te3small` | `AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME` |
+
+See `.cursor/rules/llm-provider.mdc` (repo-wide, `alwaysApply: true`) for the
+full rule and `.cursor/rules/llm-routing.mdc` for the role-based resolution
+spec. The `anthropic` provider is kept as a fallback in `common.llm_adapter`
+but is not the default for any agent.
+
+---
+
 ## Table Ownership
 
 **SQLAlchemy is the single database authority.** All tables live in the `dbo` schema on PostgreSQL.


### PR DESCRIPTION
## Summary

Adds a repo-wide Cursor rule (`alwaysApply: true`) and companion `CLAUDE.md` section codifying the existing policy: **Azure OpenAI is the default LLM provider. No hardcoded Anthropic model IDs in agent code, rules, or docs.**

## Why now

Week 8 review surfaced `analytics/query_engine/intent.py` with `_DEFAULT_INTENT_MODEL = "claude-haiku-4-5"` as a hardcoded literal. That violates the existing `llm-routing.mdc` rule (\"never hardcode deployment names\") but there was no explicit repo-wide rule banning Anthropic model IDs specifically — so the violation wasn't caught by Cursor. This PR closes that gap.

## What's included

- `.cursor/rules/llm-provider.mdc` — new, `alwaysApply: true`, applies repo-wide. Defines the tier → Azure deployment mapping, forbidden patterns, and correct patterns. Complements (does not duplicate) `llm-routing.mdc`.
- `CLAUDE.md` — new section pointing at both rules so Claude Code sessions pick up the policy without needing the Cursor rule evaluator.

## Out of scope for this PR (tracked separately)

- Fixing `intent.py` to drop the `claude-haiku-4-5` literal and route through `common.llm_adapter.complete(role=\"classification\")` — Pair B (Fatima + Nestor) owns this as part of their Week 8 branch before flipping out of draft.
- Audit of other agent modules for similar violations — follow-up.

## Test plan

- [x] File renders in Cursor (frontmatter parses, `alwaysApply: true` recognized)
- [x] No changes to runtime code — pure policy addition
- [ ] After merge, reviewers pick up the rule on their next Cursor session