### PR TITLE
chore(langfuse): move host port 3000 → 3001

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,7 +44,7 @@ LANGSMITH_API_KEY=
 LANGCHAIN_TRACING_V2=true
 LANGFUSE_SECRET_KEY=
 LANGFUSE_PUBLIC_KEY=
-# Cloud: https://us.cloud.langfuse.com  |  Local Docker: http://localhost:3000
+# Cloud: https://us.cloud.langfuse.com  |  Local Docker: http://localhost:3001
 LANGFUSE_BASE_URL=https://us.cloud.langfuse.com
 LANGFUSE_HOST=https://us.cloud.langfuse.com
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -59,8 +59,8 @@ cp .env.example .env
 |----------|-------|
 | `LANGFUSE_SECRET_KEY` | `sk-lf-local-dev-secret` |
 | `LANGFUSE_PUBLIC_KEY` | `pk-lf-local-dev-public` |
-| `LANGFUSE_BASE_URL` | `http://localhost:3000` |
-| `LANGFUSE_HOST` | `http://localhost:3000` |
+| `LANGFUSE_BASE_URL` | `http://localhost:3001` |
+| `LANGFUSE_HOST` | `http://localhost:3001` |
 
 ### Mock Provider (no API keys needed)
 
@@ -75,7 +75,7 @@ docker compose up -d
 This starts:
 - **PostgreSQL** (port 5432) — application database with pgvector
 - **Redis** (port 6379) — inter-agent message bus
-- **Langfuse** (port 3000) — 6 containers for observability
+- **Langfuse** (port 3001) — 6 containers for observability
 
 Verify all containers are healthy:
 
@@ -85,7 +85,7 @@ docker compose ps
 
 ### Langfuse Login
 
-Open http://localhost:3000 and sign in:
+Open http://localhost:3001 and sign in:
 - Email: `dev@localhost.dev`
 - Password: `LocalDev123!`
 - Organization: Computing For All

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,10 +160,10 @@ services:
     container_name: langfuse-server
     depends_on: *langfuse-depends
     ports:
-      - "${LANGFUSE_PORT:-3000}:3000"
+      - "${LANGFUSE_PORT:-3001}:3000"
     environment:
       <<: *langfuse-env
-      NEXTAUTH_URL: http://localhost:${LANGFUSE_PORT:-3000}
+      NEXTAUTH_URL: http://localhost:${LANGFUSE_PORT:-3001}
       NEXTAUTH_SECRET: ${LANGFUSE_NEXTAUTH_SECRET:-mysecret}
       # Auto-provision org, project, user, and API keys on first start
       LANGFUSE_INIT_ORG_ID: computing-for-all

--- a/docs/guides/local-langfuse-setup.md
+++ b/docs/guides/local-langfuse-setup.md
@@ -20,7 +20,7 @@ This starts 6 containers:
 - `langfuse-minio` (minio) -- blob storage for events
 - `langfuse-redis` (redis:7-alpine) -- queue for worker
 - `langfuse-worker` (langfuse-worker:3) -- background processing
-- `langfuse-server` (langfuse:3 on port 3000) -- web UI and API
+- `langfuse-server` (langfuse:3 on port 3001) -- web UI and API
 
 Wait ~30 seconds for all services to initialize.
 
@@ -32,7 +32,7 @@ The docker-compose auto-provisions:
 - **User**: dev@localhost.dev / LocalDev123!
 - **API Keys**: `sk-lf-local-dev-secret` / `pk-lf-local-dev-public`
 
-Sign in at http://localhost:3000 with the credentials above.
+Sign in at http://localhost:3001 with the credentials above.
 
 ## 3. Configure .env
 
@@ -41,8 +41,8 @@ The `.env` file should already have the local Langfuse keys:
 ```bash
 LANGFUSE_SECRET_KEY=sk-lf-local-dev-secret
 LANGFUSE_PUBLIC_KEY=pk-lf-local-dev-public
-LANGFUSE_BASE_URL=http://localhost:3000
-LANGFUSE_HOST=http://localhost:3000
+LANGFUSE_BASE_URL=http://localhost:3001
+LANGFUSE_HOST=http://localhost:3001
 ```
 
 To switch to cloud Langfuse, uncomment the cloud keys and comment out the local ones.
@@ -80,7 +80,7 @@ This will:
 
 ## 7. View Traces in Langfuse
 
-Open http://localhost:3000 and navigate to **Tracing**. You should see:
+Open http://localhost:3001 and navigate to **Tracing**. You should see:
 
 - `processing-loop/skills-extraction` -- skills extraction LLM calls
 - `processing-loop/tasks-extraction` -- task extraction LLM calls
@@ -123,15 +123,15 @@ Toggle `LLM_PROVIDER` in `.env`:
 
 ## Troubleshooting
 
-### Port 3000 in use
-The Next.js app also uses port 3000. Set `LANGFUSE_PORT=3001` in `.env` and update `LANGFUSE_BASE_URL` accordingly.
+### Port 3001 in use
+Langfuse defaults to port 3001 (port 3000 is reserved for the wfd-os Next.js frontend). If 3001 is also in use, set `LANGFUSE_PORT=<free port>` in `.env` and update `LANGFUSE_BASE_URL` accordingly.
 
 ### Langfuse not starting
 Check logs: `docker compose logs langfuse` and `docker compose logs langfuse-worker`
 
 ### No traces appearing
 - Verify `LANGFUSE_SECRET_KEY` and `LANGFUSE_PUBLIC_KEY` match the auto-provisioned keys
-- Verify `LANGFUSE_BASE_URL` points to `http://localhost:3000`
+- Verify `LANGFUSE_BASE_URL` points to `http://localhost:3001`
 - Check that the pipeline script ran without errors
 
 ### Reset Langfuse data

--- a/docs/runbooks/WEEK07_TESTING_RUNBOOK.md
+++ b/docs/runbooks/WEEK07_TESTING_RUNBOOK.md
@@ -110,7 +110,7 @@ If these queries return errors like `relation "dbo.skill_demand_weekly" does not
 
 ### Step 3 — Verify Langfuse connectivity
 
-Open http://localhost:3000 in your browser. Sign in with `dev@localhost.dev` / `LocalDev123!`.
+Open http://localhost:3001 in your browser. Sign in with `dev@localhost.dev` / `LocalDev123!`.
 
 If the page does not load, check Docker:
 
@@ -188,8 +188,8 @@ Add these to your `.env` at the repo root (if not already present):
 # Langfuse Observability — Local Docker
 LANGFUSE_SECRET_KEY=sk-lf-local-dev-secret
 LANGFUSE_PUBLIC_KEY=pk-lf-local-dev-public
-LANGFUSE_BASE_URL=http://localhost:3000
-LANGFUSE_HOST=http://localhost:3000
+LANGFUSE_BASE_URL=http://localhost:3001
+LANGFUSE_HOST=http://localhost:3001
 ```
 
 If you are using Langfuse Cloud instead of local Docker, replace the keys and URL with your cloud project credentials from https://us.cloud.langfuse.com.
@@ -208,7 +208,7 @@ This starts all services: PostgreSQL (app database), Redis, and the 6 Langfuse c
 docker compose ps
 ```
 
-All containers should show `running` or `Up (healthy)`. Then open http://localhost:3000 and confirm the login page loads.
+All containers should show `running` or `Up (healthy)`. Then open http://localhost:3001 and confirm the login page loads.
 
 **Pre-provisioned account:**
 - Email: `dev@localhost.dev`
@@ -683,7 +683,7 @@ AZURE_OPENAI_API_KEY=<your-key>
 AZURE_OPENAI_DEPLOYMENT_NAME=chat-gpt41mini
 LANGFUSE_SECRET_KEY=sk-lf-local-dev-secret
 LANGFUSE_PUBLIC_KEY=pk-lf-local-dev-public
-LANGFUSE_BASE_URL=http://localhost:3000
+LANGFUSE_BASE_URL=http://localhost:3001
 ```
 
 The seeded database is fully processed — reset 3 jobs first so the loop has work to do:
@@ -708,7 +708,7 @@ If this line does not appear, the tracer was not initialized. Check `LANGFUSE_SE
 
 ### Step 2 — Find traces in the UI
 
-Open http://localhost:3000 → **Tracing**. You should see at least one trace from the run above.
+Open http://localhost:3001 → **Tracing**. You should see at least one trace from the run above.
 
 **Verification checklist:**
 
@@ -883,7 +883,7 @@ The dashboard uses a read-only SQLAlchemy connection. It should never show a bla
 
 ### Langfuse Issues
 
-**Langfuse UI not loading (http://localhost:3000)**
+**Langfuse UI not loading (http://localhost:3001)**
 
 ```bash
 # Check container status
@@ -916,7 +916,7 @@ All `LANGFUSE_INIT_*` variables should be present. If they are and login still f
    ```bash
    python -c "import os; from dotenv import load_dotenv; load_dotenv(); print('SECRET_KEY set:', bool(os.getenv('LANGFUSE_SECRET_KEY'))); print('BASE_URL:', os.getenv('LANGFUSE_BASE_URL', 'NOT SET'))"
    ```
-3. Check that `LANGFUSE_BASE_URL` points to `http://localhost:3000` (not `https://us.cloud.langfuse.com` if using local Docker).
+3. Check that `LANGFUSE_BASE_URL` points to `http://localhost:3001` (not `https://us.cloud.langfuse.com` if using local Docker).
 4. Check the langfuse-worker container is running — it processes incoming traces:
    ```bash
    docker compose logs langfuse-worker --tail 20
@@ -931,7 +931,7 @@ python scripts/upload_langfuse_dataset.py
 
 If this fails with a connection error:
 - Verify `LANGFUSE_SECRET_KEY` and `LANGFUSE_BASE_URL` are set correctly
-- Verify the Langfuse server is reachable: `curl http://localhost:3000/api/public/health`
+- Verify the Langfuse server is reachable: `curl http://localhost:3001/api/public/health`
 - Check that the `langfuse` Python package is installed: `pip list | grep langfuse`
 
 If it fails with an authentication error:

--- a/scripts/langfuse_cost_analysis.py
+++ b/scripts/langfuse_cost_analysis.py
@@ -13,7 +13,7 @@ from dotenv import load_dotenv
 sys.stdout.reconfigure(encoding="utf-8")
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
-base = os.getenv("LANGFUSE_BASE_URL", "http://localhost:3000")
+base = os.getenv("LANGFUSE_BASE_URL", "http://localhost:3001")
 pk = os.getenv("LANGFUSE_PUBLIC_KEY")
 sk = os.getenv("LANGFUSE_SECRET_KEY")
 


### PR DESCRIPTION
## Summary
- Frees host port 3000 so the wfd-os Next.js frontend can bind there naturally.
- Langfuse container still listens on 3000 internally — only the host mapping (`LANGFUSE_PORT` default) and documented URLs change.
- Volumes (`langfuse_db_data`, `langfuse_clickhouse_data`, `langfuse_minio_data`) untouched; no data loss. Verified `GET http://localhost:3001/api/public/health` → `{"status":"OK","version":"3.163.0"}` after `docker compose up -d langfuse`.

## Files
- `docker-compose.yml` — `LANGFUSE_PORT` default flipped to 3001; `NEXTAUTH_URL` default updated.
- `.env.example`, `ONBOARDING.md`, `docs/guides/local-langfuse-setup.md`, `docs/runbooks/WEEK07_TESTING_RUNBOOK.md`, `scripts/langfuse_cost_analysis.py` — doc and fallback references updated.
- Setup-guide troubleshooting note inverted to reflect 3001 as the new default.

Note: local `.env` (gitignored) also updated on Gary's machine so the Python SDK keeps reaching Langfuse; other devs should mirror the `.env.example` change.

## Test plan
- [x] `docker compose up -d langfuse` recreates `langfuse-server` with `0.0.0.0:3001->3000/tcp`
- [x] `curl http://localhost:3001/api/public/health` returns OK
- [x] After merge, confirm port 3000 is free and wfd-os `npm run dev` binds there

🤖 Generated with [Claude Code](https://claude.com/claude-code)