### PR TITLE
feat: surface Q&A-ready fields on job_postings and ground LLM SQL hint (#170 #171 #176)

### DIFF
--- a/analytics/query_engine/routing.py
+++ b/analytics/query_engine/routing.py
@@ -63,7 +63,8 @@ def _truncate_sql_execution_error(exc: BaseException, *, max_len: int = _SQL_EXE
 
 
 # Derived from docs/planning/QA_DATA_CONTRACT.md — update that doc first, then re-derive here.
-# Tracks: GitHub #186 (hotfix), #171 (full fix after #170 schema work lands).
+# Tracks: GitHub #186 (hotfix), #171 (full contract fix — date_posted/seniority_level/is_remote
+# columns promoted to job_postings by #170; CRITICAL block updated accordingly).
 _SCHEMA_HINT = """\
 Allowed tables (PostgreSQL dbo schema only; always reference as dbo.table_name):
 
@@ -83,6 +84,7 @@ PREFER aggregate tables for skill/tool/role/sector/geo count and trend questions
 Operational tables (use when aggregates cannot answer):
   job_postings(job_posting_id, company_id, job_title, employment_type, location,
                salary_range, status, source, external_id, createdat, ingestion_run_id,
+               date_posted, seniority_level, is_remote,
                borderplex_subregion, temporal_period, spam_tier, quality_score, is_spam,
                soc_code, naics_code, canonical_role_id, employer_profile_id,
                is_duplicate, zip_code)
@@ -94,13 +96,10 @@ Operational tables (use when aggregates cannot answer):
   industry_sectors(industry_sector_id, sector_title)
 
 CRITICAL — columns that do NOT exist (never generate SQL referencing these):
-  - job_postings has NO skill_id, skills, posted_date, or date_posted column.
+  - job_postings has NO skill_id, skills, or posted_date column.
     Skills are pre-aggregated in dbo.skill_demand_weekly.
     For "top skills by posting count" use: SELECT skill_label, posting_count
     FROM dbo.skill_demand_weekly ORDER BY posting_count DESC LIMIT 10
-  - job_postings has NO date_posted column yet. Use createdat (ingestion timestamp)
-    as a recency proxy, or join dbo.normalized_jobs ON
-    jp.source = nj.source AND jp.external_id = nj.external_id to get nj.date_posted.
   - Never reference: publish_date, employer_id, tech_area_id, start_date, end_date, location_id.
     These columns are deprecated (99-100% NULL) and must not appear in any query.\
 """

--- a/analytics/query_engine/routing.py
+++ b/analytics/query_engine/routing.py
@@ -65,6 +65,7 @@ def _truncate_sql_execution_error(exc: BaseException, *, max_len: int = _SQL_EXE
 # Derived from docs/planning/QA_DATA_CONTRACT.md — update that doc first, then re-derive here.
 # Tracks: GitHub #186 (hotfix), #171 (full contract fix — date_posted/seniority_level/is_remote
 # columns promoted to job_postings by #170; CRITICAL block updated accordingly).
+# Extended: #173 (role_classification promoted), #174 (structured salary columns promoted).
 _SCHEMA_HINT = """\
 Allowed tables (PostgreSQL dbo schema only; always reference as dbo.table_name):
 
@@ -83,8 +84,9 @@ PREFER aggregate tables for skill/tool/role/sector/geo count and trend questions
 
 Operational tables (use when aggregates cannot answer):
   job_postings(job_posting_id, company_id, job_title, employment_type, location,
-               salary_range, status, source, external_id, createdat, ingestion_run_id,
-               date_posted, seniority_level, is_remote,
+               salary_range, salary_min, salary_max, salary_currency, salary_period,
+               status, source, external_id, createdat, ingestion_run_id,
+               date_posted, seniority_level, is_remote, role_classification,
                borderplex_subregion, temporal_period, spam_tier, quality_score, is_spam,
                soc_code, naics_code, canonical_role_id, employer_profile_id,
                is_duplicate, zip_code)

--- a/analytics/query_engine/tests/test_schema_hint_columns.py
+++ b/analytics/query_engine/tests/test_schema_hint_columns.py
@@ -15,13 +15,11 @@ No live database or LLM calls are made.
 
 from __future__ import annotations
 
-import json
 import re
-from unittest.mock import MagicMock, patch
 
 import pytest
 
-from analytics.query_engine.routing import _SCHEMA_HINT, _sql_prompt
+from analytics.query_engine.routing import _SCHEMA_HINT
 
 # ---------------------------------------------------------------------------
 # Known-good column sets (source of truth: docs/planning/QA_DATA_CONTRACT.md)

--- a/analytics/query_engine/tests/test_schema_hint_columns.py
+++ b/analytics/query_engine/tests/test_schema_hint_columns.py
@@ -1,0 +1,249 @@
+"""Regression tests for _SCHEMA_HINT column completeness (GitHub #171).
+
+Validates that:
+1. Columns listed in _SCHEMA_HINT for job_postings match the known-good set after
+   the #170 schema promotion (date_posted, seniority_level, is_remote added).
+2. Columns listed in _SCHEMA_HINT do NOT include any deprecated columns that have
+   been explicitly removed (publish_date, employer_id, tech_area_id, location_id,
+   posted_date, date_posted-as-missing).
+3. The CRITICAL block no longer warns that date_posted is absent.
+4. The LLM SQL generation path (mocked) only produces SQL referencing columns
+   present in the known-good column list for job_postings.
+
+No live database or LLM calls are made.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from analytics.query_engine.routing import _SCHEMA_HINT, _sql_prompt
+
+# ---------------------------------------------------------------------------
+# Known-good column sets (source of truth: docs/planning/QA_DATA_CONTRACT.md)
+# ---------------------------------------------------------------------------
+
+JOB_POSTINGS_KNOWN_COLUMNS = frozenset(
+    {
+        "job_posting_id",
+        "company_id",
+        "job_title",
+        "employment_type",
+        "location",
+        "salary_range",
+        "status",
+        "source",
+        "external_id",
+        "createdat",
+        "ingestion_run_id",
+        # Week 8 (#170) Q&A-ready promotions
+        "date_posted",
+        "seniority_level",
+        "is_remote",
+        # Enrichment columns
+        "borderplex_subregion",
+        "temporal_period",
+        "spam_tier",
+        "quality_score",
+        "is_spam",
+        "soc_code",
+        "naics_code",
+        "canonical_role_id",
+        "employer_profile_id",
+        "is_duplicate",
+        "zip_code",
+    }
+)
+
+DEPRECATED_COLUMNS = frozenset(
+    {
+        "publish_date",
+        "employer_id",
+        "tech_area_id",
+        "start_date",
+        "end_date",
+        "location_id",
+        "posted_date",
+        # skill_id and skills are skill-join columns, not job_postings columns
+        "skill_id",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# _SCHEMA_HINT structural tests
+# ---------------------------------------------------------------------------
+
+
+def test_schema_hint_contains_date_posted_for_job_postings() -> None:
+    """date_posted must appear in the job_postings column list after #170."""
+    jp_section = _extract_job_postings_line(_SCHEMA_HINT)
+    assert "date_posted" in jp_section, (
+        "date_posted is missing from the job_postings column list in _SCHEMA_HINT. "
+        "This column was promoted by #170 and must be listed so the LLM can reference it."
+    )
+
+
+def test_schema_hint_contains_seniority_level_for_job_postings() -> None:
+    """seniority_level must appear in the job_postings column list after #170."""
+    jp_section = _extract_job_postings_line(_SCHEMA_HINT)
+    assert "seniority_level" in jp_section, (
+        "seniority_level is missing from the job_postings column list in _SCHEMA_HINT."
+    )
+
+
+def test_schema_hint_contains_is_remote_for_job_postings() -> None:
+    """is_remote must appear in the job_postings column list after #170."""
+    jp_section = _extract_job_postings_line(_SCHEMA_HINT)
+    assert "is_remote" in jp_section, (
+        "is_remote is missing from the job_postings column list in _SCHEMA_HINT."
+    )
+
+
+def test_schema_hint_critical_block_no_longer_warns_date_posted_missing() -> None:
+    """After #171, the CRITICAL block must NOT claim date_posted is absent from job_postings."""
+    assert "has NO date_posted column" not in _SCHEMA_HINT, (
+        "The CRITICAL block still says 'has NO date_posted column'. "
+        "This warning must be removed after #170 added the column."
+    )
+
+
+@pytest.mark.parametrize("col", sorted(DEPRECATED_COLUMNS))
+def test_schema_hint_does_not_list_deprecated_column_in_job_postings(col: str) -> None:
+    """No deprecated column should appear in the job_postings column declaration."""
+    jp_section = _extract_job_postings_line(_SCHEMA_HINT)
+    assert col not in jp_section, (
+        f"Deprecated column {col!r} appears in the job_postings section of _SCHEMA_HINT. "
+        "Remove it to prevent hallucinated SQL."
+    )
+
+
+def test_schema_hint_all_known_job_postings_columns_present() -> None:
+    """Every column in JOB_POSTINGS_KNOWN_COLUMNS must appear in _SCHEMA_HINT."""
+    jp_section = _extract_job_postings_line(_SCHEMA_HINT)
+    missing = [c for c in sorted(JOB_POSTINGS_KNOWN_COLUMNS) if c not in jp_section]
+    assert not missing, (
+        f"These known job_postings columns are missing from _SCHEMA_HINT: {missing}. "
+        "Update _SCHEMA_HINT to reflect the current schema."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mocked LLM SQL generation — column validation
+# ---------------------------------------------------------------------------
+
+
+def _extract_column_names(sql: str) -> list[str]:
+    """Best-effort extraction of bare column identifiers from a SELECT clause."""
+    # Strip WITH ... AS (...) CTEs for simplicity
+    sql_upper = sql.upper()
+    select_pos = sql_upper.find("SELECT")
+    from_pos = sql_upper.find("FROM", select_pos)
+    if select_pos == -1 or from_pos == -1:
+        return []
+    select_clause = sql[select_pos + 6 : from_pos]
+    # Extract word-like tokens that look like column names (no dots, no parens)
+    tokens = re.findall(r"\b([a-z_][a-z0-9_]*)\b", select_clause.lower())
+    # Filter out SQL keywords and aggregate function names
+    sql_keywords = {
+        "as",
+        "distinct",
+        "count",
+        "sum",
+        "avg",
+        "min",
+        "max",
+        "case",
+        "when",
+        "then",
+        "else",
+        "end",
+        "and",
+        "or",
+        "not",
+        "null",
+        "true",
+        "false",
+        "desc",
+        "asc",
+        "limit",
+        "offset",
+    }
+    return [t for t in tokens if t not in sql_keywords]
+
+
+@pytest.mark.parametrize(
+    ("question", "mock_sql"),
+    [
+        (
+            "What are the most recent job postings?",
+            "SELECT job_posting_id, job_title, date_posted FROM dbo.job_postings "
+            "ORDER BY date_posted DESC LIMIT 10",
+        ),
+        (
+            "Show me senior roles posted this month",
+            "SELECT job_posting_id, job_title, seniority_level, date_posted "
+            "FROM dbo.job_postings WHERE seniority_level = 'senior' LIMIT 20",
+        ),
+        (
+            "How many remote jobs were posted in Texas?",
+            "SELECT COUNT(*) AS remote_count FROM dbo.job_postings "
+            "WHERE is_remote = TRUE AND location ILIKE '%Texas%'",
+        ),
+    ],
+)
+def test_mock_llm_sql_references_valid_job_postings_columns(question: str, mock_sql: str) -> None:
+    """SQL referencing promoted columns must pass guardrail validation."""
+    from analytics.query_engine.sql_guardrails import validate_ask_the_data_sql
+
+    ok, reason, normalized = validate_ask_the_data_sql(mock_sql)
+    assert ok, (
+        f"SQL for question {question!r} was rejected by guardrail. "
+        f"Reason: {reason!r}. SQL: {mock_sql!r}"
+    )
+
+    col_names = _extract_column_names(mock_sql)
+    unknown = [
+        c for c in col_names if c not in JOB_POSTINGS_KNOWN_COLUMNS and c not in {"remote_count"}
+    ]
+    assert not unknown, (
+        f"SQL for {question!r} references unknown job_postings columns: {unknown}. "
+        f"Add them to JOB_POSTINGS_KNOWN_COLUMNS or remove from SQL."
+    )
+
+
+def test_schema_hint_does_not_list_posted_date_in_job_postings_declaration() -> None:
+    """posted_date (never a real column) must not appear in the job_postings column declaration.
+
+    It may appear in the CRITICAL block as a negative example — that is correct. This
+    test checks only the positive column list section.
+    """
+    jp_section = _extract_job_postings_line(_SCHEMA_HINT)
+    assert "posted_date" not in jp_section, (
+        "posted_date appears in the job_postings column declaration in _SCHEMA_HINT. "
+        "This column never existed; remove it from the positive column list."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_job_postings_line(hint: str) -> str:
+    """Return the multi-line block that declares job_postings columns."""
+    lines = hint.splitlines()
+    inside = False
+    block: list[str] = []
+    for line in lines:
+        if "job_postings(" in line:
+            inside = True
+        if inside:
+            block.append(line)
+            if line.strip().endswith(")"):
+                break
+    return " ".join(block)

--- a/analytics/query_engine/tests/test_schema_hint_columns.py
+++ b/analytics/query_engine/tests/test_schema_hint_columns.py
@@ -42,6 +42,13 @@ JOB_POSTINGS_KNOWN_COLUMNS = frozenset(
         "date_posted",
         "seniority_level",
         "is_remote",
+        # Week 8 (#173) role_classification promotion
+        "role_classification",
+        # Week 8 (#174) structured salary promotions
+        "salary_min",
+        "salary_max",
+        "salary_currency",
+        "salary_period",
         # Enrichment columns
         "borderplex_subregion",
         "temporal_period",
@@ -99,6 +106,26 @@ def test_schema_hint_contains_is_remote_for_job_postings() -> None:
     jp_section = _extract_job_postings_line(_SCHEMA_HINT)
     assert "is_remote" in jp_section, (
         "is_remote is missing from the job_postings column list in _SCHEMA_HINT."
+    )
+
+
+def test_schema_hint_contains_role_classification_for_job_postings() -> None:
+    """role_classification must appear in the job_postings column list after #173."""
+    jp_section = _extract_job_postings_line(_SCHEMA_HINT)
+    assert "role_classification" in jp_section, (
+        "role_classification is missing from the job_postings column list in _SCHEMA_HINT. "
+        "This column was promoted by #173 and must be listed so the LLM can group/filter by role."
+    )
+
+
+@pytest.mark.parametrize("col", ["salary_min", "salary_max", "salary_currency", "salary_period"])
+def test_schema_hint_contains_structured_salary_column(col: str) -> None:
+    """Structured salary columns must appear in the job_postings column list after #174."""
+    jp_section = _extract_job_postings_line(_SCHEMA_HINT)
+    assert col in jp_section, (
+        f"{col} is missing from the job_postings column list in _SCHEMA_HINT. "
+        "This column was promoted by #174 and must be listed so the LLM can compute "
+        "salary aggregations without text-parsing salary_range."
     )
 
 
@@ -192,6 +219,25 @@ def _extract_column_names(sql: str) -> list[str]:
             "SELECT COUNT(*) AS remote_count FROM dbo.job_postings "
             "WHERE is_remote = TRUE AND location ILIKE '%Texas%'",
         ),
+        (
+            "How many software engineering postings does each role have? (#173 role_classification)",
+            "SELECT role_classification, COUNT(*) AS posting_count FROM dbo.job_postings "
+            "WHERE role_classification IS NOT NULL GROUP BY role_classification "
+            "ORDER BY posting_count DESC LIMIT 20",
+        ),
+        (
+            "What is the average annual salary in USD across data engineering roles? (#174 structured salary)",
+            "SELECT AVG(salary_max) AS avg_salary_max, COUNT(*) AS posting_count "
+            "FROM dbo.job_postings "
+            "WHERE salary_currency = 'USD' AND salary_period = 'annual' "
+            "AND role_classification ILIKE '%data engineer%' AND salary_max IS NOT NULL",
+        ),
+        (
+            "What is the salary range floor for senior remote roles? (#173 + #174 combined)",
+            "SELECT seniority_level, AVG(salary_min) AS avg_floor FROM dbo.job_postings "
+            "WHERE seniority_level = 'senior' AND is_remote = TRUE "
+            "AND salary_min IS NOT NULL GROUP BY seniority_level",
+        ),
     ],
 )
 def test_mock_llm_sql_references_valid_job_postings_columns(question: str, mock_sql: str) -> None:
@@ -206,7 +252,8 @@ def test_mock_llm_sql_references_valid_job_postings_columns(question: str, mock_
 
     col_names = _extract_column_names(mock_sql)
     unknown = [
-        c for c in col_names if c not in JOB_POSTINGS_KNOWN_COLUMNS and c not in {"remote_count"}
+        c for c in col_names if c not in JOB_POSTINGS_KNOWN_COLUMNS
+        and c not in {"remote_count", "posting_count", "avg_salary_max", "avg_floor"}
     ]
     assert not unknown, (
         f"SQL for {question!r} references unknown job_postings columns: {unknown}. "

--- a/common/data_store/migrations.py
+++ b/common/data_store/migrations.py
@@ -139,6 +139,15 @@ _JOB_POSTINGS_ALTER_STATEMENTS = [
     "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS date_posted TIMESTAMPTZ",
     "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS seniority_level TEXT",
     "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS is_remote BOOLEAN",
+    # Week 8 (#173) — role_classification promoted from RecordEnriched event payload
+    # (computed by classify_job() during enrichment; previously only used for sector_id resolution).
+    "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS role_classification TEXT",
+    # Week 8 (#174) — structured salary columns promoted from normalized_jobs.
+    # Keep salary_range TEXT for backward compat; prefer structured columns for analytics.
+    "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS salary_min NUMERIC",
+    "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS salary_max NUMERIC",
+    "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS salary_currency TEXT",
+    "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS salary_period TEXT",
 ]
 
 # Optional FK after ``canonical_roles`` exists (create_all + alters). Idempotent via try/except.
@@ -307,6 +316,8 @@ _QNA_RETRIEVAL_INDEX_STATEMENTS = [
     "ON dbo.job_postings (employer_profile_id)",
     "CREATE INDEX IF NOT EXISTS ix_job_postings_seniority "
     "ON dbo.job_postings (seniority_level)",
+    "CREATE INDEX IF NOT EXISTS ix_job_postings_role_classification "
+    "ON dbo.job_postings (role_classification)",
     "CREATE INDEX IF NOT EXISTS ix_job_postings_source_external "
     "ON dbo.job_postings (source, external_id)",
     # NOTE: ix_extracted_intelligence_src_ext was removed — extracted_intelligence has

--- a/common/data_store/migrations.py
+++ b/common/data_store/migrations.py
@@ -134,6 +134,11 @@ _JOB_POSTINGS_ALTER_STATEMENTS = [
     "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS employer_profile_id UUID REFERENCES dbo.employer_profiles(id)",
     # Week 7 — canonical role clustering (Pair C): posting → discovered role
     "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS canonical_role_id TEXT",
+    # Week 8 (#170) — Q&A-ready fields: date_posted promoted from normalized_jobs,
+    # seniority_level + is_remote promoted from RecordEnriched event payload.
+    "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS date_posted TIMESTAMPTZ",
+    "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS seniority_level TEXT",
+    "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS is_remote BOOLEAN",
 ]
 
 # Optional FK after ``canonical_roles`` exists (create_all + alters). Idempotent via try/except.
@@ -150,6 +155,13 @@ _JOB_POSTINGS_LEGACY_CLEANUP = [
     "ALTER TABLE dbo.job_postings DROP CONSTRAINT IF EXISTS fk_job_postings_company_addresses1",
     # Drop FK to companies — pipeline resolves company_id via _resolve_or_create_company
     "ALTER TABLE dbo.job_postings DROP CONSTRAINT IF EXISTS fk_job_postings_companies1",
+    # Drop FK to employers / technology_areas — columns are 99–100% NULL; indexes are dead weight.
+    # #170 deprecation: employer_id and tech_area_id are never written by the pipeline.
+    "ALTER TABLE dbo.job_postings DROP CONSTRAINT IF EXISTS fk_job_postings_employers1",
+    "ALTER TABLE dbo.job_postings DROP CONSTRAINT IF EXISTS fk_job_postings_technology_areas1",
+    "DROP INDEX IF EXISTS dbo.fk_job_postings_employers1_idx",
+    "DROP INDEX IF EXISTS dbo.fk_job_postings_technology_areas1_idx",
+    "DROP INDEX IF EXISTS dbo.fk_job_postings_company_addresses1_idx",
     # Make legacy NOT NULL columns nullable
     "ALTER TABLE dbo.job_postings ALTER COLUMN location_id DROP NOT NULL",
     "ALTER TABLE dbo.job_postings ALTER COLUMN county DROP NOT NULL",
@@ -280,6 +292,27 @@ _SKILL_DEMAND_WEEKLY_ALTER_STATEMENTS = [
 _JOB_INGESTION_RUNS_ALTER_STATEMENTS = [
     "ALTER TABLE dbo.job_ingestion_runs ADD COLUMN IF NOT EXISTS api_requests_used INTEGER NOT NULL DEFAULT 0",
 ]
+# Week 8 (#176) — Q&A retrieval indexes on job_postings and extracted_intelligence.
+# All statements are idempotent (CREATE INDEX IF NOT EXISTS).
+# Must be applied AFTER the #170 ADD COLUMN statements so date_posted and
+# seniority_level exist on job_postings before the index is created.
+_QNA_RETRIEVAL_INDEX_STATEMENTS = [
+    "CREATE INDEX IF NOT EXISTS ix_job_postings_created_at "
+    "ON dbo.job_postings (createdat DESC)",
+    "CREATE INDEX IF NOT EXISTS ix_job_postings_date_posted "
+    "ON dbo.job_postings (date_posted DESC)",
+    "CREATE INDEX IF NOT EXISTS ix_job_postings_canonical_role "
+    "ON dbo.job_postings (canonical_role_id)",
+    "CREATE INDEX IF NOT EXISTS ix_job_postings_employer_profile "
+    "ON dbo.job_postings (employer_profile_id)",
+    "CREATE INDEX IF NOT EXISTS ix_job_postings_seniority "
+    "ON dbo.job_postings (seniority_level)",
+    "CREATE INDEX IF NOT EXISTS ix_job_postings_source_external "
+    "ON dbo.job_postings (source, external_id)",
+    "CREATE INDEX IF NOT EXISTS ix_extracted_intelligence_src_ext "
+    "ON dbo.extracted_intelligence (source, external_id)",
+]
+
 _SERIAL_SEQUENCE_TARGETS = (
     ("raw_ingested_jobs", "id"),
     ("job_ingestion_runs", "id"),
@@ -669,5 +702,20 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_cohort_gap_cache_cohort_key
                 statement=stmt,
                 error=str(exc),
             )
+
+    # Week 8 (#176) — Q&A retrieval indexes on job_postings and extracted_intelligence.
+    # Must run AFTER #170 ADD COLUMN statements so date_posted/seniority_level exist.
+    if engine.dialect.name == "postgresql":
+        for stmt in _QNA_RETRIEVAL_INDEX_STATEMENTS:
+            try:
+                with engine.begin() as conn:
+                    conn.execute(text(stmt))
+            except Exception as exc:
+                log.warning(
+                    "migration_qna_retrieval_index_skipped",
+                    statement=stmt,
+                    error=str(exc),
+                )
+        log.info("migrations_qna_retrieval_indexes_applied")
 
     log.info("migrations_complete")

--- a/common/data_store/migrations.py
+++ b/common/data_store/migrations.py
@@ -309,8 +309,9 @@ _QNA_RETRIEVAL_INDEX_STATEMENTS = [
     "ON dbo.job_postings (seniority_level)",
     "CREATE INDEX IF NOT EXISTS ix_job_postings_source_external "
     "ON dbo.job_postings (source, external_id)",
-    "CREATE INDEX IF NOT EXISTS ix_extracted_intelligence_src_ext "
-    "ON dbo.extracted_intelligence (source, external_id)",
+    # NOTE: ix_extracted_intelligence_src_ext was removed — extracted_intelligence has
+    # no source/external_id columns (it links via normalized_job_id FK). The join path
+    # is already covered by ix_normalized_jobs_source_eid on dbo.normalized_jobs.
 ]
 
 _SERIAL_SEQUENCE_TARGETS = (

--- a/common/data_store/models.py
+++ b/common/data_store/models.py
@@ -20,6 +20,9 @@ job_postings agent-added columns (via run_migrations ALTER TABLE; not in Prisma 
             is_duplicate, duplicate_cluster_id, dedup_text_hash, dedup_embedding,
             zip_code, employer_profile_id, canonical_role_id
   Week 8 (#170, Q&A-ready):  date_posted, seniority_level, is_remote
+  Week 8 (#173): role_classification (computed by classify_job() during enrichment)
+  Week 8 (#174, structured salary): salary_min, salary_max, salary_currency, salary_period
+                                    (legacy salary_range TEXT remains for backward compat)
   Deprecated (never write): employer_id, tech_area_id, location_id
     → FK constraints fk_job_postings_employers1, fk_job_postings_technology_areas1,
       fk_job_postings_company_addresses1 and their backing indexes are dropped by

--- a/common/data_store/models.py
+++ b/common/data_store/models.py
@@ -12,6 +12,18 @@ Agent-created tables: raw_ingested_jobs, job_ingestion_runs, normalized_jobs,
     cohort_gap_cache, orchestration_audit_log.
 Reference tables (seeded, agent-owned): companies, industry_sectors,
     technology_areas, skills, socc, naics, job_postings.
+
+job_postings agent-added columns (via run_migrations ALTER TABLE; not in Prisma schema):
+  Phase 1:  source, external_id, ingestion_run_id, ai_relevance_score, quality_score,
+            is_spam, spam_score, spam_tier, overall_confidence, field_confidence
+  Phase 1b: soc_code, naics_code, temporal_period, borderplex_subregion,
+            is_duplicate, duplicate_cluster_id, dedup_text_hash, dedup_embedding,
+            zip_code, employer_profile_id, canonical_role_id
+  Week 8 (#170, Q&A-ready):  date_posted, seniority_level, is_remote
+  Deprecated (never write): employer_id, tech_area_id, location_id
+    → FK constraints fk_job_postings_employers1, fk_job_postings_technology_areas1,
+      fk_job_postings_company_addresses1 and their backing indexes are dropped by
+      run_migrations. Columns remain NULL; do not reference in new SQL.
 """
 
 from __future__ import annotations

--- a/enrichment/job_postings_promotion.py
+++ b/enrichment/job_postings_promotion.py
@@ -77,7 +77,10 @@ _UPDATE_UNCERTAIN_SQL = text(
         naics_code = :naics_code,
         soc_code = :soc_code,
         sector_id = :sector_id,
-        employer_profile_id = COALESCE(CAST(:employer_profile_id AS uuid), employer_profile_id)
+        employer_profile_id = COALESCE(CAST(:employer_profile_id AS uuid), employer_profile_id),
+        date_posted = COALESCE(:date_posted, date_posted),
+        seniority_level = COALESCE(:seniority_level, seniority_level),
+        is_remote = COALESCE(:is_remote, is_remote)
     WHERE job_posting_id::text = :job_posting_id
     """
 )
@@ -95,7 +98,10 @@ _UPDATE_CLEAN_SQL = text(
         sector_id = :sector_id,
         employer_profile_id = COALESCE(CAST(:employer_profile_id AS uuid), employer_profile_id),
         is_spam = FALSE,
-        spam_score = :spam_score
+        spam_score = :spam_score,
+        date_posted = COALESCE(:date_posted, date_posted),
+        seniority_level = COALESCE(:seniority_level, seniority_level),
+        is_remote = COALESCE(:is_remote, is_remote)
     WHERE job_posting_id::text = :job_posting_id
     """
 )
@@ -113,7 +119,10 @@ _UPDATE_FLAGGED_SQL = text(
         sector_id = :sector_id,
         employer_profile_id = COALESCE(CAST(:employer_profile_id AS uuid), employer_profile_id),
         is_spam = NULL,
-        spam_score = :spam_score
+        spam_score = :spam_score,
+        date_posted = COALESCE(:date_posted, date_posted),
+        seniority_level = COALESCE(:seniority_level, seniority_level),
+        is_remote = COALESCE(:is_remote, is_remote)
     WHERE job_posting_id::text = :job_posting_id
     """
 )
@@ -576,6 +585,19 @@ def apply_enrichment_to_job_postings(
     role_classification = record_enriched_payload.get("role_classification")
     sector_id = resolve_sector(role_classification, session)
 
+    # seniority_level: prefer explicit "seniority_level" key; fall back to "seniority"
+    # (RecordEnriched single-record contract uses "seniority"; "seniority_level" is
+    # the canonical DB column name added in #170).
+    raw_seniority = record_enriched_payload.get("seniority_level") or record_enriched_payload.get("seniority")
+    seniority_level_param: str | None = raw_seniority.strip() if isinstance(raw_seniority, str) and raw_seniority.strip() else None
+
+    # date_posted and is_remote come from normalized_jobs (already in resolved dict)
+    date_posted_param = resolved.get("date_posted") if resolved else None
+    is_remote_param = resolved.get("is_remote") if resolved else None
+    # Coerce is_remote to Python bool or None (guard against DB-returned int-like values)
+    if is_remote_param is not None:
+        is_remote_param = bool(is_remote_param)
+
     employer_profile_id_param = None
     em = record_enriched_payload.get("employer_metadata")
     if isinstance(em, dict) and str(company_id).strip():
@@ -595,6 +617,9 @@ def apply_enrichment_to_job_postings(
         "soc_code": soc_code,
         "sector_id": sector_id,
         "employer_profile_id": employer_profile_id_param,
+        "date_posted": date_posted_param,
+        "seniority_level": seniority_level_param,
+        "is_remote": is_remote_param,
         **derived_output_fields,
     }
 

--- a/enrichment/job_postings_promotion.py
+++ b/enrichment/job_postings_promotion.py
@@ -80,7 +80,12 @@ _UPDATE_UNCERTAIN_SQL = text(
         employer_profile_id = COALESCE(CAST(:employer_profile_id AS uuid), employer_profile_id),
         date_posted = COALESCE(:date_posted, date_posted),
         seniority_level = COALESCE(:seniority_level, seniority_level),
-        is_remote = COALESCE(:is_remote, is_remote)
+        is_remote = COALESCE(:is_remote, is_remote),
+        role_classification = COALESCE(:role_classification, role_classification),
+        salary_min = COALESCE(:salary_min, salary_min),
+        salary_max = COALESCE(:salary_max, salary_max),
+        salary_currency = COALESCE(:salary_currency, salary_currency),
+        salary_period = COALESCE(:salary_period, salary_period)
     WHERE job_posting_id::text = :job_posting_id
     """
 )
@@ -101,7 +106,12 @@ _UPDATE_CLEAN_SQL = text(
         spam_score = :spam_score,
         date_posted = COALESCE(:date_posted, date_posted),
         seniority_level = COALESCE(:seniority_level, seniority_level),
-        is_remote = COALESCE(:is_remote, is_remote)
+        is_remote = COALESCE(:is_remote, is_remote),
+        role_classification = COALESCE(:role_classification, role_classification),
+        salary_min = COALESCE(:salary_min, salary_min),
+        salary_max = COALESCE(:salary_max, salary_max),
+        salary_currency = COALESCE(:salary_currency, salary_currency),
+        salary_period = COALESCE(:salary_period, salary_period)
     WHERE job_posting_id::text = :job_posting_id
     """
 )
@@ -122,7 +132,12 @@ _UPDATE_FLAGGED_SQL = text(
         spam_score = :spam_score,
         date_posted = COALESCE(:date_posted, date_posted),
         seniority_level = COALESCE(:seniority_level, seniority_level),
-        is_remote = COALESCE(:is_remote, is_remote)
+        is_remote = COALESCE(:is_remote, is_remote),
+        role_classification = COALESCE(:role_classification, role_classification),
+        salary_min = COALESCE(:salary_min, salary_min),
+        salary_max = COALESCE(:salary_max, salary_max),
+        salary_currency = COALESCE(:salary_currency, salary_currency),
+        salary_period = COALESCE(:salary_period, salary_period)
     WHERE job_posting_id::text = :job_posting_id
     """
 )
@@ -585,6 +600,13 @@ def apply_enrichment_to_job_postings(
     role_classification = record_enriched_payload.get("role_classification")
     sector_id = resolve_sector(role_classification, session)
 
+    # role_classification (#173): also persist directly to job_postings (above only feeds resolve_sector).
+    role_classification_param: str | None = (
+        role_classification.strip()
+        if isinstance(role_classification, str) and role_classification.strip()
+        else None
+    )
+
     # seniority_level: prefer explicit "seniority_level" key; fall back to "seniority"
     # (RecordEnriched single-record contract uses "seniority"; "seniority_level" is
     # the canonical DB column name added in #170).
@@ -597,6 +619,23 @@ def apply_enrichment_to_job_postings(
     # Coerce is_remote to Python bool or None (guard against DB-returned int-like values)
     if is_remote_param is not None:
         is_remote_param = bool(is_remote_param)
+
+    # Structured salary (#174): pulled from normalized_jobs (already in resolved dict).
+    # legacy salary_range TEXT is kept for backward compat; structured columns are preferred for analytics.
+    salary_min_param = resolved.get("salary_min") if resolved else None
+    salary_max_param = resolved.get("salary_max") if resolved else None
+    salary_currency_raw = resolved.get("salary_currency") if resolved else None
+    salary_currency_param: str | None = (
+        salary_currency_raw.strip()
+        if isinstance(salary_currency_raw, str) and salary_currency_raw.strip()
+        else None
+    )
+    salary_period_raw = resolved.get("salary_period") if resolved else None
+    salary_period_param: str | None = (
+        salary_period_raw.strip()
+        if isinstance(salary_period_raw, str) and salary_period_raw.strip()
+        else None
+    )
 
     employer_profile_id_param = None
     em = record_enriched_payload.get("employer_metadata")
@@ -620,6 +659,11 @@ def apply_enrichment_to_job_postings(
         "date_posted": date_posted_param,
         "seniority_level": seniority_level_param,
         "is_remote": is_remote_param,
+        "role_classification": role_classification_param,
+        "salary_min": salary_min_param,
+        "salary_max": salary_max_param,
+        "salary_currency": salary_currency_param,
+        "salary_period": salary_period_param,
         **derived_output_fields,
     }
 

--- a/enrichment/tests/test_job_postings_promotion.py
+++ b/enrichment/tests/test_job_postings_promotion.py
@@ -617,12 +617,20 @@ def _resolved_row_with_qna_fields(
     *,
     date_posted: object = None,
     is_remote: object = None,
+    salary_min: object = None,
+    salary_max: object = None,
+    salary_currency: object = None,
+    salary_period: object = None,
 ) -> dict[str, object]:
     return {
         "job_posting_id": "11111111-1111-1111-1111-111111111111",
         "company_id": "22222222-2222-2222-2222-222222222222",
         "date_posted": date_posted,
         "is_remote": is_remote,
+        "salary_min": salary_min,
+        "salary_max": salary_max,
+        "salary_currency": salary_currency,
+        "salary_period": salary_period,
     }
 
 
@@ -793,3 +801,122 @@ def test_apply_enrichment_qna_fields_present_for_all_tiers(tier: str, spam_score
     assert params["date_posted"] == posted_at, f"date_posted wrong for tier={tier!r}"
     assert params["seniority_level"] == "Entry-level", f"seniority_level wrong for tier={tier!r}"
     assert params["is_remote"] is True, f"is_remote wrong for tier={tier!r}"
+
+
+# ---------------------------------------------------------------------------
+# Field-level coverage for #173 (role_classification) and #174 (structured salary)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_enrichment_binds_role_classification_from_payload() -> None:
+    """role_classification from RecordEnriched payload must be bound in UPDATE params."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(),
+        {"role_classification": "Software Engineer"},
+    )
+    assert params["role_classification"] == "Software Engineer"
+
+
+def test_apply_enrichment_binds_role_classification_none_when_absent() -> None:
+    """role_classification must be None (not absent) when no key in the payload."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(),
+        {},
+    )
+    assert "role_classification" in params
+    assert params["role_classification"] is None
+
+
+def test_apply_enrichment_binds_role_classification_strips_whitespace() -> None:
+    """Whitespace-only role_classification values must be treated as None."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(),
+        {"role_classification": "   "},
+    )
+    assert params["role_classification"] is None
+
+
+def test_apply_enrichment_binds_salary_min_from_resolved_row() -> None:
+    """salary_min from normalized_jobs resolved row must be bound in UPDATE params."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(salary_min=85000.0),
+        {},
+    )
+    assert params["salary_min"] == 85000.0
+
+
+def test_apply_enrichment_binds_salary_max_from_resolved_row() -> None:
+    """salary_max from normalized_jobs resolved row must be bound in UPDATE params."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(salary_max=145000.0),
+        {},
+    )
+    assert params["salary_max"] == 145000.0
+
+
+def test_apply_enrichment_binds_salary_currency_from_resolved_row() -> None:
+    """salary_currency from normalized_jobs resolved row must be bound in UPDATE params."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(salary_currency="USD"),
+        {},
+    )
+    assert params["salary_currency"] == "USD"
+
+
+def test_apply_enrichment_binds_salary_period_from_resolved_row() -> None:
+    """salary_period from normalized_jobs resolved row must be bound in UPDATE params."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(salary_period="annual"),
+        {},
+    )
+    assert params["salary_period"] == "annual"
+
+
+def test_apply_enrichment_binds_salary_columns_none_when_missing() -> None:
+    """All 4 structured salary params must be None (not absent) when the resolved row has nulls."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(),
+        {},
+    )
+    for key in ("salary_min", "salary_max", "salary_currency", "salary_period"):
+        assert key in params
+        assert params[key] is None, f"{key} must be None when missing from resolved row"
+
+
+def test_apply_enrichment_binds_salary_currency_strips_whitespace() -> None:
+    """Whitespace-only salary_currency must be treated as None."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(salary_currency="  "),
+        {},
+    )
+    assert params["salary_currency"] is None
+
+
+def test_apply_enrichment_binds_salary_period_strips_whitespace() -> None:
+    """Whitespace-only salary_period must be treated as None."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(salary_period="   "),
+        {},
+    )
+    assert params["salary_period"] is None
+

--- a/enrichment/tests/test_job_postings_promotion.py
+++ b/enrichment/tests/test_job_postings_promotion.py
@@ -606,3 +606,190 @@ def test_apply_enrichment_sector_id_is_in_params_base_for_all_tiers() -> None:
         assert out is True, f"Expected True for tier={tier}"
         _stmt, params = session.execute.call_args_list[1][0]
         assert params.get("sector_id") == sector_uuid, f"sector_id missing or wrong for tier={tier}"
+
+
+# ---------------------------------------------------------------------------
+# Week 8 (#170) — promoted Q&A-ready fields: date_posted, seniority_level, is_remote
+# ---------------------------------------------------------------------------
+
+
+def _resolved_row_with_qna_fields(
+    *,
+    date_posted: object = None,
+    is_remote: object = None,
+) -> dict[str, object]:
+    return {
+        "job_posting_id": "11111111-1111-1111-1111-111111111111",
+        "company_id": "22222222-2222-2222-2222-222222222222",
+        "date_posted": date_posted,
+        "is_remote": is_remote,
+    }
+
+
+def _apply_with_qna_payload(session: MagicMock, resolved_row: dict, payload_overrides: dict) -> dict:
+    """Run apply_enrichment_to_job_postings; return the UPDATE params dict."""
+    resolve_result = MagicMock()
+    resolve_result.mappings.return_value.first.return_value = resolved_row
+    update_result = MagicMock()
+    session.execute.side_effect = [resolve_result, update_result]
+
+    payload: dict[str, object] = {
+        "spam_tier": "clean",
+        "spam_score": 0.2,
+        "quality_score": 0.85,
+        **payload_overrides,
+    }
+    with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
+        out = apply_enrichment_to_job_postings(session, 42, payload)
+
+    assert out is True
+    _stmt, params = session.execute.call_args_list[1][0]
+    return params
+
+
+def test_apply_enrichment_binds_date_posted_from_resolved_row() -> None:
+    """date_posted from normalized_jobs resolved row must be bound in the UPDATE params."""
+    posted_at = datetime(2024, 3, 15, 9, 0, 0, tzinfo=timezone.utc)
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(date_posted=posted_at),
+        {},
+    )
+    assert params["date_posted"] == posted_at
+
+
+def test_apply_enrichment_binds_date_posted_none_when_missing_from_resolved_row() -> None:
+    """date_posted must be None (not absent) when the resolved row has no date."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(date_posted=None),
+        {},
+    )
+    assert "date_posted" in params
+    assert params["date_posted"] is None
+
+
+def test_apply_enrichment_binds_seniority_level_from_seniority_key() -> None:
+    """seniority_level param must be populated from the 'seniority' payload key (RecordEnriched contract)."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(),
+        {"seniority": "Senior"},
+    )
+    assert params["seniority_level"] == "Senior"
+
+
+def test_apply_enrichment_binds_seniority_level_from_seniority_level_key() -> None:
+    """'seniority_level' key takes precedence over 'seniority' when both are present."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(),
+        {"seniority": "Mid-level", "seniority_level": "Senior"},
+    )
+    assert params["seniority_level"] == "Senior"
+
+
+def test_apply_enrichment_binds_seniority_level_none_when_absent() -> None:
+    """seniority_level param must be None when no seniority key appears in the payload."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(),
+        {},
+    )
+    assert "seniority_level" in params
+    assert params["seniority_level"] is None
+
+
+def test_apply_enrichment_binds_seniority_level_strips_whitespace() -> None:
+    """Whitespace-only seniority values must be treated as None, not stored."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(),
+        {"seniority": "   "},
+    )
+    assert params["seniority_level"] is None
+
+
+def test_apply_enrichment_binds_is_remote_true_from_resolved_row() -> None:
+    """is_remote=True in the resolved row must be bound as Python True in UPDATE params."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(is_remote=True),
+        {},
+    )
+    assert params["is_remote"] is True
+
+
+def test_apply_enrichment_binds_is_remote_false_from_resolved_row() -> None:
+    """is_remote=False in the resolved row must be bound as Python False in UPDATE params."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(is_remote=False),
+        {},
+    )
+    assert params["is_remote"] is False
+
+
+def test_apply_enrichment_binds_is_remote_none_when_missing() -> None:
+    """is_remote must be None (not absent) when the resolved row has no value."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(is_remote=None),
+        {},
+    )
+    assert "is_remote" in params
+    assert params["is_remote"] is None
+
+
+def test_apply_enrichment_coerces_is_remote_int_to_bool() -> None:
+    """DB-returned integer truthy values (e.g. 1) must be coerced to Python bool."""
+    session = MagicMock()
+    params = _apply_with_qna_payload(
+        session,
+        _resolved_row_with_qna_fields(is_remote=1),
+        {},
+    )
+    assert params["is_remote"] is True
+    assert isinstance(params["is_remote"], bool)
+
+
+@pytest.mark.parametrize("tier,spam_score", [("clean", 0.2), ("flagged", 0.75), ("uncertain", None)])
+def test_apply_enrichment_qna_fields_present_for_all_tiers(tier: str, spam_score: float | None) -> None:
+    """date_posted, seniority_level, and is_remote must be bound for every spam tier."""
+    posted_at = datetime(2024, 1, 10, 0, 0, 0, tzinfo=timezone.utc)
+    session = MagicMock()
+    resolve_result = MagicMock()
+    resolve_result.mappings.return_value.first.return_value = {
+        "job_posting_id": "11111111-1111-1111-1111-111111111111",
+        "company_id": "22222222-2222-2222-2222-222222222222",
+        "date_posted": posted_at,
+        "is_remote": True,
+    }
+    update_result = MagicMock()
+    session.execute.side_effect = [resolve_result, update_result]
+
+    payload: dict[str, object] = {
+        "spam_tier": tier,
+        "quality_score": 0.85,
+        "seniority": "Entry-level",
+    }
+    if spam_score is not None:
+        payload["spam_score"] = spam_score
+
+    with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
+        out = apply_enrichment_to_job_postings(session, 42, payload)
+
+    assert out is True, f"Expected True for tier={tier!r}"
+    _stmt, params = session.execute.call_args_list[1][0]
+    assert params["date_posted"] == posted_at, f"date_posted wrong for tier={tier!r}"
+    assert params["seniority_level"] == "Entry-level", f"seniority_level wrong for tier={tier!r}"
+    assert params["is_remote"] is True, f"is_remote wrong for tier={tier!r}"

--- a/scripts/backfill_qna_columns.py
+++ b/scripts/backfill_qna_columns.py
@@ -1,0 +1,534 @@
+"""Deterministic backfill for Week 8 Q&A-ready columns on dbo.job_postings.
+
+Closes the data half of issues #172, #173, #174 (PR #195 added the schema/promotion
+half — this script populates existing rows without re-running enrichment).
+
+What this script does
+---------------------
+For every row in ``dbo.job_postings`` where the target column is NULL, it fills
+the value from a deterministic source — no LLM calls, no enrichment re-run.
+
+| Column                | Source                                                      |
+|-----------------------|-------------------------------------------------------------|
+| date_posted           | normalized_jobs.date_posted (typed timestamptz)             |
+| is_remote             | normalized_jobs.is_remote                                   |
+| salary_min            | normalized_jobs.salary_min                                  |
+| salary_max            | normalized_jobs.salary_max                                  |
+| salary_currency       | normalized_jobs.salary_currency                             |
+| salary_period         | normalized_jobs.salary_period                               |
+| seniority_level       | (a) normalized_jobs.experience_level mapped to closed set;  |
+|                       | (b) classify_seniority() regex fallback over title +        |
+|                       |     description + extracted_intelligence tasks/responsibil. |
+| role_classification   | classify_role() over title + corpus, against DB-seeded      |
+|                       | technology_areas + industry_sectors                         |
+
+All operations are idempotent: only rows where the target column IS NULL are touched.
+
+Safety
+------
+- Read-only against ``raw_ingested_jobs``, ``normalized_jobs``,
+  ``extracted_intelligence``, ``technology_areas``, ``industry_sectors``.
+- Writes only to ``dbo.job_postings`` and only via UPDATE (never DELETE / TRUNCATE).
+- Per-pair audit tables (raw_ingested_jobs, llm_audit_log, etc.) are never modified.
+
+Usage
+-----
+::
+
+    # Preview what would change (no writes)
+    python scripts/backfill_qna_columns.py --dry-run
+
+    # Backfill all 8 columns
+    python scripts/backfill_qna_columns.py
+
+    # Backfill only specific columns (comma-separated)
+    python scripts/backfill_qna_columns.py --columns date_posted,is_remote
+
+    # Limit batch size for the per-row passes (default 500)
+    python scripts/backfill_qna_columns.py --batch-size 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from common.data_store.database import get_engine
+from enrichment.classification import (
+    build_job_corpus,
+    classify_role,
+    classify_seniority,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+log = logging.getLogger("backfill_qna_columns")
+
+# All eight target columns, grouped by backfill strategy.
+BULK_COLUMNS_FROM_NORMALIZED = (
+    "date_posted",
+    "is_remote",
+    "salary_min",
+    "salary_max",
+    "salary_currency",
+    "salary_period",
+)
+PER_ROW_COLUMNS = ("seniority_level", "role_classification")
+ALL_COLUMNS = BULK_COLUMNS_FROM_NORMALIZED + PER_ROW_COLUMNS
+
+# Mapping from JSearch-style experience_level strings to the closed seniority set
+# the regex classifier produces. Anything not mapped falls through to the regex pass.
+EXPERIENCE_LEVEL_TO_SENIORITY = {
+    "INTERNSHIP": "intern",
+    "INTERN": "intern",
+    "ENTRY_LEVEL": "junior",
+    "ENTRY": "junior",
+    "JUNIOR": "junior",
+    "ASSOCIATE": "junior",
+    "MID_LEVEL": "mid",
+    "MID": "mid",
+    "MID_SENIOR_LEVEL": "mid",
+    "SENIOR_LEVEL": "senior",
+    "SENIOR": "senior",
+    "LEAD": "lead",
+    "PRINCIPAL": "lead",
+    "STAFF": "lead",
+    "EXECUTIVE": "executive",
+    "DIRECTOR": "executive",
+    "VP": "executive",
+    "C_SUITE": "executive",
+    "CEO": "executive",
+    "CTO": "executive",
+}
+
+
+# ---------------------------------------------------------------------------
+# Bulk pass: date_posted, is_remote, salary_min, salary_max, salary_currency, salary_period
+# ---------------------------------------------------------------------------
+
+# A single multi-column UPDATE FROM join. Each column is wrapped in COALESCE so we
+# never overwrite a non-NULL value already on the row (idempotent).
+_BULK_UPDATE_SQL = text(
+    """
+    UPDATE dbo.job_postings jp SET
+        date_posted     = COALESCE(jp.date_posted,     nj.date_posted),
+        is_remote       = COALESCE(jp.is_remote,       nj.is_remote),
+        salary_min      = COALESCE(jp.salary_min,      nj.salary_min),
+        salary_max      = COALESCE(jp.salary_max,      nj.salary_max),
+        salary_currency = COALESCE(jp.salary_currency, nj.salary_currency),
+        salary_period   = COALESCE(jp.salary_period,   nj.salary_period)
+    FROM dbo.normalized_jobs nj
+    WHERE jp.source = nj.source
+      AND jp.external_id = nj.external_id
+      AND (
+          jp.date_posted     IS NULL
+       OR jp.is_remote       IS NULL
+       OR jp.salary_min      IS NULL
+       OR jp.salary_max      IS NULL
+       OR jp.salary_currency IS NULL
+       OR jp.salary_period   IS NULL
+      )
+    """
+)
+
+_BULK_DRYRUN_SQL = text(
+    """
+    SELECT
+        SUM(CASE WHEN jp.date_posted     IS NULL AND nj.date_posted     IS NOT NULL THEN 1 ELSE 0 END) AS date_posted,
+        SUM(CASE WHEN jp.is_remote       IS NULL AND nj.is_remote       IS NOT NULL THEN 1 ELSE 0 END) AS is_remote,
+        SUM(CASE WHEN jp.salary_min      IS NULL AND nj.salary_min      IS NOT NULL THEN 1 ELSE 0 END) AS salary_min,
+        SUM(CASE WHEN jp.salary_max      IS NULL AND nj.salary_max      IS NOT NULL THEN 1 ELSE 0 END) AS salary_max,
+        SUM(CASE WHEN jp.salary_currency IS NULL AND nj.salary_currency IS NOT NULL THEN 1 ELSE 0 END) AS salary_currency,
+        SUM(CASE WHEN jp.salary_period   IS NULL AND nj.salary_period   IS NOT NULL THEN 1 ELSE 0 END) AS salary_period
+    FROM dbo.job_postings jp
+    JOIN dbo.normalized_jobs nj
+      ON jp.source = nj.source
+     AND jp.external_id = nj.external_id
+    """
+)
+
+
+def backfill_bulk_columns(session: Session, *, dry_run: bool) -> dict[str, int]:
+    """Bulk-fill the 6 normalized-source columns. Returns per-column would-fill counts.
+
+    The per-column counts are taken from a snapshot BEFORE the UPDATE runs (dry-run SQL).
+    The actual UPDATE may also include rows where some columns were already non-NULL
+    (COALESCE preserves them). The main() before/after snapshot is the source of truth
+    for the live-mode delta report.
+    """
+    pre = session.execute(_BULK_DRYRUN_SQL).mappings().first()
+    counts = {col: int(pre[col] or 0) for col in BULK_COLUMNS_FROM_NORMALIZED}
+    if dry_run:
+        return counts
+    result = session.execute(_BULK_UPDATE_SQL)
+    session.commit()
+    log.info("bulk_pass_complete rows_touched=%d would_fill=%s", result.rowcount or 0, counts)
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Per-row pass: seniority_level (hybrid: experience_level mapping → regex classifier)
+# ---------------------------------------------------------------------------
+
+_SENIORITY_FROM_EXPERIENCE_LEVEL_SQL = text(
+    """
+    UPDATE dbo.job_postings jp
+    SET seniority_level = sub.mapped
+    FROM (
+        SELECT
+            jp2.job_posting_id,
+            CASE UPPER(TRIM(nj.experience_level))
+                WHEN 'INTERNSHIP'        THEN 'intern'
+                WHEN 'INTERN'            THEN 'intern'
+                WHEN 'ENTRY_LEVEL'       THEN 'junior'
+                WHEN 'ENTRY'             THEN 'junior'
+                WHEN 'JUNIOR'            THEN 'junior'
+                WHEN 'ASSOCIATE'         THEN 'junior'
+                WHEN 'MID_LEVEL'         THEN 'mid'
+                WHEN 'MID'               THEN 'mid'
+                WHEN 'MID_SENIOR_LEVEL'  THEN 'mid'
+                WHEN 'SENIOR_LEVEL'      THEN 'senior'
+                WHEN 'SENIOR'            THEN 'senior'
+                WHEN 'LEAD'              THEN 'lead'
+                WHEN 'PRINCIPAL'         THEN 'lead'
+                WHEN 'STAFF'             THEN 'lead'
+                WHEN 'EXECUTIVE'         THEN 'executive'
+                WHEN 'DIRECTOR'          THEN 'executive'
+                WHEN 'VP'                THEN 'executive'
+                WHEN 'C_SUITE'           THEN 'executive'
+                WHEN 'CEO'               THEN 'executive'
+                WHEN 'CTO'               THEN 'executive'
+                ELSE NULL
+            END AS mapped
+        FROM dbo.job_postings jp2
+        JOIN dbo.normalized_jobs nj
+          ON jp2.source = nj.source
+         AND jp2.external_id = nj.external_id
+        WHERE jp2.seniority_level IS NULL
+          AND nj.experience_level IS NOT NULL
+    ) sub
+    WHERE jp.job_posting_id = sub.job_posting_id
+      AND sub.mapped IS NOT NULL
+    """
+)
+
+_FETCH_SENIORITY_CANDIDATES_SQL = text(
+    """
+    SELECT
+        jp.job_posting_id::text  AS job_posting_id,
+        jp.job_title             AS job_title,
+        jp.job_description       AS job_description,
+        ei.skills                AS skills,
+        ei.tools                 AS tools,
+        ei.tasks                 AS tasks,
+        ei.responsibilities      AS responsibilities,
+        ei.context               AS context
+    FROM dbo.job_postings jp
+    LEFT JOIN dbo.normalized_jobs nj
+      ON jp.source = nj.source
+     AND jp.external_id = nj.external_id
+    LEFT JOIN dbo.extracted_intelligence ei
+      ON ei.normalized_job_id = nj.id
+    WHERE jp.seniority_level IS NULL
+    ORDER BY jp.job_posting_id
+    """
+)
+
+_UPDATE_SENIORITY_SQL = text(
+    "UPDATE dbo.job_postings SET seniority_level = :value "
+    "WHERE job_posting_id::text = :job_posting_id AND seniority_level IS NULL"
+)
+
+
+def backfill_seniority(
+    session: Session,
+    *,
+    dry_run: bool,
+    batch_size: int,
+) -> dict[str, int]:
+    """Hybrid seniority backfill: experience_level mapping → regex classifier fallback."""
+    counts: dict[str, int] = {"experience_level_mapped": 0, "regex_classified": 0, "still_null": 0}
+
+    # Pass A — bulk SQL UPDATE from experience_level mapping.
+    if dry_run:
+        preview = session.execute(
+            text(
+                """
+                SELECT COUNT(*) AS n
+                FROM dbo.job_postings jp
+                JOIN dbo.normalized_jobs nj
+                  ON jp.source = nj.source AND jp.external_id = nj.external_id
+                WHERE jp.seniority_level IS NULL
+                  AND nj.experience_level IS NOT NULL
+                  AND UPPER(TRIM(nj.experience_level)) IN (
+                    'INTERNSHIP','INTERN','ENTRY_LEVEL','ENTRY','JUNIOR','ASSOCIATE',
+                    'MID_LEVEL','MID','MID_SENIOR_LEVEL','SENIOR_LEVEL','SENIOR',
+                    'LEAD','PRINCIPAL','STAFF','EXECUTIVE','DIRECTOR','VP','C_SUITE','CEO','CTO'
+                  )
+                """
+            )
+        ).mappings().first()
+        counts["experience_level_mapped"] = int(preview["n"] or 0)
+    else:
+        result = session.execute(_SENIORITY_FROM_EXPERIENCE_LEVEL_SQL)
+        session.commit()
+        counts["experience_level_mapped"] = result.rowcount or 0
+        log.info("seniority pass A (experience_level mapping): %d filled", counts["experience_level_mapped"])
+
+    # Pass B — Python regex classifier on remaining NULLs. Load all candidates upfront
+    # (single snapshot — no pagination drift from concurrent updates).
+    candidates = session.execute(_FETCH_SENIORITY_CANDIDATES_SQL).mappings().all()
+    log.info("seniority pass B candidates after pass A: %d", len(candidates))
+
+    pending_updates = 0
+    for row in candidates:
+        extraction: dict[str, Any] = {
+            "skills": row.get("skills"),
+            "tools": row.get("tools"),
+            "tasks": row.get("tasks"),
+            "responsibilities": row.get("responsibilities"),
+            "context": row.get("context"),
+        }
+        value = classify_seniority(
+            row.get("job_title") or "",
+            row.get("job_description"),
+            extraction,
+        )
+        if value == "unknown":
+            # Don't write 'unknown' — leave NULL so a future enrichment can fill it.
+            continue
+        if not dry_run:
+            session.execute(
+                _UPDATE_SENIORITY_SQL,
+                {"value": value, "job_posting_id": row["job_posting_id"]},
+            )
+        counts["regex_classified"] += 1
+        pending_updates += 1
+        if pending_updates >= batch_size and not dry_run:
+            session.commit()
+            log.info("seniority pass B committed batch (%d updates so far)", counts["regex_classified"])
+            pending_updates = 0
+
+    if pending_updates and not dry_run:
+        session.commit()
+
+    # Final remaining count
+    remaining = session.execute(
+        text("SELECT COUNT(*) AS n FROM dbo.job_postings WHERE seniority_level IS NULL")
+    ).mappings().first()
+    counts["still_null"] = int(remaining["n"] or 0)
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Per-row pass: role_classification (regex classifier over title + corpus)
+# ---------------------------------------------------------------------------
+
+_FETCH_ROLE_CANDIDATES_SQL = text(
+    """
+    SELECT
+        jp.job_posting_id::text  AS job_posting_id,
+        jp.job_title             AS job_title,
+        jp.job_description       AS job_description,
+        ei.skills                AS skills,
+        ei.tools                 AS tools,
+        ei.tasks                 AS tasks,
+        ei.responsibilities      AS responsibilities,
+        ei.context               AS context
+    FROM dbo.job_postings jp
+    LEFT JOIN dbo.normalized_jobs nj
+      ON jp.source = nj.source
+     AND jp.external_id = nj.external_id
+    LEFT JOIN dbo.extracted_intelligence ei
+      ON ei.normalized_job_id = nj.id
+    WHERE jp.role_classification IS NULL
+    ORDER BY jp.job_posting_id
+    """
+)
+
+_UPDATE_ROLE_SQL = text(
+    "UPDATE dbo.job_postings SET role_classification = :value "
+    "WHERE job_posting_id::text = :job_posting_id AND role_classification IS NULL"
+)
+
+
+def backfill_role_classification(
+    session: Session,
+    *,
+    dry_run: bool,
+    batch_size: int,
+) -> dict[str, int]:
+    """Backfill role_classification using classify_role() over the corpus."""
+    # Load reference taxonomies once.
+    technology_areas = [
+        (str(r["id"]), r["title"])
+        for r in session.execute(
+            text("SELECT technology_area_id::text AS id, title FROM dbo.technology_areas WHERE title IS NOT NULL")
+        ).mappings().all()
+    ]
+    industry_sectors = [
+        (str(r["id"]), r["title"])
+        for r in session.execute(
+            text(
+                "SELECT industry_sector_id::text AS id, sector_title AS title "
+                "FROM dbo.industry_sectors WHERE sector_title IS NOT NULL"
+            )
+        ).mappings().all()
+    ]
+    log.info(
+        "role_classification taxonomies loaded: %d technology_areas, %d industry_sectors",
+        len(technology_areas), len(industry_sectors),
+    )
+
+    counts: dict[str, int] = {"classified": 0, "unclassified_written": 0, "still_null": 0}
+
+    # Load all candidates upfront (single snapshot).
+    candidates = session.execute(_FETCH_ROLE_CANDIDATES_SQL).mappings().all()
+    log.info("role pass candidates: %d", len(candidates))
+
+    pending_updates = 0
+    for row in candidates:
+        extraction: dict[str, Any] = {
+            "skills": row.get("skills"),
+            "tools": row.get("tools"),
+            "tasks": row.get("tasks"),
+            "responsibilities": row.get("responsibilities"),
+            "context": row.get("context"),
+        }
+        corpus = build_job_corpus(
+            row.get("job_title") or "",
+            row.get("job_description"),
+            extraction,
+        )
+        value = classify_role(
+            row.get("job_title") or "",
+            corpus,
+            technology_areas,
+            industry_sectors,
+        )
+        # classify_role returns "unclassified" for low-confidence — we still write it
+        # so the row is no longer NULL (matches enrichment semantics).
+        if value == "unclassified":
+            counts["unclassified_written"] += 1
+        else:
+            counts["classified"] += 1
+        if not dry_run:
+            session.execute(
+                _UPDATE_ROLE_SQL,
+                {"value": value, "job_posting_id": row["job_posting_id"]},
+            )
+        pending_updates += 1
+        if pending_updates >= batch_size and not dry_run:
+            session.commit()
+            log.info(
+                "role pass committed batch (%d classified, %d unclassified so far)",
+                counts["classified"], counts["unclassified_written"],
+            )
+            pending_updates = 0
+
+    if pending_updates and not dry_run:
+        session.commit()
+
+    remaining = session.execute(
+        text("SELECT COUNT(*) AS n FROM dbo.job_postings WHERE role_classification IS NULL")
+    ).mappings().first()
+    counts["still_null"] = int(remaining["n"] or 0)
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_columns(arg: str | None) -> tuple[str, ...]:
+    if not arg:
+        return ALL_COLUMNS
+    requested = tuple(c.strip() for c in arg.split(",") if c.strip())
+    unknown = [c for c in requested if c not in ALL_COLUMNS]
+    if unknown:
+        raise SystemExit(f"Unknown columns: {unknown}. Valid: {ALL_COLUMNS}")
+    return requested
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Count rows that would change without writing. Safe to run anytime.",
+    )
+    parser.add_argument(
+        "--columns",
+        type=str,
+        default=None,
+        help=f"Comma-separated subset to backfill. Default: all 8. Valid: {','.join(ALL_COLUMNS)}",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=500,
+        help="Per-row pass batch size (seniority_level + role_classification).",
+    )
+    args = parser.parse_args()
+
+    columns = _parse_columns(args.columns)
+    log.info("Starting backfill: columns=%s dry_run=%s batch_size=%d", columns, args.dry_run, args.batch_size)
+    started = time.monotonic()
+
+    engine = get_engine()
+    with Session(engine) as session:
+        # Snapshot NULL counts BEFORE any writes so the report shows real deltas.
+        before = {}
+        for col in ALL_COLUMNS:
+            row = session.execute(
+                text(f"SELECT COUNT(*) AS n FROM dbo.job_postings WHERE {col} IS NULL")
+            ).mappings().first()
+            before[col] = int(row["n"] or 0)
+        log.info("NULL counts BEFORE: %s", before)
+
+        # Bulk pass for normalized-sourced columns.
+        bulk_targets = [c for c in BULK_COLUMNS_FROM_NORMALIZED if c in columns]
+        if bulk_targets:
+            log.info("Bulk pass for: %s", bulk_targets)
+            backfill_bulk_columns(session, dry_run=args.dry_run)
+
+        # seniority_level
+        if "seniority_level" in columns:
+            log.info("Seniority pass (hybrid)...")
+            sen_counts = backfill_seniority(session, dry_run=args.dry_run, batch_size=args.batch_size)
+            log.info("seniority counts: %s", sen_counts)
+
+        # role_classification
+        if "role_classification" in columns:
+            log.info("Role classification pass...")
+            role_counts = backfill_role_classification(session, dry_run=args.dry_run, batch_size=args.batch_size)
+            log.info("role counts: %s", role_counts)
+
+        # Snapshot NULL counts AFTER.
+        after = {}
+        for col in ALL_COLUMNS:
+            row = session.execute(
+                text(f"SELECT COUNT(*) AS n FROM dbo.job_postings WHERE {col} IS NULL")
+            ).mappings().first()
+            after[col] = int(row["n"] or 0)
+        log.info("NULL counts AFTER: %s", after)
+
+        delta = {col: before[col] - after[col] for col in ALL_COLUMNS}
+        log.info("Filled per column: %s", delta)
+
+    elapsed = time.monotonic() - started
+    log.info("Backfill complete in %.1fs (dry_run=%s)", elapsed, args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backfill_qna_columns.py
+++ b/scripts/backfill_qna_columns.py
@@ -116,6 +116,10 @@ EXPERIENCE_LEVEL_TO_SENIORITY = {
 
 # A single multi-column UPDATE FROM join. Each column is wrapped in COALESCE so we
 # never overwrite a non-NULL value already on the row (idempotent).
+# NOTE on duplicates: dbo.normalized_jobs has ~100 duplicate (source, external_id) pairs
+# (re-ingested rows with different id). All three backfill queries pick the latest (MAX(id))
+# normalized_jobs row per (source, external_id) deterministically via LATERAL ... LIMIT 1.
+
 _BULK_UPDATE_SQL = text(
     """
     UPDATE dbo.job_postings jp SET
@@ -125,7 +129,13 @@ _BULK_UPDATE_SQL = text(
         salary_max      = COALESCE(jp.salary_max,      nj.salary_max),
         salary_currency = COALESCE(jp.salary_currency, nj.salary_currency),
         salary_period   = COALESCE(jp.salary_period,   nj.salary_period)
-    FROM dbo.normalized_jobs nj
+    FROM (
+        SELECT DISTINCT ON (source, external_id)
+            source, external_id, date_posted, is_remote,
+            salary_min, salary_max, salary_currency, salary_period
+        FROM dbo.normalized_jobs
+        ORDER BY source, external_id, id DESC
+    ) nj
     WHERE jp.source = nj.source
       AND jp.external_id = nj.external_id
       AND (
@@ -149,7 +159,13 @@ _BULK_DRYRUN_SQL = text(
         SUM(CASE WHEN jp.salary_currency IS NULL AND nj.salary_currency IS NOT NULL THEN 1 ELSE 0 END) AS salary_currency,
         SUM(CASE WHEN jp.salary_period   IS NULL AND nj.salary_period   IS NOT NULL THEN 1 ELSE 0 END) AS salary_period
     FROM dbo.job_postings jp
-    JOIN dbo.normalized_jobs nj
+    JOIN (
+        SELECT DISTINCT ON (source, external_id)
+            source, external_id, date_posted, is_remote,
+            salary_min, salary_max, salary_currency, salary_period
+        FROM dbo.normalized_jobs
+        ORDER BY source, external_id, id DESC
+    ) nj
       ON jp.source = nj.source
      AND jp.external_id = nj.external_id
     """
@@ -209,9 +225,11 @@ _SENIORITY_FROM_EXPERIENCE_LEVEL_SQL = text(
                 ELSE NULL
             END AS mapped
         FROM dbo.job_postings jp2
-        JOIN dbo.normalized_jobs nj
-          ON jp2.source = nj.source
-         AND jp2.external_id = nj.external_id
+        JOIN LATERAL (
+            SELECT experience_level FROM dbo.normalized_jobs
+            WHERE source = jp2.source AND external_id = jp2.external_id
+            ORDER BY id DESC LIMIT 1
+        ) nj ON TRUE
         WHERE jp2.seniority_level IS NULL
           AND nj.experience_level IS NOT NULL
     ) sub
@@ -232,11 +250,18 @@ _FETCH_SENIORITY_CANDIDATES_SQL = text(
         ei.responsibilities      AS responsibilities,
         ei.context               AS context
     FROM dbo.job_postings jp
-    LEFT JOIN dbo.normalized_jobs nj
-      ON jp.source = nj.source
-     AND jp.external_id = nj.external_id
-    LEFT JOIN dbo.extracted_intelligence ei
-      ON ei.normalized_job_id = nj.id
+    LEFT JOIN LATERAL (
+        SELECT id FROM dbo.normalized_jobs
+        WHERE source = jp.source AND external_id = jp.external_id
+        ORDER BY id DESC LIMIT 1
+    ) nj ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT skills, tools, tasks, responsibilities, context
+        FROM dbo.extracted_intelligence
+        WHERE normalized_job_id = nj.id
+        ORDER BY id DESC
+        LIMIT 1
+    ) ei ON TRUE
     WHERE jp.seniority_level IS NULL
     ORDER BY jp.job_posting_id
     """
@@ -264,8 +289,11 @@ def backfill_seniority(
                 """
                 SELECT COUNT(*) AS n
                 FROM dbo.job_postings jp
-                JOIN dbo.normalized_jobs nj
-                  ON jp.source = nj.source AND jp.external_id = nj.external_id
+                JOIN LATERAL (
+                    SELECT experience_level FROM dbo.normalized_jobs
+                    WHERE source = jp.source AND external_id = jp.external_id
+                    ORDER BY id DESC LIMIT 1
+                ) nj ON TRUE
                 WHERE jp.seniority_level IS NULL
                   AND nj.experience_level IS NOT NULL
                   AND UPPER(TRIM(nj.experience_level)) IN (
@@ -344,11 +372,18 @@ _FETCH_ROLE_CANDIDATES_SQL = text(
         ei.responsibilities      AS responsibilities,
         ei.context               AS context
     FROM dbo.job_postings jp
-    LEFT JOIN dbo.normalized_jobs nj
-      ON jp.source = nj.source
-     AND jp.external_id = nj.external_id
-    LEFT JOIN dbo.extracted_intelligence ei
-      ON ei.normalized_job_id = nj.id
+    LEFT JOIN LATERAL (
+        SELECT id FROM dbo.normalized_jobs
+        WHERE source = jp.source AND external_id = jp.external_id
+        ORDER BY id DESC LIMIT 1
+    ) nj ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT skills, tools, tasks, responsibilities, context
+        FROM dbo.extracted_intelligence
+        WHERE normalized_job_id = nj.id
+        ORDER BY id DESC
+        LIMIT 1
+    ) ei ON TRUE
     WHERE jp.role_classification IS NULL
     ORDER BY jp.job_posting_id
     """
@@ -371,7 +406,7 @@ def backfill_role_classification(
     technology_areas = [
         (str(r["id"]), r["title"])
         for r in session.execute(
-            text("SELECT technology_area_id::text AS id, title FROM dbo.technology_areas WHERE title IS NOT NULL")
+            text("SELECT id::text AS id, title FROM dbo.technology_areas WHERE title IS NOT NULL")
         ).mappings().all()
     ]
     industry_sectors = [
@@ -499,7 +534,9 @@ def main() -> int:
         bulk_targets = [c for c in BULK_COLUMNS_FROM_NORMALIZED if c in columns]
         if bulk_targets:
             log.info("Bulk pass for: %s", bulk_targets)
-            backfill_bulk_columns(session, dry_run=args.dry_run)
+            bulk_counts = backfill_bulk_columns(session, dry_run=args.dry_run)
+            if args.dry_run:
+                log.info("bulk projection (would-fill per column from normalized_jobs): %s", bulk_counts)
 
         # seniority_level
         if "seniority_level" in columns:

--- a/scripts/pg-seed-data/README.md
+++ b/scripts/pg-seed-data/README.md
@@ -23,7 +23,9 @@ python scripts/batch_ingest.py --dry-run
 python scripts/run_processing_loop.py --dry-run
 ```
 
-**`seed_pg_database.py`** is **idempotent**: it uses `INSERT ... ON CONFLICT DO NOTHING` so existing records are never overwritten or deleted. New fixture records are added automatically. Seeds both reference data (`fixtures/*.json`) and agent pipeline data (`agent-fixtures/*.json`) in one command.
+**`seed_pg_database.py`** is **idempotent**: existing records are never overwritten or deleted. New fixture records are added automatically. Seeds both reference data and agent pipeline data from `fixtures/*.json` (single directory — see [File Structure](#file-structure)) in one command.
+
+For most tables, conflicts use `ON CONFLICT DO NOTHING` (existing rows are skipped). For tables listed in `UPSERT_UPDATE_COLUMNS` (currently `job_postings`), conflicts trigger `DO UPDATE SET col = COALESCE(target.col, EXCLUDED.col)` for a configured column subset — so re-seeding after a schema-adds-columns migration **fills the new columns on existing rows without clobbering any locally-populated state**. Devs do not need to wipe their volume to pick up new column data.
 
 ## What Gets Seeded
 
@@ -56,7 +58,7 @@ The seed script populates **40 reference tables** with ~56,000 rows:
 ### What is NOT seeded
 
 - **PII tables** (users, jobseekers, employers, auth) — excluded for privacy
-- **Agent pipeline rows** — `seed_pg_database.py` creates agent tables via `run_migrations()` and loads pipeline data from `agent-fixtures/*.json` automatically
+- **Agent pipeline rows** — `seed_pg_database.py` creates agent tables via `run_migrations()` and loads pipeline data from `fixtures/*.json` automatically (the agent tables share the same fixtures directory as reference tables)
 - **Skill embeddings** — the `embedding` column is excluded from fixtures (107MB of pgvector data). Regenerate via the admin tool if needed.
 
 ## How It Works
@@ -66,13 +68,13 @@ The seed script populates **40 reference tables** with ~56,000 rows:
 Idempotent — safe to re-run at any time. Never deletes or overwrites existing data.
 
 1. **Checks schema** — if dbo schema has no tables (fresh DB), runs `schema.sql` DDL; otherwise skips
-2. **Runs agent migrations** — creates agent-managed tables + adds Phase 1 columns to `job_postings`
-3. **Loads reference fixtures** — `INSERT ... ON CONFLICT DO NOTHING` from `fixtures/*.json` in FK-safe tier order
-4. **Loads agent pipeline data** — calls `seed_agent_data.py` internally (same UPSERT pattern from `agent-fixtures/*.json`)
+2. **Runs agent migrations** — creates agent-managed tables + adds agent-owned columns to `job_postings`
+3. **Loads reference fixtures** — `INSERT ... ON CONFLICT` from `fixtures/*.json` in FK-safe tier order. `DO NOTHING` for most tables; `DO UPDATE SET col = COALESCE(target.col, EXCLUDED.col)` for tables in `UPSERT_UPDATE_COLUMNS`.
+4. **Loads agent pipeline data** — calls `seed_agent_data.py` internally (same upsert behavior, same `fixtures/` directory)
 
 ### `seed_agent_data.py` (called automatically, can also run standalone)
 
-Loads `agent-fixtures/*.json` into staging/enrichment tables (and additional `job_postings` rows) via `INSERT … ON CONFLICT DO NOTHING`. Row counts are documented in `agent-fixtures/metadata.json`.
+Loads agent pipeline tables from `fixtures/*.json` into staging/enrichment tables (and additional `job_postings` rows). Conflict behavior follows the same `UPSERT_UPDATE_COLUMNS` override map as `seed_pg_database.py`. Row counts are documented in `fixtures/metadata.json`.
 
 ## File Structure
 
@@ -86,18 +88,17 @@ scripts/pg-seed-data/
   clean_schema.py               ← Schema cleaner (admin only)
   schema.sql                    ← Cleaned DDL (idempotent)
   schema_raw.sql                ← Raw pg_dump output (admin reference)
-  fixtures/
-    metadata.json               ← Export metadata with row counts
-    skills.json                 ← 5,683 skills (no embeddings)
-    companies.json              ← 122 companies
-    job_postings.json           ← 172 job postings
-    ... (40 fixture files)
-  agent-fixtures/
-    raw_ingested_jobs.json      ← Ingested job data
-    normalized_jobs.json        ← Normalized records
-    extracted_intelligence.json ← Extraction results
-    job_postings.json           ← Enriched postings (promotion path; UPSERT after reference seed)
-    ...                         ← job_ingestion_runs, normalization_quarantine, llm_audit_log, metadata.json
+  fixtures/                     ← Single source of truth — both reference + agent pipeline tables
+    metadata.json               ← Export metadata with row counts (per-scope sections)
+    Reference (40 tables, ~56k rows):
+      skills.json               ← 5,683 skills (embeddings excluded)
+      cip.json, socc.json, postal_geo_data.json, ...
+    Agent pipeline (10 tables):
+      raw_ingested_jobs.json    ← Ingested job data
+      normalized_jobs.json      ← Normalized records
+      extracted_intelligence.json ← Extraction results
+      job_postings.json         ← Enriched postings (UPSERT-with-COALESCE on the 8 Q&A-ready columns)
+      job_ingestion_runs.json, normalization_quarantine.json, employer_profiles.json, companies.json, naics.json, llm_audit_log.json
 ```
 
 ## Troubleshooting
@@ -121,9 +122,9 @@ If the admin database changes, re-export fixtures:
 # 2. Export all fixtures (reference + agent pipeline) in one command
 python scripts/pg-seed-data/export_fixtures.py
 
-# Or export individual scopes:
-python scripts/pg-seed-data/export_fixtures.py --scope reference  # fixtures/ only
-python scripts/pg-seed-data/export_fixtures.py --scope agent      # agent-fixtures/ only
+# Or export individual scopes (all output to fixtures/):
+python scripts/pg-seed-data/export_fixtures.py --scope reference  # 40 reference tables only
+python scripts/pg-seed-data/export_fixtures.py --scope agent      # 10 agent pipeline tables only
 python scripts/pg-seed-data/export_fixtures.py --limit 500        # cap rows per table
 
 # 3. Optionally regenerate schema.sql
@@ -132,8 +133,28 @@ docker exec postgres-server pg_dump -U postgres -d talent_finder \
   > scripts/pg-seed-data/schema_raw.sql
 python scripts/pg-seed-data/clean_schema.py
 
-# 5. Commit updated fixtures (include agent-fixtures when pipeline snapshot changed)
+# 5. Commit updated fixtures
 git add scripts/pg-seed-data/fixtures/ scripts/pg-seed-data/schema.sql
-git add scripts/pg-seed-data/agent-fixtures/
 git commit -m "Update PostgreSQL seed fixtures"
 ```
+
+### Adding a column to `UPSERT_UPDATE_COLUMNS`
+
+When a new migration adds columns to an existing seeded table and you want
+re-seeding to fill those columns on existing rows (without clobbering local
+state), edit the `UPSERT_UPDATE_COLUMNS` map in **both** `seed_pg_database.py`
+and `seed_agent_data.py` to add the new column names:
+
+```python
+UPSERT_UPDATE_COLUMNS: dict[str, list[str]] = {
+    "job_postings": [
+        "date_posted", "seniority_level", "is_remote",
+        "role_classification",
+        "salary_min", "salary_max", "salary_currency", "salary_period",
+        # add new columns here
+    ],
+}
+```
+
+The two maps must stay in sync (verified by `scripts/tests/test_seed_upsert_on_conflict.py`).
+The COALESCE pattern guarantees existing non-NULL values are preserved.

--- a/scripts/pg-seed-data/seed_agent_data.py
+++ b/scripts/pg-seed-data/seed_agent_data.py
@@ -2,7 +2,10 @@
 Seed agent pipeline data (enriched jobs, companies, NAICS) from JSON fixtures.
 
 Called automatically by seed_pg_database.py. Can also be run standalone.
-Uses UPSERT (INSERT ... ON CONFLICT DO NOTHING) — safe to run multiple times.
+Idempotent: existing rows are preserved. For tables in UPSERT_UPDATE_COLUMNS,
+new columns added by recent migrations get filled from the fixture via
+COALESCE — so re-seeding after a schema change populates new columns on
+existing rows without clobbering any locally-populated state.
 
 Usage (from project root, with venv activated):
     python scripts/pg-seed-data/seed_agent_data.py
@@ -31,6 +34,34 @@ import psycopg2.extras  # noqa: E402
 # ── Paths ─────────────────────────────────────────────────────────────
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+# ── UPSERT override map ───────────────────────────────────────────────
+# Tables listed here use ON CONFLICT DO UPDATE SET col = COALESCE(target.col, EXCLUDED.col)
+# instead of ON CONFLICT DO NOTHING. The COALESCE pattern means:
+#   - If existing row's column is NULL → set it from the fixture value
+#   - If existing row's column has a value → keep the existing value (no clobber)
+#
+# Use this for columns added by recent migrations: dev DBs that already have
+# the rows but lack the new column data get those columns filled in by re-seeding,
+# without losing any state that was locally populated.
+#
+# Columns not present in the fixture are silently skipped (backward compatible
+# with older fixtures that don't yet have the column).
+UPSERT_UPDATE_COLUMNS: dict[str, list[str]] = {
+    "job_postings": [
+        # Week 8 (#170) Q&A-ready promotions
+        "date_posted",
+        "seniority_level",
+        "is_remote",
+        # Week 8 (#173) role_classification promotion
+        "role_classification",
+        # Week 8 (#174) structured salary promotions
+        "salary_min",
+        "salary_max",
+        "salary_currency",
+        "salary_period",
+    ],
+}
 
 # ── FK-safe insert order ──────────────────────────────────────────────
 # Tables ordered so that FK dependencies are satisfied:
@@ -102,15 +133,38 @@ def _convert_value(val):
     return val
 
 
+def _build_on_conflict_clause(table: str, pk_cols: list[str], columns: list[str]) -> str:
+    """Build the ON CONFLICT clause for the upsert.
+
+    For tables in UPSERT_UPDATE_COLUMNS, filter the configured update columns
+    to those present in the fixture, then build:
+        ON CONFLICT (pk) DO UPDATE SET col = COALESCE("dbo"."<table>".col, EXCLUDED.col), ...
+    Otherwise:
+        ON CONFLICT (pk) DO NOTHING
+    """
+    conflict_cols = ", ".join(f'"{c}"' for c in pk_cols)
+    update_cols = [c for c in UPSERT_UPDATE_COLUMNS.get(table, []) if c in columns]
+    if not update_cols:
+        return f"ON CONFLICT ({conflict_cols}) DO NOTHING"
+    set_clauses = ", ".join(
+        f'"{c}" = COALESCE("dbo"."{table}"."{c}", EXCLUDED."{c}")' for c in update_cols
+    )
+    return f"ON CONFLICT ({conflict_cols}) DO UPDATE SET {set_clauses}"
+
+
 def upsert_records(
     cur: psycopg2.extensions.cursor,
     table: str,
     records: list[dict],
     pk_cols: list[str],
 ) -> tuple[int, int]:
-    """Insert records with ON CONFLICT DO NOTHING using fast batch inserts.
+    """Insert records with ON CONFLICT handling using fast batch inserts.
 
-    Returns (inserted, skipped). Uses psycopg2.extras.execute_values()
+    For tables in UPSERT_UPDATE_COLUMNS, conflicts trigger a COALESCE-based
+    UPDATE that fills NULL columns from the fixture without clobbering existing
+    values. For all other tables, conflicts are skipped (DO NOTHING).
+
+    Returns (inserted_or_updated, skipped). Uses psycopg2.extras.execute_values()
     for batched network round-trips instead of row-by-row.
     """
     if not records:
@@ -118,9 +172,9 @@ def upsert_records(
 
     columns = list(records[0].keys())
     col_names = ", ".join(f'"{c}"' for c in columns)
-    conflict_cols = ", ".join(f'"{c}"' for c in pk_cols)
+    on_conflict = _build_on_conflict_clause(table, pk_cols, columns)
 
-    insert_sql = f'INSERT INTO "dbo"."{table}" ({col_names}) VALUES %s ON CONFLICT ({conflict_cols}) DO NOTHING'
+    insert_sql = f'INSERT INTO "dbo"."{table}" ({col_names}) VALUES %s {on_conflict}'
 
     # Pre-convert all values into tuple list
     values_list = []
@@ -134,9 +188,11 @@ def upsert_records(
             values_list,
             page_size=1000,
         )
-        inserted = cur.rowcount if cur.rowcount >= 0 else len(values_list)
-        skipped = len(values_list) - inserted
-        return inserted, skipped
+        # rowcount counts both INSERTed and UPDATEd rows under DO UPDATE; under
+        # DO NOTHING it counts only INSERTed. "skipped" = total - touched.
+        touched = cur.rowcount if cur.rowcount >= 0 else len(values_list)
+        skipped = len(values_list) - touched
+        return touched, skipped
     except Exception as exc:
         cur.connection.rollback()
         print(f"    BATCH ERROR: {str(exc)[:300]}")
@@ -145,20 +201,20 @@ def upsert_records(
         row_sql = (
             f'INSERT INTO "dbo"."{table}" ({col_names}) '
             f"VALUES ({placeholders}) "
-            f"ON CONFLICT ({conflict_cols}) DO NOTHING"
+            f"{on_conflict}"
         )
-        inserted = 0
+        touched = 0
         for i, vals in enumerate(values_list):
             try:
                 cur.execute(row_sql, vals)
                 cur.connection.commit()
                 if cur.rowcount > 0:
-                    inserted += 1
+                    touched += 1
             except Exception as row_exc:
                 cur.connection.rollback()
                 if i < 3:
                     print(f"    Row {i + 1} error: {str(row_exc)[:200]}")
-        return inserted, len(values_list) - inserted
+        return touched, len(values_list) - touched
 
 
 def run_migrations() -> None:

--- a/scripts/pg-seed-data/seed_pg_database.py
+++ b/scripts/pg-seed-data/seed_pg_database.py
@@ -2,8 +2,13 @@
 Idempotent database seeder — reference data + agent pipeline data.
 
 Safe to re-run at any time: uses INSERT ... ON CONFLICT DO NOTHING so
-existing records are never overwritten or deleted.  New fixture records
+existing records are never overwritten or deleted. New fixture records
 are added automatically.
+
+For tables in UPSERT_UPDATE_COLUMNS (e.g. job_postings), conflicts trigger
+a COALESCE-based UPDATE that fills NULL columns from the fixture without
+clobbering existing values. This lets devs re-seed after a schema change
+to populate newly-added columns on existing rows.
 
 On a fresh database (no dbo schema), runs schema.sql DDL first.
 
@@ -38,6 +43,34 @@ SCRIPT_DIR = Path(__file__).parent
 SCHEMA_FILE = SCRIPT_DIR / "schema.sql"
 FIXTURES_DIR = SCRIPT_DIR / "fixtures"
 METADATA_FILE = FIXTURES_DIR / "metadata.json"
+
+# ── UPSERT override map ───────────────────────────────────────────────
+# Tables listed here use ON CONFLICT DO UPDATE SET col = COALESCE(target.col, EXCLUDED.col)
+# instead of ON CONFLICT DO NOTHING. The COALESCE pattern means:
+#   - If existing row's column is NULL → set it from the fixture value
+#   - If existing row's column has a value → keep the existing value (no clobber)
+#
+# Use this for columns added by recent migrations: dev DBs that already have
+# the rows but lack the new column data get those columns filled in by re-seeding,
+# without losing any state that was locally populated.
+#
+# Columns not present in the fixture are silently skipped (backward compatible
+# with older fixtures that don't yet have the column).
+UPSERT_UPDATE_COLUMNS: dict[str, list[str]] = {
+    "job_postings": [
+        # Week 8 (#170) Q&A-ready promotions
+        "date_posted",
+        "seniority_level",
+        "is_remote",
+        # Week 8 (#173) role_classification promotion
+        "role_classification",
+        # Week 8 (#174) structured salary promotions
+        "salary_min",
+        "salary_max",
+        "salary_currency",
+        "salary_period",
+    ],
+}
 
 # ── FK-safe insert order ──────────────────────────────────────────────
 # Tables are grouped into tiers: each tier only depends on tables in
@@ -223,6 +256,25 @@ def load_fixture(table_name: str) -> list[dict]:
     return json.loads(text)
 
 
+def _build_on_conflict_clause(table_name: str, pk_cols: list[str], columns: list[str]) -> str:
+    """Build the ON CONFLICT clause for the upsert.
+
+    For tables in UPSERT_UPDATE_COLUMNS, filter the configured update columns
+    to those present in the fixture, then build:
+        ON CONFLICT (pk) DO UPDATE SET col = COALESCE("dbo"."<table>".col, EXCLUDED.col), ...
+    Otherwise:
+        ON CONFLICT (pk) DO NOTHING
+    """
+    conflict_cols = ", ".join(f'"{c}"' for c in pk_cols)
+    update_cols = [c for c in UPSERT_UPDATE_COLUMNS.get(table_name, []) if c in columns]
+    if not update_cols:
+        return f"ON CONFLICT ({conflict_cols}) DO NOTHING"
+    set_clauses = ", ".join(
+        f'"{c}" = COALESCE("dbo"."{table_name}"."{c}", EXCLUDED."{c}")' for c in update_cols
+    )
+    return f"ON CONFLICT ({conflict_cols}) DO UPDATE SET {set_clauses}"
+
+
 def upsert_records(
     conn: psycopg2.extensions.connection,
     table_name: str,
@@ -230,9 +282,13 @@ def upsert_records(
     col_types: dict[str, str],
     pk_cols: list[str],
 ) -> tuple[int, int]:
-    """Insert records with ON CONFLICT DO NOTHING using fast batch inserts.
+    """Insert records with ON CONFLICT handling using fast batch inserts.
 
-    Returns (inserted, skipped).
+    For tables in UPSERT_UPDATE_COLUMNS, conflicts trigger a COALESCE-based
+    UPDATE that fills NULL columns from the fixture without clobbering existing
+    values. For all other tables, conflicts are skipped (DO NOTHING).
+
+    Returns (inserted_or_updated, skipped).
     """
     if not records:
         return 0, 0
@@ -263,8 +319,8 @@ def upsert_records(
             placeholder_parts.append("%s")
     values_template = "(" + ", ".join(placeholder_parts) + ")"
 
-    conflict_cols = ", ".join(f'"{c}"' for c in pk_cols)
-    insert_sql = f'INSERT INTO "dbo"."{table_name}" ({col_list}) VALUES %s ON CONFLICT ({conflict_cols}) DO NOTHING'
+    on_conflict = _build_on_conflict_clause(table_name, pk_cols, columns)
+    insert_sql = f'INSERT INTO "dbo"."{table_name}" ({col_list}) VALUES %s {on_conflict}'
 
     # Build values list
     values_list = []
@@ -280,6 +336,8 @@ def upsert_records(
             page_size=1000,
         )
         conn.commit()
+        # rowcount counts both INSERTed and UPDATEd rows under DO UPDATE; under
+        # DO NOTHING it counts only INSERTed. "skipped" = total - touched.
         inserted = cur.rowcount if cur.rowcount >= 0 else len(values_list)
         skipped = len(values_list) - inserted
     except Exception as exc:
@@ -291,7 +349,7 @@ def upsert_records(
             row_sql = (
                 f'INSERT INTO "dbo"."{table_name}" ({col_list}) '
                 f"VALUES {values_template} "
-                f"ON CONFLICT ({conflict_cols}) DO NOTHING"
+                f"{on_conflict}"
             )
             try:
                 cur.execute(row_sql, vals)

--- a/scripts/tests/test_backfill_qna_columns.py
+++ b/scripts/tests/test_backfill_qna_columns.py
@@ -1,0 +1,309 @@
+"""Unit tests for scripts/backfill_qna_columns.py.
+
+Mocks the SQLAlchemy session — no live DB. Validates argument parsing,
+column-set semantics, and the experience_level → seniority mapping.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.backfill_qna_columns import (
+    ALL_COLUMNS,
+    BULK_COLUMNS_FROM_NORMALIZED,
+    EXPERIENCE_LEVEL_TO_SENIORITY,
+    PER_ROW_COLUMNS,
+    _parse_columns,
+    backfill_bulk_columns,
+    backfill_role_classification,
+    backfill_seniority,
+)
+
+
+# ---------------------------------------------------------------------------
+# Column-set invariants
+# ---------------------------------------------------------------------------
+
+
+def test_all_columns_is_union_of_bulk_and_per_row() -> None:
+    assert set(ALL_COLUMNS) == set(BULK_COLUMNS_FROM_NORMALIZED) | set(PER_ROW_COLUMNS)
+
+
+def test_all_columns_has_eight_unique_entries() -> None:
+    assert len(ALL_COLUMNS) == 8
+    assert len(set(ALL_COLUMNS)) == 8
+
+
+def test_bulk_columns_match_normalized_jobs_source_set() -> None:
+    """Bulk-pass columns must be exactly the 6 with deterministic normalized_jobs sources."""
+    assert set(BULK_COLUMNS_FROM_NORMALIZED) == {
+        "date_posted",
+        "is_remote",
+        "salary_min",
+        "salary_max",
+        "salary_currency",
+        "salary_period",
+    }
+
+
+def test_per_row_columns_are_classifier_derived() -> None:
+    """Per-row columns must be the two that require regex classifier execution."""
+    assert set(PER_ROW_COLUMNS) == {"seniority_level", "role_classification"}
+
+
+# ---------------------------------------------------------------------------
+# experience_level → seniority mapping (closed-set sanity)
+# ---------------------------------------------------------------------------
+
+
+def test_experience_level_mapping_covers_jsearch_canonical_values() -> None:
+    """Every JSearch canonical experience_level must map to a known seniority label."""
+    canonical_jsearch = ["INTERNSHIP", "ENTRY_LEVEL", "MID_SENIOR_LEVEL", "SENIOR_LEVEL", "EXECUTIVE"]
+    for level in canonical_jsearch:
+        assert level in EXPERIENCE_LEVEL_TO_SENIORITY, f"{level} missing from mapping"
+
+
+@pytest.mark.parametrize(
+    ("experience_level", "expected_seniority"),
+    [
+        ("INTERNSHIP", "intern"),
+        ("INTERN", "intern"),
+        ("ENTRY_LEVEL", "junior"),
+        ("JUNIOR", "junior"),
+        ("MID_LEVEL", "mid"),
+        ("MID_SENIOR_LEVEL", "mid"),
+        ("SENIOR_LEVEL", "senior"),
+        ("LEAD", "lead"),
+        ("PRINCIPAL", "lead"),
+        ("STAFF", "lead"),
+        ("EXECUTIVE", "executive"),
+        ("DIRECTOR", "executive"),
+        ("VP", "executive"),
+    ],
+)
+def test_experience_level_mapping_returns_closed_set_label(experience_level: str, expected_seniority: str) -> None:
+    """Mapped values must be from the closed seniority set the regex classifier produces."""
+    assert EXPERIENCE_LEVEL_TO_SENIORITY[experience_level] == expected_seniority
+
+
+def test_experience_level_mapping_target_set_matches_classifier() -> None:
+    """All mapped-to values must be from {intern, junior, mid, senior, lead, executive}."""
+    closed_set = {"intern", "junior", "mid", "senior", "lead", "executive"}
+    assert set(EXPERIENCE_LEVEL_TO_SENIORITY.values()).issubset(closed_set)
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_columns_default_returns_all() -> None:
+    assert _parse_columns(None) == ALL_COLUMNS
+
+
+def test_parse_columns_empty_string_returns_all() -> None:
+    assert _parse_columns("") == ALL_COLUMNS
+
+
+def test_parse_columns_subset_preserves_order_of_input() -> None:
+    assert _parse_columns("is_remote,date_posted") == ("is_remote", "date_posted")
+
+
+def test_parse_columns_strips_whitespace() -> None:
+    assert _parse_columns(" is_remote , date_posted ") == ("is_remote", "date_posted")
+
+
+def test_parse_columns_rejects_unknown_column() -> None:
+    with pytest.raises(SystemExit, match="Unknown columns"):
+        _parse_columns("date_posted,bogus_column")
+
+
+def test_parse_columns_accepts_per_row_only() -> None:
+    assert _parse_columns("seniority_level,role_classification") == ("seniority_level", "role_classification")
+
+
+# ---------------------------------------------------------------------------
+# Bulk pass — dry-run vs live distinction
+# ---------------------------------------------------------------------------
+
+
+def _mapping_first(row: dict) -> MagicMock:
+    m = MagicMock()
+    m.mappings.return_value.first.return_value = row
+    return m
+
+
+def test_backfill_bulk_columns_dry_run_does_not_execute_update() -> None:
+    """Dry run must call only the count-SQL, never the UPDATE."""
+    session = MagicMock()
+    session.execute.return_value = _mapping_first(
+        {col: 100 for col in BULK_COLUMNS_FROM_NORMALIZED}
+    )
+    counts = backfill_bulk_columns(session, dry_run=True)
+
+    assert counts == {col: 100 for col in BULK_COLUMNS_FROM_NORMALIZED}
+    # Only one execute call (the dryrun count); no commit.
+    assert session.execute.call_count == 1
+    session.commit.assert_not_called()
+
+
+def test_backfill_bulk_columns_live_runs_update_and_commits() -> None:
+    """Live mode must call the count-SQL THEN the UPDATE, and commit."""
+    session = MagicMock()
+    pre_count = _mapping_first({col: 50 for col in BULK_COLUMNS_FROM_NORMALIZED})
+    update_result = MagicMock()
+    update_result.rowcount = 50
+    session.execute.side_effect = [pre_count, update_result]
+
+    counts = backfill_bulk_columns(session, dry_run=False)
+
+    assert counts == {col: 50 for col in BULK_COLUMNS_FROM_NORMALIZED}
+    assert session.execute.call_count == 2
+    session.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Seniority pass — pass A SQL execution (mocked)
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_seniority_pass_a_executes_in_live_mode() -> None:
+    """Live mode must run the experience_level mapping UPDATE before per-row pass."""
+    session = MagicMock()
+    pass_a_result = MagicMock()
+    pass_a_result.rowcount = 1500
+    candidates_result = MagicMock()
+    candidates_result.mappings.return_value.all.return_value = []  # no remaining
+    remaining_result = _mapping_first({"n": 0})
+    session.execute.side_effect = [pass_a_result, candidates_result, remaining_result]
+
+    counts = backfill_seniority(session, dry_run=False, batch_size=500)
+
+    assert counts["experience_level_mapped"] == 1500
+    assert counts["regex_classified"] == 0
+    assert counts["still_null"] == 0
+    # First execute call should be the bulk SQL UPDATE; commit fired after.
+    assert session.commit.called
+
+
+def test_backfill_seniority_dry_run_uses_preview_count() -> None:
+    """Dry run must use the SELECT preview, never the UPDATE."""
+    session = MagicMock()
+    preview_result = _mapping_first({"n": 1234})
+    candidates_result = MagicMock()
+    candidates_result.mappings.return_value.all.return_value = []
+    remaining_result = _mapping_first({"n": 100})
+    session.execute.side_effect = [preview_result, candidates_result, remaining_result]
+
+    counts = backfill_seniority(session, dry_run=True, batch_size=500)
+
+    assert counts["experience_level_mapped"] == 1234
+    session.commit.assert_not_called()
+
+
+def test_backfill_seniority_per_row_pass_skips_unknown_classifications() -> None:
+    """When classify_seniority returns 'unknown', the row is left NULL (no UPDATE issued)."""
+    session = MagicMock()
+    pass_a_result = MagicMock()
+    pass_a_result.rowcount = 0
+    # Two candidates: one with no signal at all (→ "unknown"), one with "Senior" in the title.
+    candidates_result = MagicMock()
+    candidates_result.mappings.return_value.all.return_value = [
+        {
+            "job_posting_id": "11111111-1111-1111-1111-111111111111",
+            "job_title": "Job Posting",  # no seniority signal
+            "job_description": "Generic description without level keywords",
+            "skills": None,
+            "tools": None,
+            "tasks": None,
+            "responsibilities": None,
+            "context": None,
+        },
+        {
+            "job_posting_id": "22222222-2222-2222-2222-222222222222",
+            "job_title": "Senior Software Engineer",
+            "job_description": None,
+            "skills": None,
+            "tools": None,
+            "tasks": None,
+            "responsibilities": None,
+            "context": None,
+        },
+    ]
+    update_result = MagicMock()
+    remaining_result = _mapping_first({"n": 1})  # unknown one stays NULL
+    session.execute.side_effect = [pass_a_result, candidates_result, update_result, remaining_result]
+
+    counts = backfill_seniority(session, dry_run=False, batch_size=500)
+
+    # Only the senior row gets classified; the unknown one is skipped.
+    assert counts["regex_classified"] == 1
+    assert counts["still_null"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Role classification pass — taxonomy load + classify_role flow
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_role_classification_loads_taxonomies_then_processes_candidates() -> None:
+    """Reference taxonomies must be loaded before per-row classification."""
+    session = MagicMock()
+    tech_areas = MagicMock()
+    tech_areas.mappings.return_value.all.return_value = [
+        {"id": "tech-1", "title": "software"},
+    ]
+    industry_sectors = MagicMock()
+    industry_sectors.mappings.return_value.all.return_value = [
+        {"id": "sec-1", "title": "technology"},
+    ]
+    candidates = MagicMock()
+    candidates.mappings.return_value.all.return_value = []  # no candidates → no classification work
+    remaining = _mapping_first({"n": 0})
+    session.execute.side_effect = [tech_areas, industry_sectors, candidates, remaining]
+
+    counts = backfill_role_classification(session, dry_run=False, batch_size=500)
+
+    # First two SELECTs load taxonomies; third loads candidates; fourth is the final remaining count.
+    assert session.execute.call_count == 4
+    assert counts["classified"] == 0
+    assert counts["unclassified_written"] == 0
+    assert counts["still_null"] == 0
+
+
+def test_backfill_role_classification_writes_unclassified_when_no_match() -> None:
+    """classify_role returning 'unclassified' still writes (matches enrichment semantics)."""
+    session = MagicMock()
+    tech_areas = MagicMock()
+    tech_areas.mappings.return_value.all.return_value = [
+        {"id": "tech-1", "title": "software"},
+    ]
+    industry_sectors = MagicMock()
+    industry_sectors.mappings.return_value.all.return_value = [
+        {"id": "sec-1", "title": "technology"},
+    ]
+    # A candidate whose title doesn't hint and whose corpus has no overlap with taxonomies.
+    candidates = MagicMock()
+    candidates.mappings.return_value.all.return_value = [
+        {
+            "job_posting_id": "33333333-3333-3333-3333-333333333333",
+            "job_title": "Mystery Role",
+            "job_description": "xyz qrs nothing relevant here",
+            "skills": None,
+            "tools": None,
+            "tasks": None,
+            "responsibilities": None,
+            "context": None,
+        },
+    ]
+    update_result = MagicMock()
+    remaining = _mapping_first({"n": 0})
+    session.execute.side_effect = [tech_areas, industry_sectors, candidates, update_result, remaining]
+
+    counts = backfill_role_classification(session, dry_run=False, batch_size=500)
+
+    # Even unclassified rows get written so they leave the candidate set.
+    total_written = counts["classified"] + counts["unclassified_written"]
+    assert total_written == 1

--- a/scripts/tests/test_seed_upsert_on_conflict.py
+++ b/scripts/tests/test_seed_upsert_on_conflict.py
@@ -1,0 +1,189 @@
+"""Tests for the ON CONFLICT clause builders in pg-seed-data scripts.
+
+Validates the per-table upsert-with-COALESCE behavior added so devs can
+re-seed after a schema-adds-columns migration without losing existing data
+and without skipping the new column data.
+
+These are pure SQL-string tests — no DB calls.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+# pg-seed-data isn't a Python package; import its modules by path.
+_SEED_DIR = Path(__file__).resolve().parent.parent / "pg-seed-data"
+sys.path.insert(0, str(_SEED_DIR))
+
+seed_agent_data = importlib.import_module("seed_agent_data")
+seed_pg_database = importlib.import_module("seed_pg_database")
+
+
+# ---------------------------------------------------------------------------
+# Override-map invariants — same shape in both scripts
+# ---------------------------------------------------------------------------
+
+
+def test_both_scripts_define_upsert_update_columns() -> None:
+    """Both seed scripts must define UPSERT_UPDATE_COLUMNS at module scope."""
+    assert hasattr(seed_agent_data, "UPSERT_UPDATE_COLUMNS")
+    assert hasattr(seed_pg_database, "UPSERT_UPDATE_COLUMNS")
+
+
+def test_upsert_update_columns_match_between_scripts() -> None:
+    """The two scripts must use the same per-table override map (otherwise re-seed
+    behavior diverges depending on which entry-point a dev runs)."""
+    assert seed_agent_data.UPSERT_UPDATE_COLUMNS == seed_pg_database.UPSERT_UPDATE_COLUMNS
+
+
+def test_job_postings_upsert_includes_all_eight_qna_columns() -> None:
+    """job_postings UPSERT must cover all 8 columns added by #170/#173/#174."""
+    expected = {
+        "date_posted",
+        "seniority_level",
+        "is_remote",
+        "role_classification",
+        "salary_min",
+        "salary_max",
+        "salary_currency",
+        "salary_period",
+    }
+    assert set(seed_agent_data.UPSERT_UPDATE_COLUMNS["job_postings"]) == expected
+
+
+# ---------------------------------------------------------------------------
+# seed_agent_data._build_on_conflict_clause
+# ---------------------------------------------------------------------------
+
+
+def test_agent_clause_table_not_in_map_returns_do_nothing() -> None:
+    """Tables without an override entry must use DO NOTHING (backward compat)."""
+    clause = seed_agent_data._build_on_conflict_clause(
+        "companies", ["company_id"], ["company_id", "company_name"]
+    )
+    assert "DO NOTHING" in clause
+    assert "DO UPDATE" not in clause
+
+
+def test_agent_clause_table_in_map_with_matching_columns_returns_do_update() -> None:
+    """Tables in the map with fixture columns intersecting update list use DO UPDATE."""
+    fixture_cols = [
+        "job_posting_id",
+        "company_id",
+        "job_title",
+        "date_posted",
+        "is_remote",
+        "role_classification",
+    ]
+    clause = seed_agent_data._build_on_conflict_clause(
+        "job_postings", ["job_posting_id"], fixture_cols
+    )
+    assert "DO UPDATE SET" in clause
+    # Every overlapping column should appear in the SET clause as COALESCE
+    for col in ("date_posted", "is_remote", "role_classification"):
+        assert f'"{col}" = COALESCE("dbo"."job_postings"."{col}", EXCLUDED."{col}")' in clause
+
+
+def test_agent_clause_filters_to_columns_present_in_fixture() -> None:
+    """If the fixture lacks a column from the update map, that column is silently dropped
+    (backward compat with old fixtures)."""
+    # Fixture only has date_posted, not the other 7
+    fixture_cols = ["job_posting_id", "date_posted"]
+    clause = seed_agent_data._build_on_conflict_clause(
+        "job_postings", ["job_posting_id"], fixture_cols
+    )
+    assert '"date_posted" = COALESCE("dbo"."job_postings"."date_posted", EXCLUDED."date_posted")' in clause
+    # None of the other 7 should appear
+    for col in ("seniority_level", "is_remote", "role_classification", "salary_min",
+                "salary_max", "salary_currency", "salary_period"):
+        assert col not in clause
+
+
+def test_agent_clause_no_overlap_falls_back_to_do_nothing() -> None:
+    """If none of the update-map columns are in the fixture, DO NOTHING is used."""
+    # Fixture has only legacy columns
+    fixture_cols = ["job_posting_id", "company_id", "job_title"]
+    clause = seed_agent_data._build_on_conflict_clause(
+        "job_postings", ["job_posting_id"], fixture_cols
+    )
+    assert "DO NOTHING" in clause
+
+
+def test_agent_clause_pk_quoting_handles_compound_key() -> None:
+    """Multi-column primary key must be properly quoted in the conflict target."""
+    clause = seed_agent_data._build_on_conflict_clause(
+        "job_postings", ["source", "external_id"], ["source", "external_id", "job_title"]
+    )
+    assert 'CONFLICT ("source", "external_id")' in clause
+
+
+def test_agent_clause_qualifies_target_columns_with_schema_and_table() -> None:
+    """The COALESCE must reference dbo.<table>.<col>, not bare <col>, to avoid
+    ambiguity when a column with the same name exists in EXCLUDED."""
+    clause = seed_agent_data._build_on_conflict_clause(
+        "job_postings", ["job_posting_id"], ["job_posting_id", "date_posted"]
+    )
+    assert '"dbo"."job_postings"."date_posted"' in clause
+
+
+# ---------------------------------------------------------------------------
+# seed_pg_database._build_on_conflict_clause (mirror behavior)
+# ---------------------------------------------------------------------------
+
+
+def test_pg_clause_table_not_in_map_returns_do_nothing() -> None:
+    clause = seed_pg_database._build_on_conflict_clause(
+        "companies", ["company_id"], ["company_id", "company_name"]
+    )
+    assert "DO NOTHING" in clause
+    assert "DO UPDATE" not in clause
+
+
+def test_pg_clause_table_in_map_with_matching_columns_returns_do_update() -> None:
+    fixture_cols = ["job_posting_id", "date_posted", "is_remote"]
+    clause = seed_pg_database._build_on_conflict_clause(
+        "job_postings", ["job_posting_id"], fixture_cols
+    )
+    assert "DO UPDATE SET" in clause
+    assert '"date_posted" = COALESCE("dbo"."job_postings"."date_posted", EXCLUDED."date_posted")' in clause
+    assert '"is_remote" = COALESCE("dbo"."job_postings"."is_remote", EXCLUDED."is_remote")' in clause
+
+
+def test_pg_clause_no_overlap_falls_back_to_do_nothing() -> None:
+    fixture_cols = ["job_posting_id", "company_id", "job_title"]
+    clause = seed_pg_database._build_on_conflict_clause(
+        "job_postings", ["job_posting_id"], fixture_cols
+    )
+    assert "DO NOTHING" in clause
+
+
+def test_pg_clause_qualifies_target_columns_with_schema_and_table() -> None:
+    clause = seed_pg_database._build_on_conflict_clause(
+        "job_postings", ["job_posting_id"], ["job_posting_id", "date_posted"]
+    )
+    assert '"dbo"."job_postings"."date_posted"' in clause
+
+
+# ---------------------------------------------------------------------------
+# Cross-script clause equivalence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("table", "pk", "fixture_cols"),
+    [
+        ("companies", ["company_id"], ["company_id", "company_name"]),  # not in map
+        ("job_postings", ["job_posting_id"], ["job_posting_id", "date_posted", "is_remote"]),
+        ("job_postings", ["source", "external_id"],
+         ["source", "external_id", "salary_min", "salary_max", "salary_currency", "salary_period"]),
+    ],
+)
+def test_clauses_match_between_scripts(table: str, pk: list[str], fixture_cols: list[str]) -> None:
+    """The two scripts must produce identical ON CONFLICT clauses for the same inputs."""
+    a = seed_agent_data._build_on_conflict_clause(table, pk, fixture_cols)
+    p = seed_pg_database._build_on_conflict_clause(table, pk, fixture_cols)
+    assert a == p


### PR DESCRIPTION
## Summary

Closes #170, #171, #176. Final branch of the Week 8 carry-forward chain
(`#177 → #186 → #170 → #171 → #176`), unblocking LaborPulse Q&A for Week 9.

---

## What changed

### Schema — `job_postings` gets three Q&A-ready columns (#170)

`date_posted`, `seniority_level`, and `is_remote` are now first-class columns
on `dbo.job_postings`, promoted by the enrichment pipeline on every run.

**`common/data_store/migrations.py`**
- Added `ADD COLUMN IF NOT EXISTS` for all three columns
  (`date_posted TIMESTAMPTZ`, `seniority_level TEXT`, `is_remote BOOLEAN`)
- Dropped the three dead FK constraints and their backing indexes
  (`fk_job_postings_employers1`, `fk_job_postings_technology_areas1`,
  `fk_job_postings_company_addresses1_idx`) — those columns are 99–100% NULL
  and were never written by the pipeline

**`common/data_store/models.py`**
- Added a complete agent-added-column inventory to the module docstring, with
  a clear deprecation notice for `employer_id`, `tech_area_id`, `location_id`

### Promotion logic — `enrichment/job_postings_promotion.py` (#170)

All three UPDATE paths (`clean`, `flagged`, `uncertain`) now write the three
new columns via `COALESCE` so existing non-NULL values are preserved on
re-enrichment.

- `date_posted` — pulled from the resolved `normalized_jobs` row (already in
  the resolved dict; no extra query)
- `is_remote` — same source; coerced to Python `bool` to guard against
  DB-returned integer-like values
- `seniority_level` — read from payload key `"seniority_level"` with a
  fallback to `"seniority"` (the key the `RecordEnriched` single-record
  contract actually uses), stripped to `None` if blank

### LLM SQL hint — `analytics/query_engine/routing.py` (#171)

`_SCHEMA_HINT` is now contract-grounded post-#170:

- `date_posted`, `seniority_level`, `is_remote` added to the `job_postings`
  column list so the LLM can generate valid SQL without hallucinating joins
- Removed the `CRITICAL` warning that said `job_postings has NO date_posted
  column yet` — that workaround is no longer needed

### Retrieval indexes — `migrations.py` (#176)

Six idempotent `CREATE INDEX IF NOT EXISTS` statements added to
`_QNA_RETRIEVAL_INDEX_STATEMENTS`, applied after the `ADD COLUMN` statements:



---

## UPDATE — scope expansion + live-DB verification

> Added by Gary's session on 2026-04-20 — this section is **appended** to Bryan's original description above. Closes additional sub-issues, adds a deterministic backfill, fixes a seed-script gap so devs can re-seed without losing data, and verifies the full path against the local DB. Fixtures ship in a separate follow-up PR.

### Additional issues closed by this update

| Sub-issue | Scope | Status after this PR |
|-----------|-------|----------------------|
| **#172** | promote `date_posted` + backfill | column ✓, promotion ✓, **deterministic backfill ✓** |
| **#173** | promote `seniority_level` + `role_classification` + `is_remote` + backfill | all 3 columns ✓, promotion ✓, backfill ✓ |
| **#174** | structured salary columns (`salary_min`, `salary_max`, `salary_currency`, `salary_period`) + backfill | 4 columns ✓, promotion ✓, backfill ✓ |

### Schema additions (`common/data_store/migrations.py`)

`ADD COLUMN IF NOT EXISTS` (idempotent):
- `role_classification TEXT` (#173)
- `salary_min NUMERIC`, `salary_max NUMERIC`, `salary_currency TEXT`, `salary_period TEXT` (#174)
- One new index: `ix_job_postings_role_classification`

### Promotion logic (`enrichment/job_postings_promotion.py`)

All 3 UPDATE paths (`clean`/`flagged`/`uncertain`) now also `COALESCE`-write `role_classification` + the 4 salary columns. Same idempotent pattern as Bryan's original.

### LLM SQL hint (`analytics/query_engine/routing.py`)

`_SCHEMA_HINT` extended to include the 5 new columns in the `job_postings` declaration.

### Deterministic backfill — `scripts/backfill_qna_columns.py` (NEW)

No LLM calls, no enrichment re-run. Pulls from existing DB state:

| Column | Source |
|--------|--------|
| `date_posted`, `is_remote`, `salary_min/max/currency/period` | bulk SQL `UPDATE FROM normalized_jobs` join on `(source, external_id)` with `DISTINCT ON ... ORDER BY id DESC` (handles ~100 duplicate `(source, external_id)` pairs found during live run) |
| `seniority_level` (hybrid) | (a) `normalized_jobs.experience_level` mapped to closed set; (b) `classify_seniority()` regex fallback over title + description + extracted_intelligence tasks/responsibilities |
| `role_classification` | `classify_role()` regex over corpus, against DB-seeded `technology_areas` + `industry_sectors` |

All operations idempotent (only writes where target column IS NULL); `--dry-run`, `--columns` filter, `--batch-size` flags; per-column NULL count snapshot before + after.

### Seed-script UPSERT — `scripts/pg-seed-data/seed_*.py`

When devs pull `development` after this merges and re-seed against their existing DB, the new column data needs to **fill in on existing rows without `docker compose down -v`** (which trips the no-data-loss rule per `CLAUDE.md`). The old `INSERT ... ON CONFLICT DO NOTHING` pattern silently SKIPS existing rows — so new column data never lands.

Both `seed_agent_data.py` and `seed_pg_database.py` now define an identical override map:

```python
UPSERT_UPDATE_COLUMNS: dict[str, list[str]] = {
    "job_postings": [
        "date_posted", "seniority_level", "is_remote",         # #170
        "role_classification",                                  # #173
        "salary_min", "salary_max", "salary_currency", "salary_period",  # #174
    ],
}
```

Tables in the map use `ON CONFLICT (pk) DO UPDATE SET col = COALESCE("dbo"."<table>"."col", EXCLUDED."col")`. The COALESCE preserves any non-NULL existing value and only fills when the existing value is NULL — same idempotent semantics as the backfill script. Tables NOT in the map keep `DO NOTHING` (backward compat). Columns NOT in the fixture are silently dropped from the SET clause (backward compat with older fixtures).

### README (`scripts/pg-seed-data/README.md`)

Removed all 6 stale references to a separate `agent-fixtures/` directory (the codebase consolidated to a single `fixtures/` directory long ago — verified by `export_fixtures.py` docstring line 7). Documented the new `UPSERT_UPDATE_COLUMNS` pattern with a "how to add a column" guide so future PRs know to update both seed scripts in tandem.

### Live verification on local DB

Backfill completed in **10.8s** on 3,496 rows:

| Column | Filled | Remaining NULL | Notes |
|---|---:|---:|---|
| `role_classification` | **3,496** | 0 | full coverage (70 "unclassified" written) |
| `seniority_level` | 3,198 | 298 | 298 are regex-"unknown" (left NULL by design) |
| `date_posted` | 2,122 | 1,374 | rest are legacy seeded rows w/o normalized lineage |
| `is_remote` | 2,065 | 1,431 | same |
| `salary_min` / `salary_max` | 586 each | 2,910 | most postings don't disclose salary |
| `salary_currency` | 567 | 2,929 | |
| `salary_period` | 584 | 2,912 | |

Sample populated row: `Principal Data Engineer | role=Data Engineering | sen=senior | rem=False | posted=2026-03-27 | sal=100000-125000 USD/YEAR`

`seniority_level` distribution: mid 1,212 / senior 972 / lead 692 / NULL 298 / junior 155 / executive 138 / intern 29.

`role_classification` top 5: "N/A Not an IT role" 657, Mobile App Development 642, Software Engineering 533, IT Project Management 284, Network Administration 194.

### Tests

| File | Coverage |
|------|----------|
| `analytics/query_engine/tests/test_schema_hint_columns.py` (extended) | +1 `role_classification` presence, +4 parametrized salary-column presence, +3 mocked-LLM SQL tests through the guardrail |
| `enrichment/tests/test_job_postings_promotion.py` (extended) | +10 field-level tests for `role_classification` (3) and structured salary (4 presence + 3 None/whitespace) |
| `scripts/tests/test_backfill_qna_columns.py` (NEW) | 32 tests — column-set invariants, experience_level mapping completeness + closed-set conformance, CLI parsing, bulk-pass dry-run vs live, seniority pass A/B, role-classification taxonomy load + unclassified write |
| `scripts/tests/test_seed_upsert_on_conflict.py` (NEW) | 16 tests — both scripts define the override map (presence), maps are identical between scripts, all 8 columns in the `job_postings` map, tables not in map → `DO NOTHING` (backward compat), tables in map with overlap → `DO UPDATE`, fixture lacks column → silently dropped, multi-column PK quoting, schema-qualified `COALESCE` references, cross-script clause equivalence (parametrized) |

**All 314 tests pass locally** (excluding pre-existing `test_agent_process.py::test_process_is_spam_false_calls_enrich_once` failure — unrelated, filed as #196).

### Fixtures (separate PR)

`python scripts/pg-seed-data/export_fixtures.py --scope agent` ran clean against the post-backfill local DB. Generated `fixtures/job_postings.json` (17.3 MB, 3,496 records) with all 8 new columns populated to the live counts above. **Fixtures ship in a separate follow-up PR after this one merges** — keeps PR #195 focused on code/migrations and isolates the binary-ish JSON diff to its own review surface.
