### PR TITLE
fix(geo-demand): use COALESCE(publish_date, date_posted) for week bucketing

### DIFF
--- a/analytics/aggregators/geo_demand.py
+++ b/analytics/aggregators/geo_demand.py
@@ -18,8 +18,11 @@ def compute_geo_demand_weekly(session: Session, week_start: date) -> list[GeoDem
     Count ``dbo.job_postings`` rows per ``borderplex_subregion`` for the week beginning
     ``week_start`` (inclusive) through ``week_start + 7 days`` (exclusive), in UTC.
 
+    Week bucketing uses ``COALESCE(publish_date, date_posted)`` so postings that lack a
+    ``publish_date`` (the majority of the corpus) fall back to the promoted ``date_posted``
+    column added in Issue #172.  Rows with NULL ``borderplex_subregion`` are excluded.
+
     Returns ORM instances without primary keys set, ready for ``session.add_all`` / bulk insert.
-    Rows with NULL ``borderplex_subregion`` are excluded.
     """
     bind = session.get_bind()
     if bind is None or bind.dialect.name != "postgresql":
@@ -45,9 +48,9 @@ def compute_geo_demand_weekly(session: Session, week_start: date) -> list[GeoDem
             TRIM(BOTH FROM jp.borderplex_subregion::text) AS region,
             COUNT(*)::bigint AS cnt
         FROM dbo.job_postings jp
-        WHERE jp.publish_date IS NOT NULL
-          AND jp.publish_date >= :week_start_ts
-          AND jp.publish_date < :week_end_ts
+        WHERE COALESCE(jp.publish_date, jp.date_posted) IS NOT NULL
+          AND COALESCE(jp.publish_date, jp.date_posted) >= :week_start_ts
+          AND COALESCE(jp.publish_date, jp.date_posted) < :week_end_ts
           AND jp.borderplex_subregion IS NOT NULL
           AND TRIM(BOTH FROM jp.borderplex_subregion::text) <> ''
         GROUP BY TRIM(BOTH FROM jp.borderplex_subregion::text)

--- a/analytics/tests/test_geo_demand.py
+++ b/analytics/tests/test_geo_demand.py
@@ -18,6 +18,12 @@ def _pg_session() -> MagicMock:
     return session
 
 
+def _executed_sql(session: MagicMock) -> str:
+    """Return the SQL string passed to session.execute."""
+    stmt = session.execute.call_args[0][0]
+    return str(stmt)
+
+
 def test_compute_geo_demand_weekly_non_postgresql_raises() -> None:
     session = MagicMock()
     bind = MagicMock()
@@ -59,3 +65,43 @@ def test_compute_geo_demand_weekly_empty() -> None:
 
     rows = compute_geo_demand_weekly(session, date(2025, 12, 1))
     assert rows == []
+
+
+def test_compute_geo_demand_weekly_sql_uses_coalesce_fallback() -> None:
+    """SQL must use COALESCE(publish_date, date_posted) — not publish_date alone.
+
+    Postings promoted via Issue #172 carry date_posted but NULL publish_date.
+    A filter on publish_date IS NOT NULL would silently drop the vast majority
+    of the corpus.  This test guards against regression to the old behaviour.
+    """
+    session = _pg_session()
+    mappings = MagicMock()
+    mappings.all.return_value = []
+    session.execute.return_value.mappings.return_value = mappings
+
+    compute_geo_demand_weekly(session, date(2026, 4, 13))
+
+    sql = _executed_sql(session).upper()
+    assert "COALESCE" in sql, "SQL must use COALESCE to fall back to date_posted"
+    assert "DATE_POSTED" in sql, "SQL must reference date_posted as the COALESCE fallback"
+
+
+def test_compute_geo_demand_weekly_date_window_binds() -> None:
+    """Week window parameters must span exactly 7 days and use UTC datetimes."""
+    from datetime import timezone
+
+    session = _pg_session()
+    mappings = MagicMock()
+    mappings.all.return_value = []
+    session.execute.return_value.mappings.return_value = mappings
+
+    ws = date(2026, 4, 13)
+    compute_geo_demand_weekly(session, ws)
+
+    bound = session.execute.call_args[0][1]
+    ts_start = bound["week_start_ts"]
+    ts_end = bound["week_end_ts"]
+
+    assert ts_start.tzinfo == timezone.utc
+    assert ts_end.tzinfo == timezone.utc
+    assert (ts_end - ts_start).days == 7


### PR DESCRIPTION
## Problem

`geo_demand_weekly` was producing 0 rows despite 3,600+ job postings in the
database. The aggregator filtered on `jp.publish_date IS NOT NULL`, silently
dropping ~94% of the corpus whose `publish_date` is NULL.

Issue #172 promoted `date_posted` onto `job_postings` as a reliable fallback
date, but `geo_demand.py` was never updated to use it.

## Root cause

`demand_weekly.py` already applied the correct pattern:
```sql
COALESCE(jp.publish_date, nj.date_posted)

## Fix

Replace the `publish_date IS NOT NULL` filter in `compute_geo_demand_weekly`
with `COALESCE(jp.publish_date, jp.date_posted)` — using `jp.date_posted`
directly since Issue #172 made it available on `job_postings` without
requiring a join to `normalized_jobs`.

`demand_weekly.py` already applied the correct pattern:

```sql
COALESCE(jp.publish_date, nj.date_posted)
```

`geo_demand.py` was written before #172 landed and was never aligned with
that convention.

## Result (local DB, week 2026-04-13)

| Table | Before | After |
|---|---|---|
| `geo_demand_weekly` | 0 rows | 3 regions · 928 postings |

## Tests

- Added `test_compute_geo_demand_weekly_sql_uses_coalesce_fallback` — asserts
  the generated SQL contains `COALESCE` and `DATE_POSTED`, preventing
  regression to `publish_date`-only filtering.
- Added `test_compute_geo_demand_weekly_date_window_binds` — asserts the week
  window spans exactly 7 days with UTC tzinfo.
- All 5 tests pass (`pytest analytics/tests/test_geo_demand.py -v`).

## Files changed

- `analytics/aggregators/geo_demand.py` — SQL fix + updated docstring
- `analytics/tests/test_geo_demand.py` — 2 new regression tests