### PR TITLE
chore: document qa-eval --use-http env-var pattern in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,18 @@ JSEARCH_API_KEY_4=                                # optional overflow
 # --- POST /analytics/query API keys (JIE #226, LaborPulse / wfd-os) ---
 # Server allowlist: JSON array of { "key_id": "...", "secret": "..." }.
 # Logs record key_id only; never log the secret.
+#
+# Local dev quick start (qa-eval --use-http and similar CLI flows):
+#   The JIE_API_KEYS[].secret MUST match ANALYTICS_QUERY_X_API_KEY exactly —
+#   the server-side allowlist and the outbound client header are two ends of the
+#   same secret. Generate one hex value, paste it into both places. Example:
+#
+#   JIE_API_KEYS=[{"key_id":"local-dev-1","secret":"a1b2c3d4e5f6789012345678abcdef01"}]
+#   ANALYTICS_QUERY_X_TENANT_ID=borderplex
+#   ANALYTICS_QUERY_X_USER_EMAIL=you@example.com
+#   ANALYTICS_QUERY_X_API_KEY=a1b2c3d4e5f6789012345678abcdef01
+#
+# (Replace the secret with your own random hex; the value above is illustrative only.)
 # JIE_API_KEYS=[{"key_id":"local-dev-1","secret":"REPLACE_ME"}]
 JIE_API_KEYS=
 # Or point to a YAML/JSON file with the same list shape:
@@ -67,10 +79,10 @@ JIE_API_KEYS=
 JIE_API_KEYS_FILE=
 # Clients (dashboard, curl, smoke scripts) must send: X-API-Key: <secret matching one entry>
 # LaborPulse POST /analytics/query also requires X-Tenant-Id, X-User-Email, X-Request-Id (JIE #222):
-# ANALYTICS_QUERY_X_TENANT_ID=borderplex
-# ANALYTICS_QUERY_X_USER_EMAIL=dashboard@thewaifinder.com
+ANALYTICS_QUERY_X_TENANT_ID=
+ANALYTICS_QUERY_X_USER_EMAIL=
 # ANALYTICS_QUERY_X_REQUEST_ID=          # optional; if empty, clients generate a UUID per request
-# ANALYTICS_QUERY_X_API_KEY=REPLACE_ME   # outbound secret for dashboard/scripts when calling the API
+ANALYTICS_QUERY_X_API_KEY=
 # JIE #224 — X-Tenant-Id allowlist (analytics/tenant_scope.py). Unknown IDs -> 400 invalid_tenant_id.
 # JIE_TENANT_ALLOWLIST=borderplex,puget_sound
 


### PR DESCRIPTION
## Summary

Adds a **Local dev quick start** comment block to `.env.example` capturing the env-var pattern Emilio shared in Discord on 2026-04-24 for running `qa-eval --use-http` (and similar CLI flows that hit `POST /analytics/query`).

The four vars were already present but commented out, with no obvious indication that they need to be wired together. The new block:

- Calls out the critical invariant: **`JIE_API_KEYS[].secret` MUST match `ANALYTICS_QUERY_X_API_KEY` exactly** — the server allowlist and the outbound client header are two ends of the same secret.
- Provides a working example block with an illustrative hex secret.

Also uncomments `ANALYTICS_QUERY_X_TENANT_ID=`, `ANALYTICS_QUERY_X_USER_EMAIL=`, and `ANALYTICS_QUERY_X_API_KEY=` so they appear in the same "required for HTTP mode" shape as `JIE_API_KEYS=`. `ANALYTICS_QUERY_X_REQUEST_ID` stays commented (genuinely optional — clients auto-generate UUID per request).

## Test plan

- [x] `.env.example` still parses cleanly (no shell syntax errors)
- [x] No actual secrets committed (the hex value in the comment block is illustrative only)
- [x] Vars match what's already consumed by `analytics/api/auth.py` + `analytics/cli/qa_eval.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)