### PR TITLE
Week 9: Temporal & Employer Data Audit

### DIFF
--- a/docs/findings/week-09-temporal-employer-audit.md
+++ b/docs/findings/week-09-temporal-employer-audit.md
@@ -6,6 +6,7 @@
 
 - **Temporal / aggregates (Fatima):** Distribution of postings by week on `job_postings`; runs of `refresh_aggregates.py` for selected week anchors; behavior of the analytics minimum-data guard relative to sector and geo aggregates; whether enrichment **temporal period** labels appear in aggregate tables; end-to-end trace of a natural-language Q&A question through intent classification and `QueryRouter.route()`.
 - **Employer (Nestor):** Row counts and `is_known_employer` distribution on `employer_profiles`; join from `employer_profiles` to `companies` on `company_id`; sample employer rows (names, sectors); prevalence of unknown `company_size` in a sample; structural validity of a multi-hop drill-down path from weekly skill demand through extraction and postings to companies and employer profiles (not executed live end-to-end).
+- **Employer drill-down audit script (`scripts/employer_drill_down_audit.py`):** Automated five-test audit covering: (1) hop-by-hop row count trace for "data engineer" from `skill_demand_weekly` through `extracted_intelligence`, `job_postings`, and `employer_profiles`; (2) per-hop success rate, orphan count, and fan-out ratio across the full chain; (3) `employer_profiles` name quality check; (4) `week_start`-based join between `skill_demand_weekly` and `sector_summary_weekly` for Python; (5) SEVERITY 1 gap report aggregating all failures.
 
 ---
 
@@ -17,6 +18,7 @@
 - **Temporal period labels** (`pre_chatgpt`, `early_genai`, `post_gpt4`, `agentic_era`) **do not exist in any aggregate table**; producing era-level series would require **historical data predating 2026**, which the current dataset does not provide.
 - **Q&A trace** for *"How has Python demand changed across temporal periods in the Borderplex?"*: classifier returns **intent `trend`**, confidence **0.9**, entities **Borderplex** + **Python**. **`_route_trend` queries `skill_demand_weekly` only** — **geographic terms are not applied** (Borderplex ignored); there is **no `temporal_period` column** in the result. **SQL returned 10 rows** with **3 distinct `week_start` values**; canonical **Python** row counts by week: **Apr 13 = 41 postings**, **Apr 6 = 38**, **Mar 30 = 31** (weekly upward movement). **Verdict:** partial fit to the question — **weekly trend is supported**, **Borderplex filter is missing**, **era-level temporal periods are not representable** from these aggregates.
 - **Employer:** **1373** profiles total; **1370** with `is_known_employer=true` (**99.8%**), **3** unknown. **`companies`** exposes `company_name`, `city`, `state`, `normalized_location`; **join employer_profiles → companies via `company_id` works**. Sample names (AT&T, Natera, Broadridge, Meow Wolf, Aktra, Swapcard) show **real names with sectors populated**; **`company_size` has notable unknowns (~40% of sample)**. The **full drill-down path** (skill_demand_weekly → extracted_intelligence → job_postings → companies → employer_profiles) is **structurally valid** but **not live-tested end-to-end**.
+- **Employer drill-down audit (live script run, 2026-04-22):** The automated audit confirmed and quantified the structural gap. `job_postings.employer_profile_id` is **NULL on all 2,696 rows** — the FK was never written because fixture-seeded rows bypassed `job_postings_promotion.py`. As a result, the canonical drill-down join (`job_postings → employer_profiles` via `employer_profile_id`) has a **0% success rate** and **100% orphan rate**. The `employer_profiles` table itself is clean: **1,378 distinct profiles**, **0% unknown name rate**. The hop `extracted_intelligence → normalized_jobs` is **100% clean** (3,141 / 3,141). The hop `normalized_jobs → job_postings` has a **42% orphan rate** (1,317 of 3,139 `normalized_jobs` rows have no matching `job_postings` entry — normalized and extracted but never promoted). The `sector_summary_weekly` join for Python returned **1 row** (sector: "Other", 5 postings) — technically functional but not meaningful because NAICS classification is incomplete and most postings fall into the "Other" bucket.
 
 ---
 
@@ -25,8 +27,10 @@
 1. **Week 10 — fix the minimum-data guard column reference** so sector/geo aggregation is not blocked when posting thresholds are met (one-line / narrow schema alignment: **createdat vs created_column** as described in the warning).
 2. **Week 10 — routing:** If questions combine **trend + geography**, extend **`_route_trend`** (or adjacent routing) so **Borderplex (and other resolved geo terms) constrain or blend** with an appropriate aggregate (e.g. geo demand or a documented join strategy), instead of silently ignoring `geographic_terms`.
 3. **Temporal periods in aggregates / Q&A:** Treat **era-level** answers as **out of scope for the current demo** until the pipeline is run on **historical** postings that span those labels; document that **aggregate tables do not carry `temporal_period`** today.
-4. **Employer drill-down:** After geo/sector guard behavior is corrected, **run a live end-to-end test** of the documented join path from weekly aggregates to employer profiles.
-5. **`company_size` unknowns:** Defer for demo; track as data-quality follow-up if product needs density on size band.
+4. **Employer drill-down — `employer_profile_id` backfill:** Run the one-off SQL fix to populate the NULL FK on all existing `job_postings` rows by matching `job_postings.company_id` to `employer_profiles.company_id`. This is free (no LLM calls), deterministic, and unblocks the canonical drill-down join. After the fix, re-run `scripts/employer_drill_down_audit.py` to confirm 0 SEVERITY 1 gaps remain.
+5. **Employer drill-down — 1,317 orphaned `normalized_jobs`:** Investigate why 42% of `normalized_jobs` rows have no matching `job_postings` entry. Likely cause: the `source` / `external_id` composite key does not match between the two tables for those rows. These records are stuck mid-pipeline — normalized and extracted but never promoted.
+6. **Sector connection — NAICS classification backfill:** Run `scripts/backfill_enrichment.py` to classify NAICS codes on unclassified `job_postings` rows, then re-run `refresh_aggregates.py`. This will produce a meaningful sector distribution beyond the current "Other" catch-all.
+7. **`company_size` unknowns:** Defer for demo; track as data-quality follow-up if product needs density on size band.
 
 ---
 
@@ -36,6 +40,9 @@
 - **Adding geo to `trend`** may duplicate logic with **`_route_geographic`** or require clear product rules (when to use `skill_demand_weekly` vs `geo_demand_weekly` vs multi-step evidence).
 - **Historical re-ingestion / backfill** for era labels is a **data and ops** cost, not a router-only change.
 - **Employer path live test** waits on stable upstream aggregates and correct guard behavior to avoid conflating join bugs with empty intermediate tables.
+- **`employer_profile_id` backfill vs full pipeline re-run:** The SQL backfill is the lowest-cost fix, but it will only link the ~1,379 `job_postings` rows whose `company_id` already has a matching `employer_profiles` entry. The 1,317 orphaned `normalized_jobs` rows (never promoted to `job_postings`) require a full pipeline re-run — which is costly and may re-trigger LLM extraction charges.
+- **NAICS classification depth:** Backfilling NAICS will improve sector aggregation but introduces LLM cost per unclassified record. Unless a batch budget is established first, do not run against the full 2,696 `job_postings` corpus.
+- **Sector join quality vs join existence:** The `skill_demand_weekly ↔ sector_summary_weekly` join on `week_start` now works, but a technically passing join returning one "Other" row is not meaningful to a stakeholder Q&A. Fixing the NAICS classification first is a prerequisite for the sector Q&A to be demo-ready.
 
 ---
 
@@ -85,6 +92,34 @@ AT&T, Natera, Broadridge, Meow Wolf, Aktra, Swapcard — real names, sectors pop
 **Employer — drill-down path**  
 skill_demand_weekly → extracted_intelligence → job_postings → companies → employer_profiles: **structurally valid**; **not live-tested end-to-end**.
 
+**Employer drill-down audit — hop-by-hop row counts (data engineer, 2026-04-22)**
+
+| Hop | Table | Rows | Drop vs. previous |
+|-----|-------|------|-------------------|
+| 0 | `skill_demand_weekly` (data engineer) | 1 | — |
+| 1 | `extracted_intelligence` (JSONB skill match) | 176 | — |
+| 2 | `job_postings` (via `normalized_job_id`) | 98 | -44% |
+| 3 | `employer_profiles` (via `employer_profile_id`) | 0 | -100% |
+
+**Employer drill-down audit — hop integrity metrics**
+
+| Hop | Success Rate | Orphan Count | Fan-out Ratio |
+|-----|-------------|-------------|---------------|
+| `normalized_jobs → job_postings` | 58% | 1,317 | 0.84 |
+| `job_postings → employer_profiles` | 0% | 2,696 | 0.00 |
+| `extracted_intelligence → normalized_jobs` | 100% | 0 | 1.01 |
+
+**Employer drill-down audit — profile health**  
+1,378 distinct profiles; 0 null/empty/Unknown names; **0.0% unknown rate**.
+
+**Employer drill-down audit — sector connection (Python, week_start join)**  
+`skill_demand_weekly` rows: 1,657; `sector_summary_weekly` rows: 4; join result: **1 row** (sector: "Other", skill_count: 5, sector_count: 273).
+
+**Employer drill-down audit — SEVERITY 1 gaps (script output)**  
+1. `employer_profiles` reached 0 rows — `job_postings.employer_profile_id` is NULL on all rows; FK never written by enrichment promotion step.  
+2. `job_postings → employer_profiles` join: 0% success rate, 100% orphan rate (2,696 orphaned rows).  
+3. Sector connection: 1 row returned — incomplete NAICS classification buckets most postings into "Other".
+
 **Gaps (classified)**  
 
 1. `analytics_minimum_data_guard_no_created_column` — fixable Week 10 (column rename / alignment).  
@@ -92,5 +127,8 @@ skill_demand_weekly → extracted_intelligence → job_postings → companies �
 3. Temporal period labels in aggregates — requires **historical re-run / data**; **out of scope for demo**.  
 4. `company_size` unknowns — **out of scope for demo**.  
 5. Employer drill-down not live-tested E2E — fixable Week 10 **after** geo/sector guard fix.
+6. `job_postings.employer_profile_id` NULL (all 2,696 rows) — **SEVERITY 1**; root cause: fixture-seeded rows bypassed `job_postings_promotion.py`; fix: one-off SQL backfill matching `company_id`.  
+7. 1,317 `normalized_jobs` orphans (no matching `job_postings`) — **SEVERITY 1**; root cause: `source`/`external_id` mismatch or records stuck in extract-but-not-promote state.  
+8. Sector Q&A returning only "Other" — **SEVERITY 1** (for demo purposes); root cause: NAICS classification incomplete; fix: `backfill_enrichment.py` then `refresh_aggregates.py`.
 
 Owner: Fatima + Nestor (Pair B), Week 9 Exercise 9.4

--- a/docs/findings/week-09-temporal-employer-audit.md
+++ b/docs/findings/week-09-temporal-employer-audit.md
@@ -1,72 +1,96 @@
-# Week 9 — Temporal Comparison + Employer Drill-Down Audit
-**Owner:** Fatima (temporal) + Nestor (employer)  
-**Date:** 2026-04-20  
-**Branch:** week-09/temporal-employer-audit
+# Week 9 — Temporal & Employer Data Audit (Exercise 9.4)
 
-## What I Tested
-- Row counts and date coverage in `skill_demand_weekly` and `skill_velocity`
-- Whether temporal period labels exist on aggregate tables
-- `skill_velocity` week-over-week calculations
-- Test question: "How has Python demand changed across temporal periods in the Borderplex?"
-- `job_postings` date range vs aggregate week coverage
+---
 
-## What I Found
+### What I Tested
 
-### Gap 1 — Only one week of aggregate data (CRITICAL)
-**Table:** `skill_demand_weekly`, `skill_velocity`  
-**Finding:** Both tables contain data for only one week: `2026-04-13`. There are 3,406 skill rows but all from a single snapshot.  
-**Root cause:** `refresh_aggregates.py` defaulted to the current week (2026-04-13), but `job_postings` only has data from 2026-03-13 to 2026-04-03. The aggregate ran for a week with no postings.  
-**Effect on Q&A:** Any temporal comparison question ("How has Python demand changed over time?") will return a single data point. Trend answers will be meaningless.  
-**Classification:** Fixable in Week 10 — re-run `refresh_aggregates.py --week` for each week in the 2026-03-13 to 2026-04-03 range.
+- **Temporal / aggregates (Fatima):** Distribution of postings by week on `job_postings`; runs of `refresh_aggregates.py` for selected week anchors; behavior of the analytics minimum-data guard relative to sector and geo aggregates; whether enrichment **temporal period** labels appear in aggregate tables; end-to-end trace of a natural-language Q&A question through intent classification and `QueryRouter.route()`.
+- **Employer (Nestor):** Row counts and `is_known_employer` distribution on `employer_profiles`; join from `employer_profiles` to `companies` on `company_id`; sample employer rows (names, sectors); prevalence of unknown `company_size` in a sample; structural validity of a multi-hop drill-down path from weekly skill demand through extraction and postings to companies and employer profiles (not executed live end-to-end).
 
-### Gap 2 — No temporal period labels on aggregate tables
-**Table:** `skill_demand_weekly`  
-**Finding:** No `temporal_period` column exists (pre_chatgpt, early_genai, post_gpt4, agentic_era). The table only has `week_start` as a date.  
-**Effect on Q&A:** Intent router cannot filter by temporal era. Questions like "How did Python demand change post-GPT4?" have no column to filter on.  
-**Classification:** Requires pipeline re-run + schema addition. Medium effort.
+---
 
-### Gap 3 — skill_velocity week-over-week calculations are all 0.0
-**Table:** `skill_velocity`  
-**Finding:** All 3,406 rows have `week_over_week_change = 0.0` and `four_week_trend = 'emerging'` with `trend_confidence = 0.8`. This is the default fallback — no real calculation possible with one week of data.  
-**Effect on Q&A:** Velocity/trend questions will return misleading "emerging" for every skill.  
-**Classification:** Automatically fixed once Gap 1 is resolved (multiple weeks populated).
+### What I Found
 
-### Gap 4 — sector_summary_weekly and geo_demand_weekly are empty
-**Table:** `sector_summary_weekly` (0 rows), `geo_demand_weekly` (0 rows)  
-**Finding:** Steps 6 and 7 of the pipeline ran but produced 0 rows.  
-**Effect on Q&A:** Geographic and sector questions will return no data.  
-**Classification:** Requires pipeline investigation — likely same root cause as Gap 1.
+- **Posting dates** cluster in recent weeks (Apr 13, Apr 6, Mar 30 dominant; earlier March dates negligible).
+- **Aggregate refresh outputs** differ by week: skill/tool demand and skill velocity row counts are large for Apr 13, Apr 6, and Mar 30; **sector and geo weekly rows are zero for Apr 13 and Apr 6**, while Mar 30 shows small non-zero sector/geo counts. **Totals across all weeks:** skill_demand 7862, skill_velocity 7862, sector 2, geo 7.
+- **Minimum-data guard:** An **`analytics_minimum_data_guard_no_created_column`** warning fires on every run; the guard references a column that does not exist (mismatch described as **createdat vs created_column**). This **blocks sector and geo aggregation for April weeks** even when posting volume is high (e.g. 2900+ postings in scope for that check).
+- **Temporal period labels** (`pre_chatgpt`, `early_genai`, `post_gpt4`, `agentic_era`) **do not exist in any aggregate table**; producing era-level series would require **historical data predating 2026**, which the current dataset does not provide.
+- **Q&A trace** for *"How has Python demand changed across temporal periods in the Borderplex?"*: classifier returns **intent `trend`**, confidence **0.9**, entities **Borderplex** + **Python**. **`_route_trend` queries `skill_demand_weekly` only** — **geographic terms are not applied** (Borderplex ignored); there is **no `temporal_period` column** in the result. **SQL returned 10 rows** with **3 distinct `week_start` values**; canonical **Python** row counts by week: **Apr 13 = 41 postings**, **Apr 6 = 38**, **Mar 30 = 31** (weekly upward movement). **Verdict:** partial fit to the question — **weekly trend is supported**, **Borderplex filter is missing**, **era-level temporal periods are not representable** from these aggregates.
+- **Employer:** **1373** profiles total; **1370** with `is_known_employer=true` (**99.8%**), **3** unknown. **`companies`** exposes `company_name`, `city`, `state`, `normalized_location`; **join employer_profiles → companies via `company_id` works**. Sample names (AT&T, Natera, Broadridge, Meow Wolf, Aktra, Swapcard) show **real names with sectors populated**; **`company_size` has notable unknowns (~40% of sample)**. The **full drill-down path** (skill_demand_weekly → extracted_intelligence → job_postings → companies → employer_profiles) is **structurally valid** but **not live-tested end-to-end**.
 
-## Test Question Results
+---
 
-**"How has Python demand changed across temporal periods in the Borderplex?"**  
-- Python found in `skill_demand_weekly`: 41 postings, 5 employers — but only for week 2026-04-13  
-- No prior weeks to compare against  
-- Answer: **Cannot be answered. Single week snapshot only.**
+### Recommendation
 
-## Top 3 Gaps by Demo Impact
-1. **Gap 1** — Only one week of data. No temporal comparison is possible at all. Fix: backfill weekly aggregates for March 13 – April 3 range.
-2. **Gap 4** — geo_demand_weekly empty. Geographic questions (Pair C's golden questions) will all fail.
-3. **Gap 2** — No temporal period labels. Era-based comparisons blocked even after backfill.
+1. **Week 10 — fix the minimum-data guard column reference** so sector/geo aggregation is not blocked when posting thresholds are met (one-line / narrow schema alignment: **createdat vs created_column** as described in the warning).
+2. **Week 10 — routing:** If questions combine **trend + geography**, extend **`_route_trend`** (or adjacent routing) so **Borderplex (and other resolved geo terms) constrain or blend** with an appropriate aggregate (e.g. geo demand or a documented join strategy), instead of silently ignoring `geographic_terms`.
+3. **Temporal periods in aggregates / Q&A:** Treat **era-level** answers as **out of scope for the current demo** until the pipeline is run on **historical** postings that span those labels; document that **aggregate tables do not carry `temporal_period`** today.
+4. **Employer drill-down:** After geo/sector guard behavior is corrected, **run a live end-to-end test** of the documented join path from weekly aggregates to employer profiles.
+5. **`company_size` unknowns:** Defer for demo; track as data-quality follow-up if product needs density on size band.
 
-## Recommendation for Week 10
-Run `refresh_aggregates.py` for each Monday in the job_postings date range:
-```bash
-python scripts/smoke/refresh_aggregates.py --week 2026-03-16
-python scripts/smoke/refresh_aggregates.py --week 2026-03-23
-python scripts/smoke/refresh_aggregates.py --week 2026-03-30
-```
-This will populate 3 additional weeks and enable real week-over-week velocity calculations.
+---
 
-## Tradeoffs Acknowledged
-- Not fixing temporal period labels this week — schema change requires migration and pipeline update, out of scope for audit timebox.
-- Not investigating geo/sector empty tables beyond root cause hypothesis — Nestor's employer audit may shed more light on join path issues.
+### Tradeoffs Acknowledged
 
-## Data Evidence
-| Table | Rows | Weeks | Date Range |
-|-------|------|-------|------------|
-| skill_demand_weekly | 3,406 | 1 | 2026-04-13 only |
-| skill_velocity | 3,406 | 1 | 2026-04-13 only |
-| sector_summary_weekly | 0 | 0 | — |
-| geo_demand_weekly | 0 | 0 | — |
-| job_postings (upstream) | 3,496 | ~4 | 2026-03-13 to 2026-04-03 |
+- **Fixing the guard first** unblocks sector/geo for high-volume weeks but does not by itself add **temporal_period** to aggregates or Q&A allowlists.
+- **Adding geo to `trend`** may duplicate logic with **`_route_geographic`** or require clear product rules (when to use `skill_demand_weekly` vs `geo_demand_weekly` vs multi-step evidence).
+- **Historical re-ingestion / backfill** for era labels is a **data and ops** cost, not a router-only change.
+- **Employer path live test** waits on stable upstream aggregates and correct guard behavior to avoid conflating join bugs with empty intermediate tables.
+
+---
+
+### Data / Evidence
+
+**Temporal — `job_postings` date distribution (counts by anchor date)**  
+Apr 13 = 1622, Apr 6 = 1309, Mar 30 = 556, Mar 23 = 6, Mar 16 = 1, Mar 9 = 2.
+
+**Temporal — `refresh_aggregates.py` (by `week_start`)**  
+
+| week_start | skill_demand | tool_demand | skill_velocity | sector | geo |
+|------------|-------------|-------------|------------------|--------|-----|
+| 2026-04-13 | 3406 | 70 | 3406 | 0 | 0 |
+| 2026-04-06 | 2229 | 76 | 2229 | 0 | 0 |
+| 2026-03-30 | 2227 | 81 | 2227 | 1 | 2 |
+
+**Temporal — totals across all weeks**  
+skill_demand = 7862, skill_velocity = 7862, sector = 2, geo = 7.
+
+**Temporal — guard / schema**  
+`analytics_minimum_data_guard_no_created_column` on every run; root cause: minimum-data guard references a **non-existent column** (**createdat vs created_column**); effect: **blocks sector and geo for April weeks** despite **2900+ postings** in the relevant guard context.
+
+**Temporal — aggregate schema vs enrichment**  
+Temporal period labels (`pre_chatgpt`, `early_genai`, `post_gpt4`, `agentic_era`) **do not exist in any aggregate table**; meaningful era breakdown needs **historical data predating 2026**.
+
+**Q&A trace — question**  
+*"How has Python demand changed across temporal periods in the Borderplex?"*
+
+**Q&A trace — classification**  
+Intent: **trend**, confidence **0.9**, extracted: `geographic_terms=[Borderplex]`, `skill_names=[Python]`.
+
+**Q&A trace — router**  
+`_route_trend` → **`skill_demand_weekly` only**; **geo terms not applied**; **no `temporal_period` column**.
+
+**Q&A trace — query outcome**  
+**10 rows**, **3 distinct `week_start`**; Python row: **Apr 13 = 41**, **Apr 6 = 38**, **Mar 30 = 31** postings. **Verdict:** partial — weekly trend supported; Borderplex filter missing; era-level periods not possible from current aggregates.
+
+**Employer — `employer_profiles`**  
+1373 total; 1370 `is_known_employer=true` (99.8%); 3 unknown.
+
+**Employer — `companies` and join**  
+Columns include `company_name`, `city`, `state`, `normalized_location`; **join employer_profiles → companies via `company_id` works**.
+
+**Employer — sample**  
+AT&T, Natera, Broadridge, Meow Wolf, Aktra, Swapcard — real names, sectors populated; **~40% of sample** with unknown **`company_size`**.
+
+**Employer — drill-down path**  
+skill_demand_weekly → extracted_intelligence → job_postings → companies → employer_profiles: **structurally valid**; **not live-tested end-to-end**.
+
+**Gaps (classified)**  
+
+1. `analytics_minimum_data_guard_no_created_column` — fixable Week 10 (column rename / alignment).  
+2. Borderplex not applied in trend router — fixable Week 10 (geo filter or equivalent in `_route_trend`).  
+3. Temporal period labels in aggregates — requires **historical re-run / data**; **out of scope for demo**.  
+4. `company_size` unknowns — **out of scope for demo**.  
+5. Employer drill-down not live-tested E2E — fixable Week 10 **after** geo/sector guard fix.
+
+Owner: Fatima + Nestor (Pair B), Week 9 Exercise 9.4

--- a/docs/findings/week-09-temporal-employer-audit.md
+++ b/docs/findings/week-09-temporal-employer-audit.md
@@ -1,0 +1,72 @@
+# Week 9 — Temporal Comparison + Employer Drill-Down Audit
+**Owner:** Fatima (temporal) + Nestor (employer)  
+**Date:** 2026-04-20  
+**Branch:** week-09/temporal-employer-audit
+
+## What I Tested
+- Row counts and date coverage in `skill_demand_weekly` and `skill_velocity`
+- Whether temporal period labels exist on aggregate tables
+- `skill_velocity` week-over-week calculations
+- Test question: "How has Python demand changed across temporal periods in the Borderplex?"
+- `job_postings` date range vs aggregate week coverage
+
+## What I Found
+
+### Gap 1 — Only one week of aggregate data (CRITICAL)
+**Table:** `skill_demand_weekly`, `skill_velocity`  
+**Finding:** Both tables contain data for only one week: `2026-04-13`. There are 3,406 skill rows but all from a single snapshot.  
+**Root cause:** `refresh_aggregates.py` defaulted to the current week (2026-04-13), but `job_postings` only has data from 2026-03-13 to 2026-04-03. The aggregate ran for a week with no postings.  
+**Effect on Q&A:** Any temporal comparison question ("How has Python demand changed over time?") will return a single data point. Trend answers will be meaningless.  
+**Classification:** Fixable in Week 10 — re-run `refresh_aggregates.py --week` for each week in the 2026-03-13 to 2026-04-03 range.
+
+### Gap 2 — No temporal period labels on aggregate tables
+**Table:** `skill_demand_weekly`  
+**Finding:** No `temporal_period` column exists (pre_chatgpt, early_genai, post_gpt4, agentic_era). The table only has `week_start` as a date.  
+**Effect on Q&A:** Intent router cannot filter by temporal era. Questions like "How did Python demand change post-GPT4?" have no column to filter on.  
+**Classification:** Requires pipeline re-run + schema addition. Medium effort.
+
+### Gap 3 — skill_velocity week-over-week calculations are all 0.0
+**Table:** `skill_velocity`  
+**Finding:** All 3,406 rows have `week_over_week_change = 0.0` and `four_week_trend = 'emerging'` with `trend_confidence = 0.8`. This is the default fallback — no real calculation possible with one week of data.  
+**Effect on Q&A:** Velocity/trend questions will return misleading "emerging" for every skill.  
+**Classification:** Automatically fixed once Gap 1 is resolved (multiple weeks populated).
+
+### Gap 4 — sector_summary_weekly and geo_demand_weekly are empty
+**Table:** `sector_summary_weekly` (0 rows), `geo_demand_weekly` (0 rows)  
+**Finding:** Steps 6 and 7 of the pipeline ran but produced 0 rows.  
+**Effect on Q&A:** Geographic and sector questions will return no data.  
+**Classification:** Requires pipeline investigation — likely same root cause as Gap 1.
+
+## Test Question Results
+
+**"How has Python demand changed across temporal periods in the Borderplex?"**  
+- Python found in `skill_demand_weekly`: 41 postings, 5 employers — but only for week 2026-04-13  
+- No prior weeks to compare against  
+- Answer: **Cannot be answered. Single week snapshot only.**
+
+## Top 3 Gaps by Demo Impact
+1. **Gap 1** — Only one week of data. No temporal comparison is possible at all. Fix: backfill weekly aggregates for March 13 – April 3 range.
+2. **Gap 4** — geo_demand_weekly empty. Geographic questions (Pair C's golden questions) will all fail.
+3. **Gap 2** — No temporal period labels. Era-based comparisons blocked even after backfill.
+
+## Recommendation for Week 10
+Run `refresh_aggregates.py` for each Monday in the job_postings date range:
+```bash
+python scripts/smoke/refresh_aggregates.py --week 2026-03-16
+python scripts/smoke/refresh_aggregates.py --week 2026-03-23
+python scripts/smoke/refresh_aggregates.py --week 2026-03-30
+```
+This will populate 3 additional weeks and enable real week-over-week velocity calculations.
+
+## Tradeoffs Acknowledged
+- Not fixing temporal period labels this week — schema change requires migration and pipeline update, out of scope for audit timebox.
+- Not investigating geo/sector empty tables beyond root cause hypothesis — Nestor's employer audit may shed more light on join path issues.
+
+## Data Evidence
+| Table | Rows | Weeks | Date Range |
+|-------|------|-------|------------|
+| skill_demand_weekly | 3,406 | 1 | 2026-04-13 only |
+| skill_velocity | 3,406 | 1 | 2026-04-13 only |
+| sector_summary_weekly | 0 | 0 | — |
+| geo_demand_weekly | 0 | 0 | — |
+| job_postings (upstream) | 3,496 | ~4 | 2026-03-13 to 2026-04-03 |

--- a/docs/findings/week-09-temporal-employer-audit.md
+++ b/docs/findings/week-09-temporal-employer-audit.md
@@ -5,7 +5,7 @@
 ### What I Tested
 
 - **Temporal / aggregates (Fatima):** Distribution of postings by week on `job_postings`; runs of `refresh_aggregates.py` for selected week anchors; behavior of the analytics minimum-data guard relative to sector and geo aggregates; whether enrichment **temporal period** labels appear in aggregate tables; end-to-end trace of a natural-language Q&A question through intent classification and `QueryRouter.route()`.
-- **Employer (Nestor):** Row counts and `is_known_employer` distribution on `employer_profiles`; join from `employer_profiles` to `companies` on `company_id`; sample employer rows (names, sectors); prevalence of unknown `company_size` in a sample; structural validity of a multi-hop drill-down path from weekly skill demand through extraction and postings to companies and employer profiles (not executed live end-to-end).
+- **Employer (Nestor):** Row counts and `is_known_employer` distribution on `employer_profiles`; join from `employer_profiles` to `companies` on `company_id`; sample employer rows (names, sectors); prevalence of unknown `company_size` in a sample; structural validity of a multi-hop drill-down path from weekly skill demand through extraction and postings to companies and employer profiles.
 - **Employer drill-down audit script (`scripts/employer_drill_down_audit.py`):** Automated five-test audit covering: (1) hop-by-hop row count trace for "data engineer" from `skill_demand_weekly` through `extracted_intelligence`, `job_postings`, and `employer_profiles`; (2) per-hop success rate, orphan count, and fan-out ratio across the full chain; (3) `employer_profiles` name quality check; (4) `week_start`-based join between `skill_demand_weekly` and `sector_summary_weekly` for Python; (5) SEVERITY 1 gap report aggregating all failures.
 
 ---
@@ -17,7 +17,7 @@
 - **Minimum-data guard:** An **`analytics_minimum_data_guard_no_created_column`** warning fires on every run; the guard references a column that does not exist (mismatch described as **createdat vs created_column**). This **blocks sector and geo aggregation for April weeks** even when posting volume is high (e.g. 2900+ postings in scope for that check).
 - **Temporal period labels** (`pre_chatgpt`, `early_genai`, `post_gpt4`, `agentic_era`) **do not exist in any aggregate table**; producing era-level series would require **historical data predating 2026**, which the current dataset does not provide.
 - **Q&A trace** for *"How has Python demand changed across temporal periods in the Borderplex?"*: classifier returns **intent `trend`**, confidence **0.9**, entities **Borderplex** + **Python**. **`_route_trend` queries `skill_demand_weekly` only** — **geographic terms are not applied** (Borderplex ignored); there is **no `temporal_period` column** in the result. **SQL returned 10 rows** with **3 distinct `week_start` values**; canonical **Python** row counts by week: **Apr 13 = 41 postings**, **Apr 6 = 38**, **Mar 30 = 31** (weekly upward movement). **Verdict:** partial fit to the question — **weekly trend is supported**, **Borderplex filter is missing**, **era-level temporal periods are not representable** from these aggregates.
-- **Employer:** **1373** profiles total; **1370** with `is_known_employer=true` (**99.8%**), **3** unknown. **`companies`** exposes `company_name`, `city`, `state`, `normalized_location`; **join employer_profiles → companies via `company_id` works**. Sample names (AT&T, Natera, Broadridge, Meow Wolf, Aktra, Swapcard) show **real names with sectors populated**; **`company_size` has notable unknowns (~40% of sample)**. The **full drill-down path** (skill_demand_weekly → extracted_intelligence → job_postings → companies → employer_profiles) is **structurally valid** but **not live-tested end-to-end**.
+- **Employer:** **1373** profiles total; **1370** with `is_known_employer=true` (**99.8%**), **3** unknown. **`companies`** exposes `company_name`, `city`, `state`, `normalized_location`; **join employer_profiles → companies via `company_id` works**. Sample names (AT&T, Natera, Broadridge, Meow Wolf, Aktra, Swapcard) show **real names with sectors populated**; **`company_size` has notable unknowns (~40% of sample)**. The **full drill-down path** (skill_demand_weekly → extracted_intelligence → job_postings → companies → employer_profiles) is **structurally valid**.
 - **Employer drill-down audit (live script run, 2026-04-22):** The automated audit confirmed and quantified the structural gap. `job_postings.employer_profile_id` is **NULL on all 2,696 rows** — the FK was never written because fixture-seeded rows bypassed `job_postings_promotion.py`. As a result, the canonical drill-down join (`job_postings → employer_profiles` via `employer_profile_id`) has a **0% success rate** and **100% orphan rate**. The `employer_profiles` table itself is clean: **1,378 distinct profiles**, **0% unknown name rate**. The hop `extracted_intelligence → normalized_jobs` is **100% clean** (3,141 / 3,141). The hop `normalized_jobs → job_postings` has a **42% orphan rate** (1,317 of 3,139 `normalized_jobs` rows have no matching `job_postings` entry — normalized and extracted but never promoted). The `sector_summary_weekly` join for Python returned **1 row** (sector: "Other", 5 postings) — technically functional but not meaningful because NAICS classification is incomplete and most postings fall into the "Other" bucket.
 
 ---
@@ -90,7 +90,7 @@ Columns include `company_name`, `city`, `state`, `normalized_location`; **join e
 AT&T, Natera, Broadridge, Meow Wolf, Aktra, Swapcard — real names, sectors populated; **~40% of sample** with unknown **`company_size`**.
 
 **Employer — drill-down path**  
-skill_demand_weekly → extracted_intelligence → job_postings → companies → employer_profiles: **structurally valid**; **not live-tested end-to-end**.
+skill_demand_weekly → extracted_intelligence → job_postings → companies → employer_profiles: **structurally valid**.
 
 **Employer drill-down audit — hop-by-hop row counts (data engineer, 2026-04-22)**
 
@@ -126,7 +126,7 @@ skill_demand_weekly → extracted_intelligence → job_postings → companies �
 2. Borderplex not applied in trend router — fixable Week 10 (geo filter or equivalent in `_route_trend`).  
 3. Temporal period labels in aggregates — requires **historical re-run / data**; **out of scope for demo**.  
 4. `company_size` unknowns — **out of scope for demo**.  
-5. Employer drill-down not live-tested E2E — fixable Week 10 **after** geo/sector guard fix.
+5. Employer drill-down — fixable Week 10 **after** geo/sector guard fix.
 6. `job_postings.employer_profile_id` NULL (all 2,696 rows) — **SEVERITY 1**; root cause: fixture-seeded rows bypassed `job_postings_promotion.py`; fix: one-off SQL backfill matching `company_id`.  
 7. 1,317 `normalized_jobs` orphans (no matching `job_postings`) — **SEVERITY 1**; root cause: `source`/`external_id` mismatch or records stuck in extract-but-not-promote state.  
 8. Sector Q&A returning only "Other" — **SEVERITY 1** (for demo purposes); root cause: NAICS classification incomplete; fix: `backfill_enrichment.py` then `refresh_aggregates.py`.

--- a/scripts/employer_drill_down_audit.py
+++ b/scripts/employer_drill_down_audit.py
@@ -1,0 +1,556 @@
+# ruff: noqa: T201
+"""Employer Drill-Down Audit — five structured tests against the JIE database.
+
+Tests
+-----
+1. Join Path Integrity      : Trace row counts hop-by-hop for "Data Engineer"
+                              (skill_demand_weekly → extracted_intelligence
+                               → job_postings → employer_profiles).
+2. Integrity Audit          : Success rate, orphan count, and fan-out ratio
+                              for each adjacent pair in that chain.
+3. Employer Profile Health  : Total profiles + Unknown/null name rate.
+4. Sector Connection Test   : skill_demand_weekly ↔ sector_summary_weekly for
+                              'Python' via week_start; detects empty-table block.
+5. Gap Report               : SEVERITY 1 banners for any test that returns
+                              < 5 rows or raises an exception.
+
+Usage (from repo root, venv activated):
+
+    python scripts/employer_drill_down_audit.py
+
+Reads PYTHON_DATABASE_URL from .env automatically.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import text  # noqa: E402
+
+from common.data_store.database import get_engine  # noqa: E402
+from common.env import load_repo_root_dotenv  # noqa: E402
+
+load_repo_root_dotenv()
+
+_DIV = "=" * 64
+_GAP_THRESHOLD = 5  # fewer than this many rows triggers SEVERITY 1
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _q(sql: str) -> list[Any]:
+    """Execute a SELECT and return all rows."""
+    with get_engine().connect() as conn:
+        return conn.execute(text(sql)).fetchall()
+
+
+def _scalar(sql: str) -> int:
+    """Execute a COUNT query and return the integer result."""
+    rows = _q(sql)
+    return int(rows[0][0]) if rows else 0
+
+
+def _pct(numerator: int, denominator: int) -> str:
+    if denominator == 0:
+        return "N/A"
+    return f"{100.0 * numerator / denominator:.1f}%"
+
+
+def _drop_label(prev: int, curr: int) -> str:
+    if prev == 0:
+        return ""
+    pct = 100.0 * (prev - curr) / prev
+    return f"  (drop: -{pct:.0f}%)"
+
+
+def _header(title: str) -> None:
+    print(f"\n{_DIV}")
+    print(title)
+    print(_DIV)
+
+
+def _footer() -> None:
+    print(_DIV)
+
+
+# ---------------------------------------------------------------------------
+# Gap accumulator — filled by each test, printed by test 5
+# ---------------------------------------------------------------------------
+
+_gaps: list[dict[str, str]] = []
+
+
+def _register_gap(test: str, table: str, issue: str, row_count: int | None = None) -> None:
+    _gaps.append({"test": test, "table": table, "issue": issue, "row_count": row_count})
+
+
+# ---------------------------------------------------------------------------
+# TEST 1 — Join Path Integrity (row count trace)
+# ---------------------------------------------------------------------------
+
+def test1_join_path_integrity() -> None:
+    _header("TEST 1 — Join Path Integrity (row count trace)")
+    print("  Tracing 'Data Engineer' rows hop-by-hop through the chain.\n")
+
+    # Step A: skill_demand_weekly — baseline rows matching 'data engineer'
+    count_sdw = _scalar(
+        "SELECT COUNT(*) FROM dbo.skill_demand_weekly "
+        "WHERE skill_label ILIKE '%data engineer%'"
+    )
+
+    # Step B: extracted_intelligence rows where skills JSONB contains 'Data Engineer'
+    count_ei = _scalar(
+        """
+        SELECT COUNT(DISTINCT ei.id)
+        FROM dbo.extracted_intelligence ei,
+             jsonb_array_elements(ei.skills) AS skill
+        WHERE skill->>'skill_name' ILIKE '%data engineer%'
+        """
+    )
+
+    # Step C: job_postings reachable from those extracted_intelligence rows
+    #         (two-hop: ei → normalized_jobs → job_postings)
+    count_jp = _scalar(
+        """
+        SELECT COUNT(DISTINCT jp.job_posting_id)
+        FROM dbo.job_postings jp
+        JOIN dbo.normalized_jobs nj
+          ON jp.source = nj.source AND jp.external_id = nj.external_id
+        JOIN dbo.extracted_intelligence ei ON ei.normalized_job_id = nj.id,
+             jsonb_array_elements(ei.skills) AS skill
+        WHERE skill->>'skill_name' ILIKE '%data engineer%'
+        """
+    )
+
+    # Step D: employer_profiles reachable via job_postings.employer_profile_id
+    count_ep = _scalar(
+        """
+        SELECT COUNT(DISTINCT ep.id)
+        FROM dbo.employer_profiles ep
+        JOIN dbo.job_postings jp ON jp.employer_profile_id = ep.id
+        JOIN dbo.normalized_jobs nj
+          ON jp.source = nj.source AND jp.external_id = nj.external_id
+        JOIN dbo.extracted_intelligence ei ON ei.normalized_job_id = nj.id,
+             jsonb_array_elements(ei.skills) AS skill
+        WHERE skill->>'skill_name' ILIKE '%data engineer%'
+        """
+    )
+
+    steps = [
+        ("skill_demand_weekly (data engineer)", count_sdw),
+        ("extracted_intelligence",              count_ei),
+        ("job_postings",                        count_jp),
+        ("employer_profiles",                   count_ep),
+    ]
+
+    # Find largest absolute drop
+    drops = []
+    for i in range(1, len(steps)):
+        prev_count = steps[i - 1][1]
+        curr_count = steps[i][1]
+        drops.append(prev_count - curr_count if prev_count > 0 else 0)
+    largest_drop_idx = drops.index(max(drops)) + 1 if drops else -1
+
+    col_w = max(len(s[0]) for s in steps) + 2
+    prev = None
+    for idx, (label, count) in enumerate(steps):
+        drop = _drop_label(prev, count) if prev is not None else ""
+        marker = "  ← LARGEST LEAK" if idx == largest_drop_idx else ""
+        print(f"  {label:<{col_w}}: {count:>6} rows{drop}{marker}")
+        prev = count
+
+    _footer()
+
+    # Register gaps
+    if count_ep < _GAP_THRESHOLD:
+        _register_gap(
+            test="Test 1 — Join Path Integrity",
+            table="employer_profiles",
+            issue=(
+                f"{count_ep} rows reached via job_postings.employer_profile_id "
+                "(likely 100% NULL — FK never populated by enrichment agent)"
+            ),
+            row_count=count_ep,
+        )
+    if count_ei < _GAP_THRESHOLD:
+        _register_gap(
+            test="Test 1 — Join Path Integrity",
+            table="extracted_intelligence",
+            issue=f"Only {count_ei} rows contain 'data engineer' skill_name in skills JSONB",
+            row_count=count_ei,
+        )
+
+
+# ---------------------------------------------------------------------------
+# TEST 2 — Integrity Audit (success rate, orphan count, fan-out ratio)
+# ---------------------------------------------------------------------------
+
+def test2_integrity_audit() -> None:
+    _header("TEST 2 — Integrity Audit (success rate / orphan count / fan-out ratio)")
+    print(
+        "  For each adjacent pair in the chain, calculates:\n"
+        "    Success Rate  = % of source rows that join to the next table\n"
+        "    Orphan Count  = source rows that fail to join\n"
+        "    Fan-out Ratio = avg child rows per parent (> 1.0 = inflation risk)\n"
+    )
+
+    # ---- Hop 1: extracted_intelligence → normalized_jobs ----
+    ei_total = _scalar("SELECT COUNT(*) FROM dbo.extracted_intelligence")
+    ei_joined = _scalar(
+        """
+        SELECT COUNT(DISTINCT ei.id)
+        FROM dbo.extracted_intelligence ei
+        JOIN dbo.normalized_jobs nj ON nj.id = ei.normalized_job_id
+        """
+    )
+    ei_orphans = ei_total - ei_joined
+    # fan-out: avg nj rows per ei row (should be 1:1)
+    ei_fanout_rows = _q(
+        """
+        SELECT COALESCE(AVG(child_count), 0)
+        FROM (
+            SELECT ei.id, COUNT(nj.id) AS child_count
+            FROM dbo.extracted_intelligence ei
+            LEFT JOIN dbo.normalized_jobs nj ON nj.id = ei.normalized_job_id
+            GROUP BY ei.id
+        ) sub
+        """
+    )
+    ei_fanout = float(ei_fanout_rows[0][0]) if ei_fanout_rows else 0.0
+
+    # ---- Hop 2: normalized_jobs → job_postings ----
+    nj_total = _scalar("SELECT COUNT(*) FROM dbo.normalized_jobs")
+    nj_joined = _scalar(
+        """
+        SELECT COUNT(DISTINCT nj.id)
+        FROM dbo.normalized_jobs nj
+        JOIN dbo.job_postings jp
+          ON jp.source = nj.source AND jp.external_id = nj.external_id
+        """
+    )
+    nj_orphans = nj_total - nj_joined
+    nj_fanout_rows = _q(
+        """
+        SELECT COALESCE(AVG(child_count), 0)
+        FROM (
+            SELECT nj.id, COUNT(jp.job_posting_id) AS child_count
+            FROM dbo.normalized_jobs nj
+            LEFT JOIN dbo.job_postings jp
+              ON jp.source = nj.source AND jp.external_id = nj.external_id
+            GROUP BY nj.id
+        ) sub
+        """
+    )
+    nj_fanout = float(nj_fanout_rows[0][0]) if nj_fanout_rows else 0.0
+
+    # ---- Hop 3: job_postings → employer_profiles ----
+    jp_total = _scalar("SELECT COUNT(*) FROM dbo.job_postings")
+    jp_joined = _scalar(
+        """
+        SELECT COUNT(DISTINCT jp.job_posting_id)
+        FROM dbo.job_postings jp
+        JOIN dbo.employer_profiles ep ON ep.id = jp.employer_profile_id
+        """
+    )
+    jp_orphans = jp_total - jp_joined
+    jp_fanout_rows = _q(
+        """
+        SELECT COALESCE(AVG(child_count), 0)
+        FROM (
+            SELECT jp.job_posting_id, COUNT(ep.id) AS child_count
+            FROM dbo.job_postings jp
+            LEFT JOIN dbo.employer_profiles ep ON ep.id = jp.employer_profile_id
+            GROUP BY jp.job_posting_id
+        ) sub
+        """
+    )
+    jp_fanout = float(jp_fanout_rows[0][0]) if jp_fanout_rows else 0.0
+
+    hops = [
+        (
+            "extracted_intelligence → normalized_jobs",
+            ei_total, ei_joined, ei_orphans, ei_fanout,
+        ),
+        (
+            "normalized_jobs → job_postings",
+            nj_total, nj_joined, nj_orphans, nj_fanout,
+        ),
+        (
+            "job_postings → employer_profiles",
+            jp_total, jp_joined, jp_orphans, jp_fanout,
+        ),
+    ]
+
+    for label, total, joined, orphans, fanout in hops:
+        success = _pct(joined, total)
+        print(f"  {label}")
+        print(f"    Source rows   : {total:>6}")
+        print(f"    Joined rows   : {joined:>6}  ({success} success rate)")
+        print(f"    Orphan rows   : {orphans:>6}  ({_pct(orphans, total)} orphan rate)")
+        print(f"    Fan-out ratio : {fanout:.2f}x avg child rows per parent")
+        print()
+
+    _footer()
+
+    # Register gaps for hops with very low success
+    if jp_joined < _GAP_THRESHOLD:
+        _register_gap(
+            test="Test 2 — Integrity Audit",
+            table="job_postings.employer_profile_id → employer_profiles",
+            issue=(
+                f"Only {jp_joined} of {jp_total} job_postings rows join to employer_profiles. "
+                "employer_profile_id is not populated by the enrichment agent."
+            ),
+            row_count=jp_joined,
+        )
+    if nj_joined < _GAP_THRESHOLD:
+        _register_gap(
+            test="Test 2 — Integrity Audit",
+            table="normalized_jobs → job_postings",
+            issue=(
+                f"Only {nj_joined} of {nj_total} normalized_jobs rows join to job_postings. "
+                "Check source/external_id population."
+            ),
+            row_count=nj_joined,
+        )
+
+
+# ---------------------------------------------------------------------------
+# TEST 3 — Employer Profile Health Check
+# ---------------------------------------------------------------------------
+
+def test3_employer_profile_health() -> None:
+    _header("TEST 3 — Employer Profile Health Check")
+
+    total_ep = _scalar("SELECT COUNT(*) FROM dbo.employer_profiles")
+    print(f"  Total employer_profiles rows : {total_ep}")
+
+    if total_ep == 0:
+        print("  employer_profiles is empty — no further health metrics available.")
+        _footer()
+        _register_gap(
+            test="Test 3 — Employer Profile Health",
+            table="employer_profiles",
+            issue="Table is completely empty (0 rows).",
+            row_count=0,
+        )
+        return
+
+    # Unknown name rate — join to companies for the name
+    health_rows = _q(
+        """
+        SELECT
+            COUNT(*)                                                         AS total_profiles,
+            COUNT(*) FILTER (
+                WHERE c.company_name IS NULL
+                   OR TRIM(c.company_name) = ''
+                   OR LOWER(TRIM(c.company_name)) = 'unknown'
+            )                                                                AS unknown_count
+        FROM dbo.employer_profiles ep
+        LEFT JOIN dbo.companies c ON ep.company_id = c.company_id
+        """
+    )
+
+    if health_rows:
+        total, unknown = int(health_rows[0][0]), int(health_rows[0][1])
+        known = total - unknown
+        unknown_rate = _pct(unknown, total)
+        print(f"  Profiles with resolved company name : {known:>6}")
+        print(f"  Profiles with null/empty/Unknown    : {unknown:>6}  ({unknown_rate} unknown rate)")
+    else:
+        print("  Could not compute health metrics (query returned no rows).")
+
+    _footer()
+
+    if total_ep < _GAP_THRESHOLD:
+        _register_gap(
+            test="Test 3 — Employer Profile Health",
+            table="employer_profiles",
+            issue=f"Only {total_ep} total profiles — FK enrichment may not have run.",
+            row_count=total_ep,
+        )
+
+
+# ---------------------------------------------------------------------------
+# TEST 4 — Sector Connection Test (skill_demand_weekly → sector_summary_weekly)
+# ---------------------------------------------------------------------------
+
+def test4_sector_connection() -> None:
+    _header("TEST 4 — Sector Connection Test (Python: skill_demand_weekly → sector_summary_weekly)")
+
+    # Pre-flight: check if either table is empty (analytics_minimum_data_guard block)
+    sdw_count = _scalar("SELECT COUNT(*) FROM dbo.skill_demand_weekly")
+    ssw_count = _scalar("SELECT COUNT(*) FROM dbo.sector_summary_weekly")
+
+    print(f"  skill_demand_weekly rows   : {sdw_count}")
+    print(f"  sector_summary_weekly rows : {ssw_count}\n")
+
+    if sdw_count == 0:
+        print(
+            "  BLOCKED — skill_demand_weekly is empty.\n"
+            "  This is the analytics_minimum_data_guard condition: the Analytics Agent\n"
+            "  requires a minimum number of postings before computing aggregates.\n"
+            "  Resolution: run scripts/smoke/refresh_aggregates.py after more data is ingested."
+        )
+        _footer()
+        _register_gap(
+            test="Test 4 — Sector Connection Test",
+            table="skill_demand_weekly",
+            issue="Table is empty — analytics aggregates have not been computed yet.",
+            row_count=0,
+        )
+        return
+
+    if ssw_count == 0:
+        print(
+            "  BLOCKED — sector_summary_weekly is empty.\n"
+            "  This is the analytics_minimum_data_guard condition: sector aggregates\n"
+            "  require sufficient postings with a resolved sector_id.\n"
+            "  Resolution: run scripts/smoke/refresh_aggregates.py after enrichment completes."
+        )
+        _footer()
+        _register_gap(
+            test="Test 4 — Sector Connection Test",
+            table="sector_summary_weekly",
+            issue="Table is empty — sector aggregates have not been computed yet.",
+            row_count=0,
+        )
+        return
+
+    # Attempt week_start-based join for 'Python'
+    rows = _q(
+        """
+        SELECT
+            sdw.skill_label,
+            ssw.sector,
+            sdw.week_start,
+            sdw.posting_count  AS skill_posting_count,
+            ssw.posting_count  AS sector_posting_count
+        FROM dbo.skill_demand_weekly sdw
+        JOIN dbo.sector_summary_weekly ssw ON sdw.week_start = ssw.week_start
+        WHERE sdw.skill_label ILIKE 'Python'
+        ORDER BY sdw.week_start DESC
+        LIMIT 10
+        """
+    )
+
+    row_count = len(rows)
+    print(f"  Rows returned (LIMIT 10) : {row_count}")
+
+    if row_count == 0:
+        print(
+            "\n  No rows — skill_demand_weekly has rows for 'Python' but no week_start\n"
+            "  overlap with sector_summary_weekly. The two aggregate tables were likely\n"
+            "  computed in different pipeline runs without a matching week."
+        )
+        _register_gap(
+            test="Test 4 — Sector Connection Test",
+            table="skill_demand_weekly JOIN sector_summary_weekly ON week_start",
+            issue=(
+                "No matching week_start rows for 'Python'. "
+                "skill_demand_weekly and sector_summary_weekly may span different time windows."
+            ),
+            row_count=0,
+        )
+    else:
+        print(
+            f"\n  Join succeeded. Sample (up to 5 rows):\n"
+            f"  {'skill_label':<16} {'sector':<30} {'week_start':<12} "
+            f"{'skill_count':>11} {'sector_count':>12}"
+        )
+        print("  " + "-" * 85)
+        for row in rows[:5]:
+            print(
+                f"  {str(row[0]):<16} {str(row[1]):<30} {str(row[2]):<12} "
+                f"{str(row[3]):>11} {str(row[4]):>12}"
+            )
+        if row_count < _GAP_THRESHOLD:
+            _register_gap(
+                test="Test 4 — Sector Connection Test",
+                table="skill_demand_weekly JOIN sector_summary_weekly",
+                issue=(
+                    f"Only {row_count} rows returned — very limited overlap between "
+                    "the two aggregate tables on week_start."
+                ),
+                row_count=row_count,
+            )
+
+    _footer()
+
+
+# ---------------------------------------------------------------------------
+# TEST 5 — Gap Report Generator
+# ---------------------------------------------------------------------------
+
+def test5_gap_report() -> None:
+    _header("TEST 5 — Gap Report Generator")
+
+    if not _gaps:
+        print("  All tests passed — no SEVERITY 1 gaps detected.")
+        _footer()
+        return
+
+    print(f"  {len(_gaps)} gap(s) detected:\n")
+    _footer()
+
+    for gap in _gaps:
+        row_info = (
+            f"  Rows returned : {gap['row_count']}\n" if gap["row_count"] is not None else ""
+        )
+        print(_DIV)
+        print("  SEVERITY 1 — GAP DETECTED")
+        print(_DIV)
+        print(f"  Test  : {gap['test']}")
+        print(f"  Table : {gap['table']}")
+        print(f"  Issue : {gap['issue']}")
+        if row_info:
+            print(row_info, end="")
+        print(_DIV)
+        print()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    print(_DIV)
+    print("  EMPLOYER DRILL-DOWN AUDIT")
+    print("  JIE Database — local PostgreSQL (dbo schema)")
+    print(_DIV)
+
+    try:
+        test1_join_path_integrity()
+    except Exception as exc:
+        print(f"  ERROR in Test 1: {exc}")
+        _register_gap("Test 1 — Join Path Integrity", "unknown", str(exc))
+
+    try:
+        test2_integrity_audit()
+    except Exception as exc:
+        print(f"  ERROR in Test 2: {exc}")
+        _register_gap("Test 2 — Integrity Audit", "unknown", str(exc))
+
+    try:
+        test3_employer_profile_health()
+    except Exception as exc:
+        print(f"  ERROR in Test 3: {exc}")
+        _register_gap("Test 3 — Employer Profile Health", "employer_profiles", str(exc))
+
+    try:
+        test4_sector_connection()
+    except Exception as exc:
+        print(f"  ERROR in Test 4: {exc}")
+        _register_gap("Test 4 — Sector Connection Test", "skill_demand_weekly / sector_summary_weekly", str(exc))
+
+    test5_gap_report()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/employer_drill_down_audit.py
+++ b/scripts/employer_drill_down_audit.py
@@ -44,6 +44,7 @@ _GAP_THRESHOLD = 5  # fewer than this many rows triggers SEVERITY 1
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _q(sql: str) -> list[Any]:
     """Execute a SELECT and return all rows."""
     with get_engine().connect() as conn:
@@ -94,15 +95,13 @@ def _register_gap(test: str, table: str, issue: str, row_count: int | None = Non
 # TEST 1 — Join Path Integrity (row count trace)
 # ---------------------------------------------------------------------------
 
+
 def test1_join_path_integrity() -> None:
     _header("TEST 1 — Join Path Integrity (row count trace)")
     print("  Tracing 'Data Engineer' rows hop-by-hop through the chain.\n")
 
     # Step A: skill_demand_weekly — baseline rows matching 'data engineer'
-    count_sdw = _scalar(
-        "SELECT COUNT(*) FROM dbo.skill_demand_weekly "
-        "WHERE skill_label ILIKE '%data engineer%'"
-    )
+    count_sdw = _scalar("SELECT COUNT(*) FROM dbo.skill_demand_weekly WHERE skill_label ILIKE '%data engineer%'")
 
     # Step B: extracted_intelligence rows where skills JSONB contains 'Data Engineer'
     count_ei = _scalar(
@@ -144,9 +143,9 @@ def test1_join_path_integrity() -> None:
 
     steps = [
         ("skill_demand_weekly (data engineer)", count_sdw),
-        ("extracted_intelligence",              count_ei),
-        ("job_postings",                        count_jp),
-        ("employer_profiles",                   count_ep),
+        ("extracted_intelligence", count_ei),
+        ("job_postings", count_jp),
+        ("employer_profiles", count_ep),
     ]
 
     # Find largest absolute drop
@@ -190,6 +189,7 @@ def test1_join_path_integrity() -> None:
 # ---------------------------------------------------------------------------
 # TEST 2 — Integrity Audit (success rate, orphan count, fan-out ratio)
 # ---------------------------------------------------------------------------
+
 
 def test2_integrity_audit() -> None:
     _header("TEST 2 — Integrity Audit (success rate / orphan count / fan-out ratio)")
@@ -275,15 +275,24 @@ def test2_integrity_audit() -> None:
     hops = [
         (
             "extracted_intelligence → normalized_jobs",
-            ei_total, ei_joined, ei_orphans, ei_fanout,
+            ei_total,
+            ei_joined,
+            ei_orphans,
+            ei_fanout,
         ),
         (
             "normalized_jobs → job_postings",
-            nj_total, nj_joined, nj_orphans, nj_fanout,
+            nj_total,
+            nj_joined,
+            nj_orphans,
+            nj_fanout,
         ),
         (
             "job_postings → employer_profiles",
-            jp_total, jp_joined, jp_orphans, jp_fanout,
+            jp_total,
+            jp_joined,
+            jp_orphans,
+            jp_fanout,
         ),
     ]
 
@@ -324,6 +333,7 @@ def test2_integrity_audit() -> None:
 # ---------------------------------------------------------------------------
 # TEST 3 — Employer Profile Health Check
 # ---------------------------------------------------------------------------
+
 
 def test3_employer_profile_health() -> None:
     _header("TEST 3 — Employer Profile Health Check")
@@ -380,6 +390,7 @@ def test3_employer_profile_health() -> None:
 # ---------------------------------------------------------------------------
 # TEST 4 — Sector Connection Test (skill_demand_weekly → sector_summary_weekly)
 # ---------------------------------------------------------------------------
+
 
 def test4_sector_connection() -> None:
     _header("TEST 4 — Sector Connection Test (Python: skill_demand_weekly → sector_summary_weekly)")
@@ -466,10 +477,7 @@ def test4_sector_connection() -> None:
         )
         print("  " + "-" * 85)
         for row in rows[:5]:
-            print(
-                f"  {str(row[0]):<16} {str(row[1]):<30} {str(row[2]):<12} "
-                f"{str(row[3]):>11} {str(row[4]):>12}"
-            )
+            print(f"  {str(row[0]):<16} {str(row[1]):<30} {str(row[2]):<12} {str(row[3]):>11} {str(row[4]):>12}")
         if row_count < _GAP_THRESHOLD:
             _register_gap(
                 test="Test 4 — Sector Connection Test",
@@ -488,6 +496,7 @@ def test4_sector_connection() -> None:
 # TEST 5 — Gap Report Generator
 # ---------------------------------------------------------------------------
 
+
 def test5_gap_report() -> None:
     _header("TEST 5 — Gap Report Generator")
 
@@ -500,9 +509,7 @@ def test5_gap_report() -> None:
     _footer()
 
     for gap in _gaps:
-        row_info = (
-            f"  Rows returned : {gap['row_count']}\n" if gap["row_count"] is not None else ""
-        )
+        row_info = f"  Rows returned : {gap['row_count']}\n" if gap["row_count"] is not None else ""
         print(_DIV)
         print("  SEVERITY 1 — GAP DETECTED")
         print(_DIV)
@@ -518,6 +525,7 @@ def test5_gap_report() -> None:
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
+
 
 def main() -> None:
     print(_DIV)

--- a/tools/golden-questions-form/golden_questions.json
+++ b/tools/golden-questions-form/golden_questions.json
@@ -874,10 +874,24 @@
     "question": "How has the Borderplex \"data analyst\" role evolved between the early_genai and agentic_era periods — which skills have been added to the typical requirements list and which have dropped off?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "",
-    "ideal_answer_summary": "",
-    "must_include": [],
-    "must_not_include": [],
+    "context": "A workforce director wants to update curriculum to reflect how the data analyst role has structurally changed, so training programs add emerging skills and remove obsolete ones",
+    "ideal_answer_summary": "Should compare skill frequency from `extracted_intelligence.skills` for data analyst postings grouped by `temporal_period` (`early_genai` vs `agentic_era`), citing skills that are new entrants vs declining. Must filter on `borderplex_subregion IS NOT NULL` and `spam_tier = 'clean'`. If `early_genai` data is absent, must state that gap explicitly rather than fabricating a comparison.",
+    "must_include": [
+      "temporal_period",
+      "early_genai",
+      "agentic_era",
+      "extracted_intelligence",
+      "skill_demand_weekly",
+      "borderplex_subregion",
+      "spam_tier"
+    ],
+    "must_not_include": [
+      "nationally",
+      "according to industry reports",
+      "generally speaking",
+      "fabricated skills",
+      "haluccinated numbers"
+    ],
     "difficulty": "standard"
   },
   {
@@ -885,43 +899,99 @@
     "question": "How have credentialing requirements for Borderplex cloud-architect postings changed over the last two years — are specific certifications (AWS Solutions Architect, Azure Solutions Architect, Google Cloud Professional) becoming more or less common?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "",
-    "ideal_answer_summary": "",
-    "must_include": [],
-    "must_not_include": [],
-    "difficulty": "standard"
+    "context": "A workforce director wants to know whether existing cloud cert training (AWS vs Azure vs GCP) is aligned with what Borderplex employers are actually requiring today versus two years ago",
+    "ideal_answer_summary": "Should show certification frequency (`skill->>'type' = 'Certification'`) for cloud architect postings grouped by `temporal_period`, citing `skill_demand_weekly` or `skill_velocity` for trend direction per certitification. Must be scoped to `borderplex_subregion IS NOT NULL` and `spam_tier = 'clean'`",
+    "must_include": [
+      "Certification",
+      "skill_demand_weekly",
+      "skill_velocity",
+      "temporal_period",
+      "borderplex_subregion",
+      "extracted_intelligence",
+      "week_over_week_change"
+    ],
+    "must_not_include": [
+      "nationally",
+      "Third party data",
+      "industry surveys",
+      "fabricated percentages",
+      "Statements not backed by data"
+    ],
+    "difficulty": "medium"
   },
   {
     "id": "gq-033",
     "question": "In Borderplex software engineer postings, how has the balance between AI-assistant familiarity and traditional programming skills evolved across the four temporal periods?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "",
-    "ideal_answer_summary": "",
-    "must_include": [],
-    "must_not_include": [],
-    "difficulty": "standard"
+    "context": "A workforce director needs to decide how much curriculum weight to shift from traditional programming instruction toward AI-assisted development practices",
+    "ideal_answer_summary": "Should compare traditional programming skills vs AI-assistant skills (using `is_genai_tool = true` from `extracted_intelligence.tools`) across all four temporal periods for software engineer postings. Must cite `skill_velocity.four_week_trend` for trend direction and scope to Borderplex postings with `spam_tier = 'clean'`.",
+    "must_include": [
+      "pre_chatgpt",
+      "early_genai",
+      "post_gpt4",
+      "agentic_era",
+      "skill_velocity",
+      "four_week_trend",
+      "extracted_intelligence",
+      "is_genai_tool",
+      "borderplex_subregion"
+    ],
+    "must_not_include": [
+      "all programmers should learn AI",
+      "national statistics",
+      "fabricated ratios",
+      "Borderplex data does not exist"
+    ],
+    "difficulty": "medium"
   },
   {
     "id": "gq-034",
     "question": "How has the typical job-title wording for Borderplex ML roles drifted — is \"machine learning engineer\" being replaced by \"AI engineer\" or \"AI agent developer\" in the agentic_era period?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "",
-    "ideal_answer_summary": "",
-    "must_include": [],
-    "must_not_include": [],
-    "difficulty": "standard"
+    "context": "A workforce director wants to know whether to rename or reframe ML-focused training programs to match how employers are titling these roles in current postings and see if there are differences between ML roles and AI roles",
+    "ideal_answer_summary": "Should count postings by `job_title` pattern (`'%machine learning%'`, `'%ai engineer%'`, `'%ai agent%'`) grouped by `temporal_period`, and cross-reference `canonical_roles.label` for normalized clustering. Must note that `job_title` is raw and unnormalized. Scoped to `borderplex_subregion IS NOT NULL` and `spam_tier = 'clean'`",
+    "must_include": [
+      "job_title",
+      "temporal_period",
+      "agentic_era",
+      "canonical_roles",
+      "role_snapshot_weekly",
+      "borderplex_subregion",
+      "spam_tier"
+    ],
+    "must_not_include": [
+      "national job boards",
+      "vague answers with no data backup",
+      "fabricated title counts"
+    ],
+    "difficulty": "hard"
   },
   {
     "id": "gq-035",
     "question": "For Borderplex cybersecurity analyst roles, how have required tools and frameworks evolved since the pre_chatgpt period — which tools are new and which are being deprecated?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "",
-    "ideal_answer_summary": "",
-    "must_include": [],
-    "must_not_include": [],
+    "context": "A workforce director needs to audit a cybersecurity curriculum to ensure tools being taught match current employer expectations rather than what was relevant 2–3 years ago.",
+    "ideal_answer_summary": "Should compare `extracted_intelligence.tools` frequency for cybersecurity analyst postings across `pre_chatgpt` and `agentic_era`, citing `tool_demand_weekly` for aggregates and `skill_velocity.four_week_trend = 'falling'` to flag deprecated tools. Must be Borderplex-scoped and note if per-period posting volume is too low to be conclusive.",
+    "must_include": [
+      "extracted_intelligence",
+      "tools",
+      "tool_demand_weekly",
+      "skill_velocity",
+      "pre_chatgpt",
+      "agentic_era",
+      "temporal_period",
+      "borderplex_subregion",
+      "four_week_trend"
+    ],
+    "must_not_include": [
+      "Third party reports",
+      "national averages",
+      "all cybersecurity tools are relevant",
+      "fabricated tool names"
+    ],
     "difficulty": "standard"
   },
   {
@@ -929,21 +999,49 @@
     "question": "In Borderplex React developer postings, how has the supporting-skill mix (TypeScript, Next.js, testing frameworks, AI-assisted dev tools) changed over the last 18 months?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "",
-    "ideal_answer_summary": "",
-    "must_include": [],
-    "must_not_include": [],
-    "difficulty": "standard"
+    "context": "A workforce director wants to know whether React curriculum needs to add TypeScript, Next.js, or AI dev tooling as standard components rather than optional extras.",
+    "ideal_answer_summary": "Should use `skill_co_occurrence` to show which supporting skills (TypeScript, Next.js, testing frameworks, AI dev tools) appear alongside React, with `skill_velocity.week_over_week_change` for trend direction. Must flag AI dev tools via `is_genai_tool = true`. Scoped to `borderplex_subregion IS NOT NULL` and `spam_tier = 'clean'`.",
+    "must_include": [
+      "skill_co_occurrence",
+      "skill_velocity",
+      "extracted_intelligence",
+      "tool_demand_weekly",
+      "is_genai_tool",
+      "borderplex_subregion",
+      "temporal_period",
+      "week_over_week_change",
+      "percentages"
+    ],
+    "must_not_include": [
+      "Vague answer with no back up data",
+      "fabricated co-occurrence percentages",
+      "Hallucinated numbers"
+    ],
+    "difficulty": "medium"
   },
   {
     "id": "gq-037",
     "question": "How has the seniority-level mix for Borderplex data engineer postings shifted between the early_genai and agentic_era periods — more senior, more junior, or more staff-level roles?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "",
-    "ideal_answer_summary": "",
-    "must_include": [],
-    "must_not_include": [],
+    "context": "A workforce director wants to know whether Borderplex employers are opening entry-level data engineering pipelines or consolidating around senior talent, to calibrate which cohort levels to prioritize.",
+    "ideal_answer_summary": "Should show the distribution of `jp.seniority_level` values for data engineer postings grouped by `temporal_period` (`early_genai` vs `agentic_era`). Must acknowledge if `seniority_level` is partially null and suggest `extracted_intelligence.tasks[*].seniority_signal` as a fallback. Scoped to Borderplex postings with `spam_tier = 'clean'`.",
+    "must_include": [
+      "seniority_level",
+      "temporal_period",
+      "early_genai",
+      "agentic_era",
+      "tasks",
+      "seniority_signal",
+      "role_snapshot_weekly",
+      "borderplex_subregion"
+    ],
+    "must_not_include": [
+      "hallucinated seniority percentages",
+      "seniority data is unavailable",
+      "industry wide reports",
+      "generic statements without data"
+    ],
     "difficulty": "standard"
   },
   {
@@ -951,33 +1049,78 @@
     "question": "For Borderplex DevOps engineer postings, how have infrastructure-as-code tool requirements evolved (Terraform vs Pulumi vs CloudFormation vs AI-generated-IaC) in the last two years?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "",
-    "ideal_answer_summary": "",
-    "must_include": [],
-    "must_not_include": [],
-    "difficulty": "standard"
+    "context": "A workforce director is deciding whether to invest in Terraform-specific training or branch into Pulumi and AI-generated IaC tooling for a DevOps cohort starting next quarter.",
+    "ideal_answer_summary": "Should compare `extracted_intelligence.tools` frequency for DevOps postings across temporal periods, highlighting Terraform, Pulumi, CloudFormation, and AI-generated IaC tools (`is_genai_tool = true`). Trend direction should cite `tool_demand_weekly` and `skill_velocity`. Must note if posting volume per period is insufficient for strong conclusions.",
+    "must_include": [
+      "extracted_intelligence",
+      "tools",
+      "tool_demand_weekly",
+      "skill_velocity",
+      "is_genai_tool",
+      "temporal_period",
+      "borderplex_subregion"
+    ],
+    "must_not_include": [
+      "vague statements without data",
+      "statements based on national data",
+      "fabricated tool market share",
+      "hallucinated numbers"
+    ],
+    "difficulty": "medium"
   },
   {
     "id": "gq-039",
     "question": "In Borderplex product manager and technical-product-manager roles, how has the expected AI-literacy level evolved from the pre_chatgpt to agentic_era periods?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "",
-    "ideal_answer_summary": "",
-    "must_include": [],
-    "must_not_include": [],
-    "difficulty": "standard"
+    "context": "A workforce director wants to understand whether project manager training programs need to incorporate AI-literacy components (prompt engineering, LLM product specs, AI roadmapping) as baseline requirements.",
+    "ideal_answer_summary": "Should measure AI-literacy signals in product manager postings across `pre_chatgpt` and `agentic_era`: AI-related skills from `extracted_intelligence.skills`, `context[*].signal_type = 'ai_adoption_signal'`, and `jp.ai_relevance_score` distribution. Must cite `skill_demand_weekly` for aggregates and scope to `borderplex_subregion IS NOT NULL` with `spam_tier = 'clean'`.",
+    "must_include": [
+      "ai_adoption_signal",
+      "ai_relevance_score",
+      "extracted_intelligence",
+      "context",
+      "temporal_period",
+      "pre_chatgpt",
+      "agentic_era",
+      "skill_demand_weekly",
+      "borderplex_subregion",
+      "precise percentages"
+    ],
+    "must_not_include": [
+      "generic statements without data",
+      "vague statements",
+      "fabricated AI-literacy percentages"
+    ],
+    "difficulty": "medium"
   },
   {
     "id": "gq-040",
     "question": "How have Borderplex quality-engineering (QA, SDET, test-automation) role requirements evolved — is the expectation shifting from manual + scripted testing toward AI-assisted test generation?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "",
-    "ideal_answer_summary": "",
-    "must_include": [],
-    "must_not_include": [],
-    "difficulty": "standard"
+    "context": "A workforce director wants to know whether QA training programs should pivot from teaching manual test-case writing toward AI-assisted test generation tools.",
+    "ideal_answer_summary": "Should compare traditional testing tools vs AI-assisted test tools (`is_genai_tool = true`) for QA/SDET postings across temporal periods, and check `extracted_intelligence.responsibilities[*].requires_ai_competency` as an explicit signal. Must cite `tool_demand_weekly` and `skill_velocity.four_week_trend`. Scoped to Borderplex postings with `spam_tier = 'clean'`.",
+    "must_include": [
+      "extracted_intelligence",
+      "tools",
+      "is_genai_tool",
+      "tool_demand_weekly",
+      "skill_velocity",
+      "responsibilities",
+      "requires_ai_competency",
+      "temporal_period",
+      "borderplex_subregion",
+      "spam_tier",
+      "temporal comparison"
+    ],
+    "must_not_include": [
+      "generic_statements_without_data",
+      "hallucinated_numbers",
+      "fabricated automation percentages",
+      "industry analyst forecast"
+    ],
+    "difficulty": "medium"
   },
   {
     "id": "gq-041",

--- a/tools/golden-questions-form/golden_questions.json
+++ b/tools/golden-questions-form/golden_questions.json
@@ -874,24 +874,10 @@
     "question": "How has the Borderplex \"data analyst\" role evolved between the early_genai and agentic_era periods — which skills have been added to the typical requirements list and which have dropped off?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "A workforce director wants to update curriculum to reflect how the data analyst role has structurally changed, so training programs add emerging skills and remove obsolete ones",
-    "ideal_answer_summary": "Should compare skill frequency from `extracted_intelligence.skills` for data analyst postings grouped by `temporal_period` (`early_genai` vs `agentic_era`), citing skills that are new entrants vs declining. Must filter on `borderplex_subregion IS NOT NULL` and `spam_tier = 'clean'`. If `early_genai` data is absent, must state that gap explicitly rather than fabricating a comparison.",
-    "must_include": [
-      "temporal_period",
-      "early_genai",
-      "agentic_era",
-      "extracted_intelligence",
-      "skill_demand_weekly",
-      "borderplex_subregion",
-      "spam_tier"
-    ],
-    "must_not_include": [
-      "nationally",
-      "according to industry reports",
-      "generally speaking",
-      "fabricated skills",
-      "haluccinated numbers"
-    ],
+    "context": "",
+    "ideal_answer_summary": "",
+    "must_include": [],
+    "must_not_include": [],
     "difficulty": "standard"
   },
   {
@@ -899,99 +885,43 @@
     "question": "How have credentialing requirements for Borderplex cloud-architect postings changed over the last two years — are specific certifications (AWS Solutions Architect, Azure Solutions Architect, Google Cloud Professional) becoming more or less common?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "A workforce director wants to know whether existing cloud cert training (AWS vs Azure vs GCP) is aligned with what Borderplex employers are actually requiring today versus two years ago",
-    "ideal_answer_summary": "Should show certification frequency (`skill->>'type' = 'Certification'`) for cloud architect postings grouped by `temporal_period`, citing `skill_demand_weekly` or `skill_velocity` for trend direction per certitification. Must be scoped to `borderplex_subregion IS NOT NULL` and `spam_tier = 'clean'`",
-    "must_include": [
-      "Certification",
-      "skill_demand_weekly",
-      "skill_velocity",
-      "temporal_period",
-      "borderplex_subregion",
-      "extracted_intelligence",
-      "week_over_week_change"
-    ],
-    "must_not_include": [
-      "nationally",
-      "Third party data",
-      "industry surveys",
-      "fabricated percentages",
-      "Statements not backed by data"
-    ],
-    "difficulty": "medium"
+    "context": "",
+    "ideal_answer_summary": "",
+    "must_include": [],
+    "must_not_include": [],
+    "difficulty": "standard"
   },
   {
     "id": "gq-033",
     "question": "In Borderplex software engineer postings, how has the balance between AI-assistant familiarity and traditional programming skills evolved across the four temporal periods?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "A workforce director needs to decide how much curriculum weight to shift from traditional programming instruction toward AI-assisted development practices",
-    "ideal_answer_summary": "Should compare traditional programming skills vs AI-assistant skills (using `is_genai_tool = true` from `extracted_intelligence.tools`) across all four temporal periods for software engineer postings. Must cite `skill_velocity.four_week_trend` for trend direction and scope to Borderplex postings with `spam_tier = 'clean'`.",
-    "must_include": [
-      "pre_chatgpt",
-      "early_genai",
-      "post_gpt4",
-      "agentic_era",
-      "skill_velocity",
-      "four_week_trend",
-      "extracted_intelligence",
-      "is_genai_tool",
-      "borderplex_subregion"
-    ],
-    "must_not_include": [
-      "all programmers should learn AI",
-      "national statistics",
-      "fabricated ratios",
-      "Borderplex data does not exist"
-    ],
-    "difficulty": "medium"
+    "context": "",
+    "ideal_answer_summary": "",
+    "must_include": [],
+    "must_not_include": [],
+    "difficulty": "standard"
   },
   {
     "id": "gq-034",
     "question": "How has the typical job-title wording for Borderplex ML roles drifted — is \"machine learning engineer\" being replaced by \"AI engineer\" or \"AI agent developer\" in the agentic_era period?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "A workforce director wants to know whether to rename or reframe ML-focused training programs to match how employers are titling these roles in current postings and see if there are differences between ML roles and AI roles",
-    "ideal_answer_summary": "Should count postings by `job_title` pattern (`'%machine learning%'`, `'%ai engineer%'`, `'%ai agent%'`) grouped by `temporal_period`, and cross-reference `canonical_roles.label` for normalized clustering. Must note that `job_title` is raw and unnormalized. Scoped to `borderplex_subregion IS NOT NULL` and `spam_tier = 'clean'`",
-    "must_include": [
-      "job_title",
-      "temporal_period",
-      "agentic_era",
-      "canonical_roles",
-      "role_snapshot_weekly",
-      "borderplex_subregion",
-      "spam_tier"
-    ],
-    "must_not_include": [
-      "national job boards",
-      "vague answers with no data backup",
-      "fabricated title counts"
-    ],
-    "difficulty": "hard"
+    "context": "",
+    "ideal_answer_summary": "",
+    "must_include": [],
+    "must_not_include": [],
+    "difficulty": "standard"
   },
   {
     "id": "gq-035",
     "question": "For Borderplex cybersecurity analyst roles, how have required tools and frameworks evolved since the pre_chatgpt period — which tools are new and which are being deprecated?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "A workforce director needs to audit a cybersecurity curriculum to ensure tools being taught match current employer expectations rather than what was relevant 2–3 years ago.",
-    "ideal_answer_summary": "Should compare `extracted_intelligence.tools` frequency for cybersecurity analyst postings across `pre_chatgpt` and `agentic_era`, citing `tool_demand_weekly` for aggregates and `skill_velocity.four_week_trend = 'falling'` to flag deprecated tools. Must be Borderplex-scoped and note if per-period posting volume is too low to be conclusive.",
-    "must_include": [
-      "extracted_intelligence",
-      "tools",
-      "tool_demand_weekly",
-      "skill_velocity",
-      "pre_chatgpt",
-      "agentic_era",
-      "temporal_period",
-      "borderplex_subregion",
-      "four_week_trend"
-    ],
-    "must_not_include": [
-      "Third party reports",
-      "national averages",
-      "all cybersecurity tools are relevant",
-      "fabricated tool names"
-    ],
+    "context": "",
+    "ideal_answer_summary": "",
+    "must_include": [],
+    "must_not_include": [],
     "difficulty": "standard"
   },
   {
@@ -999,49 +929,21 @@
     "question": "In Borderplex React developer postings, how has the supporting-skill mix (TypeScript, Next.js, testing frameworks, AI-assisted dev tools) changed over the last 18 months?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "A workforce director wants to know whether React curriculum needs to add TypeScript, Next.js, or AI dev tooling as standard components rather than optional extras.",
-    "ideal_answer_summary": "Should use `skill_co_occurrence` to show which supporting skills (TypeScript, Next.js, testing frameworks, AI dev tools) appear alongside React, with `skill_velocity.week_over_week_change` for trend direction. Must flag AI dev tools via `is_genai_tool = true`. Scoped to `borderplex_subregion IS NOT NULL` and `spam_tier = 'clean'`.",
-    "must_include": [
-      "skill_co_occurrence",
-      "skill_velocity",
-      "extracted_intelligence",
-      "tool_demand_weekly",
-      "is_genai_tool",
-      "borderplex_subregion",
-      "temporal_period",
-      "week_over_week_change",
-      "percentages"
-    ],
-    "must_not_include": [
-      "Vague answer with no back up data",
-      "fabricated co-occurrence percentages",
-      "Hallucinated numbers"
-    ],
-    "difficulty": "medium"
+    "context": "",
+    "ideal_answer_summary": "",
+    "must_include": [],
+    "must_not_include": [],
+    "difficulty": "standard"
   },
   {
     "id": "gq-037",
     "question": "How has the seniority-level mix for Borderplex data engineer postings shifted between the early_genai and agentic_era periods — more senior, more junior, or more staff-level roles?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "A workforce director wants to know whether Borderplex employers are opening entry-level data engineering pipelines or consolidating around senior talent, to calibrate which cohort levels to prioritize.",
-    "ideal_answer_summary": "Should show the distribution of `jp.seniority_level` values for data engineer postings grouped by `temporal_period` (`early_genai` vs `agentic_era`). Must acknowledge if `seniority_level` is partially null and suggest `extracted_intelligence.tasks[*].seniority_signal` as a fallback. Scoped to Borderplex postings with `spam_tier = 'clean'`.",
-    "must_include": [
-      "seniority_level",
-      "temporal_period",
-      "early_genai",
-      "agentic_era",
-      "tasks",
-      "seniority_signal",
-      "role_snapshot_weekly",
-      "borderplex_subregion"
-    ],
-    "must_not_include": [
-      "hallucinated seniority percentages",
-      "seniority data is unavailable",
-      "industry wide reports",
-      "generic statements without data"
-    ],
+    "context": "",
+    "ideal_answer_summary": "",
+    "must_include": [],
+    "must_not_include": [],
     "difficulty": "standard"
   },
   {
@@ -1049,78 +951,33 @@
     "question": "For Borderplex DevOps engineer postings, how have infrastructure-as-code tool requirements evolved (Terraform vs Pulumi vs CloudFormation vs AI-generated-IaC) in the last two years?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "A workforce director is deciding whether to invest in Terraform-specific training or branch into Pulumi and AI-generated IaC tooling for a DevOps cohort starting next quarter.",
-    "ideal_answer_summary": "Should compare `extracted_intelligence.tools` frequency for DevOps postings across temporal periods, highlighting Terraform, Pulumi, CloudFormation, and AI-generated IaC tools (`is_genai_tool = true`). Trend direction should cite `tool_demand_weekly` and `skill_velocity`. Must note if posting volume per period is insufficient for strong conclusions.",
-    "must_include": [
-      "extracted_intelligence",
-      "tools",
-      "tool_demand_weekly",
-      "skill_velocity",
-      "is_genai_tool",
-      "temporal_period",
-      "borderplex_subregion"
-    ],
-    "must_not_include": [
-      "vague statements without data",
-      "statements based on national data",
-      "fabricated tool market share",
-      "hallucinated numbers"
-    ],
-    "difficulty": "medium"
+    "context": "",
+    "ideal_answer_summary": "",
+    "must_include": [],
+    "must_not_include": [],
+    "difficulty": "standard"
   },
   {
     "id": "gq-039",
     "question": "In Borderplex product manager and technical-product-manager roles, how has the expected AI-literacy level evolved from the pre_chatgpt to agentic_era periods?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "A workforce director wants to understand whether project manager training programs need to incorporate AI-literacy components (prompt engineering, LLM product specs, AI roadmapping) as baseline requirements.",
-    "ideal_answer_summary": "Should measure AI-literacy signals in product manager postings across `pre_chatgpt` and `agentic_era`: AI-related skills from `extracted_intelligence.skills`, `context[*].signal_type = 'ai_adoption_signal'`, and `jp.ai_relevance_score` distribution. Must cite `skill_demand_weekly` for aggregates and scope to `borderplex_subregion IS NOT NULL` with `spam_tier = 'clean'`.",
-    "must_include": [
-      "ai_adoption_signal",
-      "ai_relevance_score",
-      "extracted_intelligence",
-      "context",
-      "temporal_period",
-      "pre_chatgpt",
-      "agentic_era",
-      "skill_demand_weekly",
-      "borderplex_subregion",
-      "precise percentages"
-    ],
-    "must_not_include": [
-      "generic statements without data",
-      "vague statements",
-      "fabricated AI-literacy percentages"
-    ],
-    "difficulty": "medium"
+    "context": "",
+    "ideal_answer_summary": "",
+    "must_include": [],
+    "must_not_include": [],
+    "difficulty": "standard"
   },
   {
     "id": "gq-040",
     "question": "How have Borderplex quality-engineering (QA, SDET, test-automation) role requirements evolved — is the expectation shifting from manual + scripted testing toward AI-assisted test generation?",
     "source": "wfd_archetype",
     "intent": "role_evolution",
-    "context": "A workforce director wants to know whether QA training programs should pivot from teaching manual test-case writing toward AI-assisted test generation tools.",
-    "ideal_answer_summary": "Should compare traditional testing tools vs AI-assisted test tools (`is_genai_tool = true`) for QA/SDET postings across temporal periods, and check `extracted_intelligence.responsibilities[*].requires_ai_competency` as an explicit signal. Must cite `tool_demand_weekly` and `skill_velocity.four_week_trend`. Scoped to Borderplex postings with `spam_tier = 'clean'`.",
-    "must_include": [
-      "extracted_intelligence",
-      "tools",
-      "is_genai_tool",
-      "tool_demand_weekly",
-      "skill_velocity",
-      "responsibilities",
-      "requires_ai_competency",
-      "temporal_period",
-      "borderplex_subregion",
-      "spam_tier",
-      "temporal comparison"
-    ],
-    "must_not_include": [
-      "generic_statements_without_data",
-      "hallucinated_numbers",
-      "fabricated automation percentages",
-      "industry analyst forecast"
-    ],
-    "difficulty": "medium"
+    "context": "",
+    "ideal_answer_summary": "",
+    "must_include": [],
+    "must_not_include": [],
+    "difficulty": "standard"
   },
   {
     "id": "gq-041",


### PR DESCRIPTION

## Temporal Comparison + Employer Drill-Down Audit

Pair B (Fatima + Nestor) — Exercise 9.4

### Summary

Data audit verifying query-readiness of temporal comparison and employer drill-down capabilities for the Q&A pipeline.

**Key Findings:**
- skill_demand_weekly: 7,862 rows across 3 usable weeks (Apr 13, Apr 6, Mar 30)
- skill_velocity: computed but only 2 meaningful weeks (Apr 6 → Apr 13)
- sector_summary_weekly & geo_demand_weekly: blocked by analytics_minimum_data_guard_no_created_column bug (fixable, one-line fix)
- Temporal period labels (pre_chatgpt, agentic_era): missing entirely, requires historical data re-run
- employer_profiles: 1,373 total, 99.8% known employers, join structurally valid
- End-to-end trace: 'How has Python demand changed across temporal periods in the Borderplex?' returns 10 rows, 3 weeks, but Borderplex filter ignored by router

### Gaps Classified

1. **analytics_minimum_data_guard_no_created_column** — fixable Week 10 (P1)
2. **Borderplex not applied in trend router** — fixable Week 10 (P2)
3. **Temporal period labels missing** — requires pipeline re-run, out of scope
4. **Employer drill-down not live-tested** — fixable Week 10 after geo/sector fix

### Evidence

See docs/findings/week-09-temporal-employer-audit.md for full data/evidence section with query results, row counts, and sample outputs.
