### PR TITLE
fix(eval): infra failures → None not 0.0 for content metrics (JIE #263)

### DIFF
--- a/eval/qa_eval.py
+++ b/eval/qa_eval.py
@@ -184,7 +184,11 @@ def _answerability_run_summary(
 
 
 def _evaluator_factory(sla_seconds: float | None):
-    """Build Langfuse evaluator: four core Evaluations, plus answerability when scored."""
+    """Build Langfuse evaluator: core Evaluations (None scores skipped), plus answerability when scored.
+
+    Infrastructure-excluded content metrics (JIE #263) produce no Evaluation rather than a 0.0
+    value so they are absent from Langfuse score distributions rather than polluting them.
+    """
 
     def combined_evaluator(
         *,
@@ -197,13 +201,8 @@ def _evaluator_factory(sla_seconds: float | None):
         from langfuse import Evaluation
 
         if not isinstance(output, dict):
-            # No golden on malformed output — emit four scores only.
-            return [
-                Evaluation(name="intent_accuracy", value=0.0, comment="malformed task output"),
-                Evaluation(name="evidence_citation", value=0.0, comment="malformed task output"),
-                Evaluation(name="confidence_flags", value=0.0, comment="malformed task output"),
-                Evaluation(name="latency_sla", value=0.0, comment="malformed task output"),
-            ]
+            # Malformed harness output (not a pipeline failure) — emit latency only.
+            return [Evaluation(name="latency_sla", value=0.0, comment="malformed task output")]
         golden = output.get("golden") or {}
         scores = compute_item_scores(
             golden=golden,
@@ -212,34 +211,29 @@ def _evaluator_factory(sla_seconds: float | None):
             pipeline_error=output.get("pipeline_error"),
             sla_seconds=sla_seconds,
         )
-        base = [
-            Evaluation(
-                name="intent_accuracy", value=scores.intent_accuracy, comment=scores.comments["intent_accuracy"]
-            ),
-            Evaluation(
-                name="evidence_citation",
-                value=scores.evidence_citation,
-                comment=scores.comments["evidence_citation"][:500],
-            ),
-            Evaluation(
-                name="confidence_flags",
-                value=scores.confidence_flags,
-                comment=scores.comments["confidence_flags"][:500],
-            ),
-            Evaluation(name="latency_sla", value=scores.latency_sla, comment=scores.comments["latency_sla"][:500]),
-        ]
+        # Only emit Evaluations for scorable (non-None) values; Langfuse requires float.
+        evals: list[Any] = []
+        for name in ("intent_accuracy", "evidence_citation", "confidence_flags"):
+            val = getattr(scores, name)
+            if val is not None:
+                evals.append(Evaluation(name=name, value=val, comment=scores.comments[name][:500]))
+        evals.append(
+            Evaluation(name="latency_sla", value=scores.latency_sla, comment=scores.comments["latency_sla"][:500])
+        )
         if scores.answerability is not None:
             ab_c = (scores.comments.get("answerability") or "")[:500]
-            base.append(
-                Evaluation(name="answerability", value=float(scores.answerability), comment=ab_c),
-            )
-        return base
+            evals.append(Evaluation(name="answerability", value=float(scores.answerability), comment=ab_c))
+        return evals
 
     return combined_evaluator
 
 
 def _run_evaluators_average() -> list:
-    """Run-level means for the four core metrics, plus mean answerability when present."""
+    """Run-level means for the four core metrics, plus mean answerability when present.
+
+    ``n_scored`` and ``n_excluded`` are included in each comment so readers know
+    the denominator and how many items were excluded as infrastructure failures (JIE #263).
+    """
 
     def run_mean(*, item_results: list, **kwargs: Any):
         from langfuse import Evaluation
@@ -257,11 +251,14 @@ def _run_evaluators_average() -> list:
                 val = getattr(ev, "value", None) if not isinstance(ev, dict) else ev.get("value")
                 if name in sums and isinstance(val, (int, float)):
                     sums[name].append(float(val))
+        n_total = len(item_results)
         out: list[Any] = []
         for k in ("intent_accuracy", "evidence_citation", "confidence_flags", "latency_sla"):
             vals = sums[k]
             if vals:
-                out.append(Evaluation(name=f"mean_{k}", value=sum(vals) / len(vals), comment=f"n={len(vals)}"))
+                n_excl = n_total - len(vals)
+                cmt = f"n_scored={len(vals)} n_excluded={n_excl} n_total={n_total}"
+                out.append(Evaluation(name=f"mean_{k}", value=sum(vals) / len(vals), comment=cmt))
         ab = sums["answerability"]
         n_scored, n_skip, _ = _answerability_run_summary(item_results)
         if ab:
@@ -301,22 +298,34 @@ def _local_answerability_summary(
     }
 
 
+def _metric_mean(rows: list[tuple[str, QAItemScores, str | None]], key: str) -> tuple[float | None, int, int]:
+    """Return (mean_or_None, n_scored, n_excluded) for a named metric across rows."""
+    vals = [getattr(r[1], key) for r in rows if getattr(r[1], key) is not None]
+    n_scored = len(vals)
+    n_excl = len(rows) - n_scored
+    mean = sum(vals) / n_scored if vals else None
+    return mean, n_scored, n_excl
+
+
 def print_console_summary(
     *,
     rows: list[tuple[str, QAItemScores, str | None]],
     worst_n: int = 8,
 ) -> None:
-    """Print means and worst items by composite score."""
+    """Print per-metric means (with n_scored / n_excluded) and worst items by composite."""
     if not rows:
         print("No items.")
         return
     n = len(rows)
     keys = ("intent_accuracy", "evidence_citation", "confidence_flags", "latency_sla")
-    means = {k: sum(getattr(r[1], k) for r in rows) / n for k in keys}
     print("\n=== QA golden eval — means ===")
     for k in keys:
-        print(f"  {k}: {means[k]:.4f}")
-    print(f"\nItems scored: {n}")
+        mean, n_scored, n_excl = _metric_mean(rows, k)
+        if mean is not None:
+            print(f"  {k}: {mean:.4f}  (n_scored={n_scored}/{n} excluded={n_excl})")
+        else:
+            print(f"  {k}: — excluded all  (n_excluded={n_excl}/{n})")
+    print(f"\nItems total: {n}")
     a_sum = _local_answerability_summary(rows)
     print("\n=== Answerability (harness data-backed expected intents; not in composite) ===")
     if a_sum["n_data_backed"]:
@@ -505,8 +514,13 @@ def main(argv: list[str] | None = None) -> int:
         }
         if rows:
             keys = ("intent_accuracy", "evidence_citation", "confidence_flags", "latency_sla")
-            n = len(rows)
-            payload_local["means"] = {k: sum(getattr(r[1], k) for r in rows) / n for k in keys}
+            payload_local["means"] = {
+                k: round(m, 6) if (m := _metric_mean(rows, k)[0]) is not None else None
+                for k in keys
+            }
+            payload_local["excluded_counts"] = {
+                k: _metric_mean(rows, k)[2] for k in ("intent_accuracy", "evidence_citation", "confidence_flags")
+            }
             payload_local["answerability_summary"] = _local_answerability_summary(rows)
             payload_local["intent_confusion"] = {
                 f"{e}->{p}": c for (e, p), c in sorted(confusion_rows(intent_pairs).items())

--- a/eval/qa_eval.py
+++ b/eval/qa_eval.py
@@ -336,14 +336,17 @@ def print_console_summary(
     else:
         print(f"  (no data-backed items)  intent-only / skipped: {a_sum['n_intent_only_skipped']}")
 
+    def _fmt(v: float | None) -> str:
+        return f"{v:.2f}" if v is not None else " — "
+
     ranked = sorted(rows, key=lambda r: composite_score(r[1]))
     print(f"\n=== Worst {worst_n} by composite (mean of four scores) ===")
     for gq_id, sc, err in ranked[:worst_n]:
         ce = err or ""
         print(
             f"  {gq_id}: composite={composite_score(sc):.3f} "
-            f"i={sc.intent_accuracy:.2f} e={sc.evidence_citation:.2f} "
-            f"c={sc.confidence_flags:.2f} l={sc.latency_sla:.2f} {ce[:60]}"
+            f"i={_fmt(sc.intent_accuracy)} e={_fmt(sc.evidence_citation)} "
+            f"c={_fmt(sc.confidence_flags)} l={sc.latency_sla:.2f} {ce[:60]}"
         )
 
 

--- a/eval/qa_scoring.py
+++ b/eval/qa_scoring.py
@@ -1,13 +1,34 @@
-"""Automated scores (0.0–1.0) for golden-question Q&A eval — Week 9 harness.
+"""Automated scores (0.0–1.0 or None) for golden-question Q&A eval — Week 9 harness.
 
 Core four metrics (baseline composite) per docs/Week 9/TODO.md:
 ``intent_accuracy``, ``evidence_citation``, ``confidence_flags``, ``latency_sla``.
 
+## None semantics (JIE #263)
+
+Infrastructure failures (pipeline crash, SQL execution error, empty answer) are
+**excluded** from quality metrics rather than zeroed out.  Zeroing them would
+conflate two orthogonal axes — pipeline health vs answer quality — and prevent
+Week 10 pairs from distinguishing "fix the prompt" from "fix the infrastructure".
+
+| Failure class                        | Score   | Rationale                              |
+|--------------------------------------|---------|----------------------------------------|
+| pipeline_error / timeout / 500       | ``None``| Infra failure; not gradable            |
+| sql_execution_error_detail set       | ``None``| Infra failure on evidence_citation     |
+| Empty answer (contract violation)    | ``None``| Pipeline output contract broken        |
+| Committed answer with no evidence    | ``0.0`` | Real quality failure; keep as signal   |
+| Correct classification of any intent | ``1.0`` | Quality signal; always computable      |
+
+``latency_sla`` is the one exception: wall-clock time is computable even when the
+pipeline fails, so it always returns a float.
+
 An optional fifth metric, ``answerability``, is reported separately: for expected
 intents marked data-backed in ``INTENT_TO_DATA_BACKED`` it is 1.0 when
-``row_count_returned > 0`` in the pipeline response, else 0.0. Intents that are
-not data-backed in the harness map are skipped (``answerability`` is ``None``).
-The baseline ``composite_score`` is still the mean of the four core metrics only.
+``row_count_returned > 0``, else 0.0 (infra → 0.0 will be fixed in JIE #269).
+Intents not in the data-backed map are skipped (returns ``None``).
+
+The ``composite_score`` is the mean of the four core metrics over the **scorable
+pool** — ``None`` values are excluded before averaging, so the denominator shrinks
+rather than the mean being dragged down by infrastructure noise.
 """
 
 from __future__ import annotations
@@ -33,7 +54,7 @@ _LABORPULSE_CONFIDENCE_BUCKET: dict[str, float] = {
 _TOKEN_SPLIT = re.compile(r"[_\s]+")
 
 # Whether the golden *expected* intent is evaluated for answerability (SQL rows).
-# Only the Week 9 eval harness (Pair A) maintains this map as data/pipeline
+# Only the Week 9 eval harness (Pair C) maintains this map as data/pipeline
 # capabilities land; the classifier does not set this.
 INTENT_TO_DATA_BACKED: dict[str, bool] = {
     "trend": False,
@@ -66,10 +87,13 @@ def _norm_intent(s: str | None) -> str:
 
 @dataclass(frozen=True)
 class QAItemScores:
-    intent_accuracy: float
-    evidence_citation: float
-    confidence_flags: float
+    # Content metrics: None when excluded due to infrastructure failure (JIE #263).
+    intent_accuracy: float | None
+    evidence_citation: float | None
+    confidence_flags: float | None
+    # Latency is always computable — even on pipeline failure we have wall-clock time.
     latency_sla: float
+    # Answerability: None for non-data-backed intents (skipped by design).
     answerability: float | None
     comments: dict[str, str]
 
@@ -117,15 +141,24 @@ def score_evidence_citation(
     refused: bool,
     sql_execution_error_detail: str | None,
     pipeline_error: str | None,
-) -> tuple[float, str]:
-    """Grounding + rubric heuristics (semantic tokens → keyword presence)."""
+) -> tuple[float | None, str]:
+    """Grounding + rubric heuristics (semantic tokens → keyword presence).
+
+    Returns ``None`` for infrastructure failures so they are excluded from run
+    means rather than dragging down the quality signal (JIE #263):
+
+    - ``pipeline_error`` set           → ``None`` (pipeline crash / timeout)
+    - ``sql_execution_error_detail`` set → ``None`` (SQL infra failure)
+    - empty answer                     → ``None`` (input-contract violation)
+    - committed answer, no evidence    → ``0.0`` (real quality failure)
+    """
     if pipeline_error:
-        return 0.0, f"pipeline_error: {pipeline_error[:200]}"
+        return None, f"excluded: pipeline_error — {pipeline_error[:200]}"
     if sql_execution_error_detail:
-        return 0.0, "sql_execution_error present"
+        return None, f"excluded: sql_execution_error — {sql_execution_error_detail[:200]}"
     ans = (answer or "").strip().lower()
     if not ans:
-        return 0.0, "empty answer"
+        return None, "excluded: empty answer (input-contract violation)"
 
     if refused:
         # Refusal can be correct; reward non-empty evidence or explicit caveat in answer.
@@ -243,6 +276,9 @@ def score_answerability(
 
     ``row_count_returned`` is set on the analytics API response
     (``AnalyticsQueryResponse``) from guardrailed SQL row count.
+
+    Note: infra failures still return 0.0 here (not None) — that redesign is
+    tracked as JIE #269 (answerability redesign).
     """
     exp = _norm_intent(expected_intent)
     if not exp:
@@ -270,9 +306,16 @@ def compute_item_scores(
     pipeline_error: str | None,
     sla_seconds: float | None = None,
 ) -> QAItemScores:
-    """Aggregate four core scores and optional answerability; on failure use 0.0 (or skip) with comments."""
+    """Aggregate four core scores and optional answerability.
+
+    On infrastructure failure (``pipeline_error`` or no ``response``), content
+    metrics are set to ``None`` so they are excluded from run means.  Only
+    ``latency_sla`` is always computed (JIE #263).
+    """
     exp_intent = str(golden.get("intent") or golden.get("expected_intent") or "")
     difficulty = str(golden.get("difficulty") or "medium")
+
+    ls, ls_c = score_latency_sla(latency_seconds=latency_seconds, sla_seconds=sla_seconds)
 
     if pipeline_error or response is None:
         an, an_c = score_answerability(
@@ -280,21 +323,21 @@ def compute_item_scores(
             response=None,
             pipeline_error=pipeline_error,
         )
-        z = QAItemScores(
-            intent_accuracy=0.0,
-            evidence_citation=0.0,
-            confidence_flags=0.0,
-            latency_sla=score_latency_sla(latency_seconds=latency_seconds, sla_seconds=sla_seconds)[0],
+        reason = pipeline_error or "no response"
+        return QAItemScores(
+            intent_accuracy=None,
+            evidence_citation=None,
+            confidence_flags=None,
+            latency_sla=ls,
             answerability=an,
             comments={
-                "intent_accuracy": pipeline_error or "no response",
-                "evidence_citation": pipeline_error or "no response",
-                "confidence_flags": pipeline_error or "no response",
-                "latency_sla": "latency only (pipeline failed)",
+                "intent_accuracy": f"excluded: {reason}",
+                "evidence_citation": f"excluded: {reason}",
+                "confidence_flags": f"excluded: {reason}",
+                "latency_sla": f"{ls_c} (content metrics excluded — pipeline failure)",
                 "answerability": an_c,
             },
         )
-        return z
 
     classified = str(response.get("classified_intent") or "other")
     ia, ia_c = score_intent_accuracy(
@@ -323,7 +366,6 @@ def compute_item_scores(
         volume_warning=response.get("volume_warning"),
     )
 
-    ls, ls_c = score_latency_sla(latency_seconds=latency_seconds, sla_seconds=sla_seconds)
     an, an_c = score_answerability(
         expected_intent=exp_intent,
         response=response,
@@ -347,9 +389,21 @@ def compute_item_scores(
 
 
 def composite_score(scores: QAItemScores) -> float:
-    """Mean of the four core metrics only (excludes ``answerability``)."""
-    vals = (scores.intent_accuracy, scores.evidence_citation, scores.confidence_flags, scores.latency_sla)
-    return float(sum(vals) / max(1, len(vals)))
+    """Mean of scorable core metrics only (excludes ``answerability`` and ``None`` values).
+
+    ``latency_sla`` is always a float so the denominator is always ≥ 1.
+    Content metrics excluded due to infrastructure failures (JIE #263) are
+    dropped from the average — the denominator shrinks rather than the mean
+    being dragged down by pipeline noise.
+    """
+    candidates = (
+        scores.intent_accuracy,
+        scores.evidence_citation,
+        scores.confidence_flags,
+        scores.latency_sla,
+    )
+    vals = [v for v in candidates if v is not None]
+    return float(sum(vals) / len(vals))
 
 
 def confusion_rows(

--- a/eval/tests/test_qa_eval_scoring.py
+++ b/eval/tests/test_qa_eval_scoring.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import io
+from contextlib import redirect_stdout
+
+from eval.qa_eval import print_console_summary
 from eval.qa_scoring import (
     QAItemScores,
     composite_score,
@@ -348,6 +352,51 @@ def test_composite_filters_none_partial() -> None:
     )
     # mean((0.0, 1.0)) = 0.5
     assert abs(composite_score(mixed) - 0.5) < 1e-9
+
+
+def test_print_console_summary_does_not_crash_with_none_content_metrics() -> None:
+    """Regression: print_console_summary must not raise TypeError when content metrics are None.
+
+    Before the fix, f"{None:.2f}" in the worst-N block crashed the summary for any
+    eval run that included at least one pipeline-failed item (JIE #263 exclusion design).
+    """
+    infra_fail = QAItemScores(
+        intent_accuracy=None,
+        evidence_citation=None,
+        confidence_flags=None,
+        latency_sla=0.8,
+        answerability=None,
+        comments={
+            "intent_accuracy": "excluded: connection reset",
+            "evidence_citation": "excluded: connection reset",
+            "confidence_flags": "excluded: connection reset",
+            "latency_sla": "latency computed",
+            "answerability": "skipped: intent not data-backed",
+        },
+    )
+    good = QAItemScores(
+        intent_accuracy=1.0,
+        evidence_citation=0.9,
+        confidence_flags=0.85,
+        latency_sla=1.0,
+        answerability=None,
+        comments={
+            "intent_accuracy": "intent matches",
+            "evidence_citation": "overlap heuristic",
+            "confidence_flags": "calibration ok",
+            "latency_sla": "within SLA",
+            "answerability": "skipped",
+        },
+    )
+    rows = [("gq-001", infra_fail, "connection reset"), ("gq-002", good, None)]
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        print_console_summary(rows=rows, worst_n=5)
+    out = buf.getvalue()
+    # None content metrics render as " — " not as a numeric format
+    assert " — " in out
+    # Non-None metrics still render as float strings
+    assert "1.00" in out or "0.90" in out
 
 
 def test_confusion_rows() -> None:

--- a/eval/tests/test_qa_eval_scoring.py
+++ b/eval/tests/test_qa_eval_scoring.py
@@ -54,8 +54,9 @@ def test_evidence_empty_not_refused() -> None:
     assert "no evidence" in c
 
 
-def test_evidence_pipeline_error_zero() -> None:
-    s, _ = score_evidence_citation(
+def test_evidence_pipeline_error_excluded() -> None:
+    """pipeline_error → None (excluded), not 0.0 (JIE #263)."""
+    s, c = score_evidence_citation(
         answer="x",
         evidence=[{"title": "t", "snippet": "n"}],
         must_include=[],
@@ -64,7 +65,53 @@ def test_evidence_pipeline_error_zero() -> None:
         sql_execution_error_detail=None,
         pipeline_error="boom",
     )
+    assert s is None
+    assert "excluded" in c
+
+
+def test_evidence_sql_error_excluded() -> None:
+    """sql_execution_error_detail → None (infrastructure failure, JIE #263)."""
+    s, c = score_evidence_citation(
+        answer="El Paso employers showed growth.",
+        evidence=[{"title": "t", "source": "s", "snippet": "el paso"}],
+        must_include=[],
+        must_not_include=[],
+        refused=False,
+        sql_execution_error_detail="column foo does not exist",
+        pipeline_error=None,
+    )
+    assert s is None
+    assert "excluded" in c
+
+
+def test_evidence_empty_answer_excluded() -> None:
+    """Empty answer is an input-contract violation → None (JIE #263)."""
+    s, c = score_evidence_citation(
+        answer="",
+        evidence=[{"title": "t", "snippet": "n"}],
+        must_include=[],
+        must_not_include=[],
+        refused=False,
+        sql_execution_error_detail=None,
+        pipeline_error=None,
+    )
+    assert s is None
+    assert "excluded" in c
+
+
+def test_evidence_committed_no_evidence_stays_zero() -> None:
+    """A non-empty, non-refused answer with no evidence rows is a real quality failure (0.0)."""
+    s, c = score_evidence_citation(
+        answer="El Paso employers showed growth.",
+        evidence=[],
+        must_include=[],
+        must_not_include=[],
+        refused=False,
+        sql_execution_error_detail=None,
+        pipeline_error=None,
+    )
     assert s == 0.0
+    assert "no evidence" in c
 
 
 def test_confidence_calibration() -> None:
@@ -88,7 +135,8 @@ def test_latency_above_sla() -> None:
     assert abs(s - 0.5) < 1e-6
 
 
-def test_compute_failure_all_zeros_except_latency() -> None:
+def test_compute_failure_content_excluded_latency_computed() -> None:
+    """On pipeline failure, content metrics are None (excluded); latency is still computed (JIE #263)."""
     g = {"id": "gq-001", "intent": "geographic", "must_include": [], "must_not_include": []}
     out = compute_item_scores(
         golden=g,
@@ -97,11 +145,42 @@ def test_compute_failure_all_zeros_except_latency() -> None:
         pipeline_error="connection reset",
         sla_seconds=45.0,
     )
-    assert out.intent_accuracy == 0.0
-    assert out.evidence_citation == 0.0
-    assert out.confidence_flags == 0.0
+    assert out.intent_accuracy is None
+    assert out.evidence_citation is None
+    assert out.confidence_flags is None
     assert out.latency_sla > 0.0
+    # geographic is data-backed; answerability stays 0.0 on infra failure (JIE #269 will fix).
     assert out.answerability == 0.0
+    assert "excluded" in out.comments["intent_accuracy"].lower()
+    assert "excluded" in out.comments["evidence_citation"].lower()
+
+
+def test_compute_sql_error_excludes_evidence_citation_only() -> None:
+    """sql_execution_error_detail excludes evidence_citation but leaves intent_accuracy scorable."""
+    g = {"id": "gq-sql", "intent": "employer", "must_include": [], "must_not_include": []}
+    resp = {
+        "answer": "Some answer here.",
+        "evidence": [],
+        "confidence": 0.8,
+        "confidence_flagged_low": False,
+        "confidence_explanation": None,
+        "volume_flagged_low": False,
+        "volume_warning": None,
+        "refused": False,
+        "sql_execution_error_detail": "relation does not exist",
+        "classified_intent": "employer",
+        "row_count_returned": 0,
+    }
+    out = compute_item_scores(
+        golden=g,
+        response=resp,
+        latency_seconds=3.0,
+        pipeline_error=None,
+        sla_seconds=45.0,
+    )
+    assert out.intent_accuracy == 1.0, "intent classification is unaffected by SQL error"
+    assert out.evidence_citation is None, "SQL error excludes evidence_citation"
+    assert out.confidence_flags is not None, "confidence calibration is unaffected by SQL error"
 
 
 def test_pipeline_error_skips_answerability_for_intent_only() -> None:
@@ -231,6 +310,44 @@ def test_composite_excludes_answerability() -> None:
         comments={},
     )
     assert composite_score(hi) == 0.0
+
+
+def test_composite_filters_none_uses_latency_anchor() -> None:
+    """When all content metrics are None (infra failure), composite is anchored to latency_sla only (JIE #263)."""
+    scores = QAItemScores(
+        intent_accuracy=None,
+        evidence_citation=None,
+        confidence_flags=None,
+        latency_sla=1.0,
+        answerability=None,
+        comments={},
+    )
+    assert composite_score(scores) == 1.0
+
+
+def test_composite_filters_none_partial() -> None:
+    """Partial None: composite averages over the scorable pool only, denominator shrinks (JIE #263)."""
+    scores = QAItemScores(
+        intent_accuracy=1.0,
+        evidence_citation=None,
+        confidence_flags=None,
+        latency_sla=1.0,
+        answerability=None,
+        comments={},
+    )
+    # Only intent_accuracy and latency_sla are scorable → mean((1.0, 1.0)) = 1.0
+    assert composite_score(scores) == 1.0
+
+    mixed = QAItemScores(
+        intent_accuracy=0.0,
+        evidence_citation=None,
+        confidence_flags=None,
+        latency_sla=1.0,
+        answerability=None,
+        comments={},
+    )
+    # mean((0.0, 1.0)) = 0.5
+    assert abs(composite_score(mixed) - 0.5) < 1e-9
 
 
 def test_confusion_rows() -> None:


### PR DESCRIPTION
## Summary

- **Root cause**: pipeline crashes and SQL errors were scored as `0.0` for `intent_accuracy`, `evidence_citation`, and `confidence_flags`, conflating infrastructure health with answer quality and distorting run means.
- **Fix**: infrastructure failures now return `None` — excluded from Langfuse score distributions and console means; `latency_sla` stays `float` (always computable).
- **Scope**: `QAItemScores` type widening, `score_evidence_citation` early returns, `compute_item_scores` short-circuit path, `composite_score` None-filter, `_evaluator_factory` skip-None emission, `_run_evaluators_average` `n_excluded` comments, `print_console_summary` None-safe means, `payload_local["excluded_counts"]`.

## Failure → score mapping

| Failure class | Score | Rationale |
|---|---|---|
| `pipeline_error` / timeout | `None` | Infra; not gradable |
| `sql_execution_error_detail` set | `None` for `evidence_citation` only | SQL infra failure; `intent_accuracy` / `confidence_flags` still scorable |
| Empty answer | `None` | Input-contract violation from pipeline |
| Committed answer, no evidence rows | `0.0` | Real quality failure — keep as signal |

## Commits

1. `fix(eval/scoring)` — dataclass types, `score_evidence_citation`, `compute_item_scores`, `composite_score`
2. `fix(eval/qa_eval)` — skip `None` Evaluations in Langfuse, `n_scored/n_excluded` comments, `_metric_mean` helper, `excluded_counts` in JSON payload
3. `test(eval)` — 8 updated/new tests covering the full None-safety contract

## Test plan

- [x] `eval/tests/test_qa_eval_scoring.py` — 21 tests all green
- [x] `tests/test_qa_scoring_laborpulse_confidence.py` — 11 tests all green
- [x] `tests/test_qa_eval_http_path.py` — 8 tests all green
- [x] `tests/test_qa_eval_laborpulse_headers.py` — 3 tests all green

## Follow-up

- **JIE #269** — extend same None pattern to `score_answerability` infra failures (currently `0.0`)
- **JIE #270** — geometric-mean composite and sub-composite redesign (builds on this None foundation)

Closes #263

Made with [Cursor](https://cursor.com)