### PR TITLE
fix(qna): extend _SCHEMA_HINT with JSONB unnest patterns for tasks/responsibilities/context (closes #199)

### DIFF
--- a/analytics/query_engine/routing.py
+++ b/analytics/query_engine/routing.py
@@ -65,7 +65,8 @@ def _truncate_sql_execution_error(exc: BaseException, *, max_len: int = _SQL_EXE
 # Derived from docs/planning/QA_DATA_CONTRACT.md — update that doc first, then re-derive here.
 # Tracks: GitHub #186 (hotfix), #171 (full contract fix — date_posted/seniority_level/is_remote
 # columns promoted to job_postings by #170; CRITICAL block updated accordingly).
-# Extended: #173 (role_classification promoted), #174 (structured salary columns promoted).
+# Extended: #173 (role_classification promoted), #174 (structured salary columns promoted),
+# #199 (JSONB unnest patterns for tasks/responsibilities/context — no-aggregate dimensions).
 _SCHEMA_HINT = """\
 Allowed tables (PostgreSQL dbo schema only; always reference as dbo.table_name):
 
@@ -97,11 +98,55 @@ Operational tables (use when aggregates cannot answer):
   employer_profiles(id, company_id, company_size, ai_maturity_signal, sector, is_known_employer)
   industry_sectors(industry_sector_id, sector_title)
 
+Extracted intelligence (JSONB unnest — ONLY path for task / responsibility / context questions):
+  extracted_intelligence(id, normalized_job_id, skills, tools, tasks, responsibilities, context)
+    skills, tools, tasks, responsibilities, context are JSONB arrays of objects.
+    skills + tools have aggregate tables above — PREFER those for counts.
+    tasks, responsibilities, context have NO aggregate — JSONB unnest is the only path.
+
+  Two-hop join from job_postings to extracted_intelligence:
+    JOIN dbo.normalized_jobs nj ON jp.source = nj.source AND jp.external_id = nj.external_id
+    JOIN dbo.extracted_intelligence ei ON ei.normalized_job_id = nj.id
+
+  Unnest tasks (no aggregate exists). Element fields:
+    task_description, task_category, seniority_signal, confidence, source_span
+    Example:
+      SELECT elem->>'task_description' AS task,
+             elem->>'task_category'    AS category,
+             elem->>'seniority_signal' AS seniority,
+             COUNT(*) AS task_count
+      FROM dbo.extracted_intelligence ei,
+           jsonb_array_elements(ei.tasks) AS elem
+      WHERE (elem->>'confidence')::float >= 0.75
+      GROUP BY task, category, seniority
+      ORDER BY task_count DESC LIMIT 20
+
+  Unnest responsibilities. Element fields:
+    responsibility_description, scope, requires_ai_competency, confidence, source_span
+    Example:
+      SELECT elem->>'scope' AS scope, COUNT(*) AS n
+      FROM dbo.extracted_intelligence ei,
+           jsonb_array_elements(ei.responsibilities) AS elem
+      WHERE (elem->>'requires_ai_competency')::bool = TRUE
+      GROUP BY scope ORDER BY n DESC
+
+  Unnest context. Element fields:
+    signal_type (remote_policy|team_size|reporting_structure|work_methodology|ai_adoption_signal),
+    value, confidence, source_span
+    Example:
+      SELECT elem->>'value' AS work_methodology, COUNT(*) AS n
+      FROM dbo.extracted_intelligence ei,
+           jsonb_array_elements(ei.context) AS elem
+      WHERE elem->>'signal_type' = 'work_methodology'
+      GROUP BY work_methodology ORDER BY n DESC LIMIT 10
+
 CRITICAL — columns that do NOT exist (never generate SQL referencing these):
   - job_postings has NO skill_id, skills, or posted_date column.
     Skills are pre-aggregated in dbo.skill_demand_weekly.
     For "top skills by posting count" use: SELECT skill_label, posting_count
     FROM dbo.skill_demand_weekly ORDER BY posting_count DESC LIMIT 10
+  - job_postings has NO tasks, responsibilities, or context column.
+    Those live as JSONB arrays on dbo.extracted_intelligence — see unnest patterns above.
   - Never reference: publish_date, employer_id, tech_area_id, start_date, end_date, location_id.
     These columns are deprecated (99-100% NULL) and must not appear in any query.\
 """

--- a/analytics/query_engine/tests/test_schema_hint_columns.py
+++ b/analytics/query_engine/tests/test_schema_hint_columns.py
@@ -292,3 +292,104 @@ def _extract_job_postings_line(hint: str) -> str:
             if line.strip().endswith(")"):
                 break
     return " ".join(block)
+
+
+# ---------------------------------------------------------------------------
+# JSONB unnest section (#199) — extracted_intelligence dimensions without aggregates
+# ---------------------------------------------------------------------------
+
+
+def test_schema_hint_contains_extracted_intelligence_section() -> None:
+    """The JSONB unnest section must declare extracted_intelligence + its 5 dimensions."""
+    assert "extracted_intelligence(" in _SCHEMA_HINT, (
+        "extracted_intelligence is missing from _SCHEMA_HINT. The 3 no-aggregate "
+        "dimensions (tasks, responsibilities, context) cannot be queried without it."
+    )
+    for col in ("skills", "tools", "tasks", "responsibilities", "context"):
+        assert col in _SCHEMA_HINT, f"extracted_intelligence dimension '{col}' missing from hint"
+
+
+def test_schema_hint_contains_jsonb_array_elements_pattern() -> None:
+    """The hint must show the jsonb_array_elements unnest syntax for at least the 3 no-aggregate dims."""
+    assert "jsonb_array_elements" in _SCHEMA_HINT, (
+        "_SCHEMA_HINT has no jsonb_array_elements example — LLM has no way to know "
+        "how to unnest tasks/responsibilities/context."
+    )
+    # Each of the 3 no-aggregate dimensions should have an unnest example
+    for dim in ("tasks", "responsibilities", "context"):
+        assert f"jsonb_array_elements(ei.{dim})" in _SCHEMA_HINT, (
+            f"Missing unnest example for ei.{dim} in _SCHEMA_HINT"
+        )
+
+
+def test_schema_hint_documents_two_hop_join_to_extracted_intelligence() -> None:
+    """The hint must document the (jp -> nj -> ei) two-hop join path."""
+    assert "ei.normalized_job_id = nj.id" in _SCHEMA_HINT, (
+        "_SCHEMA_HINT must document the join path: "
+        "extracted_intelligence.normalized_job_id = normalized_jobs.id"
+    )
+
+
+def test_schema_hint_critical_block_warns_no_jsonb_columns_on_job_postings() -> None:
+    """job_postings.tasks/responsibilities/context don't exist — must be called out as
+    a hallucination trap (LLM sometimes assumes JSONB columns are on job_postings)."""
+    assert "job_postings has NO tasks" in _SCHEMA_HINT or "NO tasks, responsibilities, or context" in _SCHEMA_HINT, (
+        "CRITICAL block must warn that tasks/responsibilities/context don't live on job_postings"
+    )
+
+
+# Mocked-LLM SQL tests for the 3 no-aggregate dimensions
+@pytest.mark.parametrize(
+    ("question", "mock_sql"),
+    [
+        (
+            "What kinds of tasks do mid-level data engineers typically handle?",
+            "SELECT elem->>'task_description' AS task, COUNT(*) AS task_count "
+            "FROM dbo.extracted_intelligence ei, jsonb_array_elements(ei.tasks) AS elem "
+            "WHERE (elem->>'confidence')::float >= 0.75 "
+            "GROUP BY task ORDER BY task_count DESC LIMIT 20",
+        ),
+        (
+            "Which roles require AI competency at team scope?",
+            "SELECT elem->>'scope' AS scope, COUNT(*) AS n "
+            "FROM dbo.extracted_intelligence ei, jsonb_array_elements(ei.responsibilities) AS elem "
+            "WHERE (elem->>'requires_ai_competency')::bool = TRUE "
+            "GROUP BY scope ORDER BY n DESC",
+        ),
+        (
+            "What work methodologies show up in postings?",
+            "SELECT elem->>'value' AS work_methodology, COUNT(*) AS n "
+            "FROM dbo.extracted_intelligence ei, jsonb_array_elements(ei.context) AS elem "
+            "WHERE elem->>'signal_type' = 'work_methodology' "
+            "GROUP BY work_methodology ORDER BY n DESC LIMIT 10",
+        ),
+    ],
+)
+def test_mock_llm_jsonb_unnest_sql_passes_guardrail(question: str, mock_sql: str) -> None:
+    """JSONB unnest SQL against extracted_intelligence must pass the guardrail.
+
+    extracted_intelligence is in ASK_THE_DATA_ALLOWED_TABLES, and the guardrail
+    does not block jsonb_array_elements() — these queries should be permitted.
+    """
+    from analytics.query_engine.sql_guardrails import validate_ask_the_data_sql
+
+    ok, reason, _ = validate_ask_the_data_sql(mock_sql)
+    assert ok, (
+        f"JSONB unnest SQL for {question!r} was rejected by guardrail. "
+        f"Reason: {reason!r}. SQL: {mock_sql!r}"
+    )
+
+
+def test_mock_llm_hallucinated_task_column_on_job_postings_passes_guardrail_but_would_fail_at_execute() -> None:
+    """Sanity check: the guardrail validates table allowlist + structure, NOT column existence.
+    A query referencing job_postings.task_description (hallucinated) passes the guardrail but
+    will fail at execute time — the schema hint exists to PREVENT the LLM from generating it
+    in the first place."""
+    from analytics.query_engine.sql_guardrails import validate_ask_the_data_sql
+
+    bad = "SELECT task_description FROM dbo.job_postings LIMIT 10"
+    ok, reason, _ = validate_ask_the_data_sql(bad)
+    # Guardrail is structure-only; this check is to document the layered defense:
+    # _SCHEMA_HINT prevents generation, guardrail catches table-level violations,
+    # actual execute_safe catches column-level violations.
+    assert ok, "Sanity check: the guardrail itself is structure-only and accepts this; the schema hint and actual SQL execution are the layers that catch hallucinated columns."


### PR DESCRIPTION
## Summary

Closes #199. Extends `_SCHEMA_HINT` with the JSONB unnest patterns for the 3 `extracted_intelligence` dimensions that have no aggregate counterpart (`tasks`, `responsibilities`, `context`). Unblocks Pair D's `workflow` golden questions for the May 7 demo.

## What changed

`analytics/query_engine/routing.py::_SCHEMA_HINT` now includes:

1. **New "Extracted intelligence (JSONB unnest)" section** documenting:
   - The two-hop join path (`jp -> nj -> ei`)
   - `jsonb_array_elements()` unnest syntax for tasks, responsibilities, context
   - Element-field schemas per dimension (e.g. `task_description, task_category, seniority_signal, confidence`)
   - One worked SQL example per dimension showing GROUP BY + filter patterns
2. **CRITICAL block extended** with a bullet calling out that `tasks/responsibilities/context` columns don't live on `job_postings` — preempts the most likely hallucination (`SELECT task_description FROM dbo.job_postings`).
3. **Comment trail** updated to track #199 alongside #186/#171/#173/#174.

## Why this is safe

- `extracted_intelligence` is **already in `ASK_THE_DATA_ALLOWED_TABLES`** (`sql_guardrails.py:47`) — the guardrail accepts JSONB unnest queries today.
- The unnest patterns are **already documented** in `docs/planning/QA_DATA_CONTRACT.md` §2c-2e — this PR just surfaces them to the LLM via the hint.
- No schema changes, no migration, no data writes. Pure prompt-engineering change.

## Tests

`test_schema_hint_columns.py` extended with **+8 tests**:
- `test_schema_hint_contains_extracted_intelligence_section` — table + 5 dims present
- `test_schema_hint_contains_jsonb_array_elements_pattern` — unnest syntax present for all 3 no-aggregate dims
- `test_schema_hint_documents_two_hop_join_to_extracted_intelligence`
- `test_schema_hint_critical_block_warns_no_jsonb_columns_on_job_postings`
- `test_mock_llm_jsonb_unnest_sql_passes_guardrail` — parametrized × 3 (tasks/responsibilities/context); each unnest query validated end-to-end through the guardrail
- `test_mock_llm_hallucinated_task_column_on_job_postings_passes_guardrail_but_would_fail_at_execute` — documents the layered defense (guardrail is structure-only; the hint prevents generation; `execute_safe` catches column-level violations)

**33/33 tests pass locally** (was 25 before — +8 new).

## Demo impact

| Pair | Intent | Before this PR | After |
|------|--------|----------------|-------|
| D | `workflow` | Refused / hallucinated | Answerable via JSONB unnest |
| A | `emergence` (raw signal) | Limited to aggregate-derived | Can also inspect raw extracted_intelligence for newly-emerging tools/skills not yet in skill_demand_weekly |

The `requires_jsonb_unnest` flag from the Day 2 deck Slide 6 becomes **informational** (still useful for split-baseline reporting) rather than a blocker for Pair D.

## Out of scope (separate work)

- Building aggregate tables for tasks/responsibilities/context (would mirror the skills/tools aggregate pattern; significant lift but better long-term performance than live JSONB unnest at scale).
- GIN indexes on the JSONB columns for query perf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
