### PR TITLE
fix(#289): structural fix for promotion silent-skip + promoted_at audit

### DIFF
--- a/common/data_store/migrations.py
+++ b/common/data_store/migrations.py
@@ -186,6 +186,13 @@ _NORMALIZED_JOBS_ALTER_STATEMENTS = [
     "ALTER TABLE dbo.raw_ingested_jobs ADD COLUMN IF NOT EXISTS zip_code VARCHAR(10)",
     "ALTER TABLE dbo.normalized_jobs ADD COLUMN IF NOT EXISTS naics_code TEXT",
     "ALTER TABLE dbo.normalized_jobs ADD COLUMN IF NOT EXISTS employer_metadata JSONB",
+    # JIE #289 — promotion audit column. Stamped by apply_enrichment_to_job_postings
+    # on successful promotion to dbo.job_postings. NULL means the row has not been
+    # promoted yet; the sweeper at scripts/sweep_unpromoted_normalized_jobs.py picks
+    # NULL rows up after a 1-hour grace window and re-attempts via the standard
+    # promotion path. The grace window is also indexed for the sweeper's hot path.
+    "ALTER TABLE dbo.normalized_jobs ADD COLUMN IF NOT EXISTS promoted_at TIMESTAMPTZ",
+    "CREATE INDEX IF NOT EXISTS ix_normalized_jobs_promoted_at_null ON dbo.normalized_jobs (created_at) WHERE promoted_at IS NULL",
 ]
 
 # Company HQ / location fields for enrichment resolve_location (#110)

--- a/common/data_store/models.py
+++ b/common/data_store/models.py
@@ -230,6 +230,13 @@ class NormalizedJob(Base):
     normalization_errors: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
+    # Promotion audit (JIE #289): stamped by apply_enrichment_to_job_postings
+    # on successful promotion to dbo.job_postings. NULL means "not yet promoted"
+    # — picked up by scripts/sweep_unpromoted_normalized_jobs.py for retry
+    # after a 1-hour grace window. Pre-#289 rows are NULL until the sweeper
+    # or the one-shot backfill backfills them.
+    promoted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
 
 class NormalizationQuarantine(Base):
     """Records that failed normalization validation."""

--- a/enrichment/agent.py
+++ b/enrichment/agent.py
@@ -788,7 +788,26 @@ class EnrichmentAgent(BaseAgent):
                         nj_promo = _coerce_normalized_job_id(
                             enriched.get("normalized_job_id") or posting.get("normalized_job_id")
                         )
-                        if session is not None and nj_promo is not None:
+                        # JIE #289: do NOT silently skip when nj_promo is None or
+                        # session is None. Both produced 469 orphan rows over multiple
+                        # batches before this fix. Log loud at ERROR so the bug is
+                        # observable; sweeper picks up the row after the grace window.
+                        if nj_promo is None:
+                            log.error(
+                                "promotion_skipped_missing_normalized_job_id",
+                                source=posting.get("source"),
+                                external_id=posting.get("external_id"),
+                                call_site="batch_serial",
+                                enriched_has_key="normalized_job_id" in enriched,
+                                posting_has_key="normalized_job_id" in posting,
+                            )
+                        elif session is None:
+                            log.error(
+                                "promotion_skipped_session_unavailable",
+                                normalized_job_id=nj_promo,
+                                call_site="batch_serial",
+                            )
+                        else:
                             try:
                                 apply_enrichment_to_job_postings(
                                     session,
@@ -812,13 +831,25 @@ class EnrichmentAgent(BaseAgent):
                     with session_scope() as db_session:
                         run_batch(db_session)
                 except Exception as exc:
-                    log.warning(
-                        "enrichment_session_scope_failed",
+                    # JIE #289: this fall-through used to silently produce orphans
+                    # for every row in the batch. Now it logs ERROR with the batch
+                    # size so operators can correlate orphan spikes with session
+                    # failures. The rows still get enriched (via run_batch(None))
+                    # but promotion is skipped — sweeper picks them up after grace.
+                    log.error(
+                        "promotion_skipped_session_scope_failed",
                         agent=self.agent_id,
                         error=str(exc),
+                        affected_records=len(rows) if rows else 0,
                     )
                     run_batch(None)
             else:
+                # JIE #289: same observability concern when DB is unreachable.
+                log.error(
+                    "promotion_skipped_db_unavailable",
+                    agent=self.agent_id,
+                    affected_records=len(rows) if rows else 0,
+                )
                 run_batch(None)
 
             # Log enrichment output to Langfuse
@@ -1043,6 +1074,20 @@ class EnrichmentAgent(BaseAgent):
                 triggered_by_event_type=event.payload.get("event_type"),
                 reason=degraded_reason,
                 extraction_note=spam_result.extraction_note,
+            )
+
+        # JIE #289: log loud at ERROR when nj_id is None on the single-record path.
+        # Unlike the batch paths, this path skips DB writes entirely when nj_id is
+        # missing — the sweeper cannot rescue these (no normalized_jobs row was
+        # ever persisted via this code path), so the goal here is observability
+        # for upstream callers that drop normalized_job_id from the payload.
+        if nj_id is None and _db_url_configured():
+            log.error(
+                "promotion_skipped_missing_normalized_job_id",
+                source=event.payload.get("source"),
+                external_id=event.payload.get("external_id"),
+                call_site="single_record",
+                payload_has_key="normalized_job_id" in event.payload,
             )
 
         if nj_id is not None and _db_url_configured():
@@ -1479,7 +1524,18 @@ class EnrichmentAgent(BaseAgent):
                         nj_promo = _coerce_normalized_job_id(
                             enriched.get("normalized_job_id") or posting.get("normalized_job_id")
                         )
-                        if nj_promo is not None:
+                        # JIE #289: log loud at ERROR when nj_promo is None so the bug
+                        # is observable. Sweeper picks up the orphaned row after grace.
+                        if nj_promo is None:
+                            log.error(
+                                "promotion_skipped_missing_normalized_job_id",
+                                source=posting.get("source"),
+                                external_id=posting.get("external_id"),
+                                call_site="batch_parallel",
+                                enriched_has_key="normalized_job_id" in enriched,
+                                posting_has_key="normalized_job_id" in posting,
+                            )
+                        else:
                             try:
                                 apply_enrichment_to_job_postings(
                                     job_session,

--- a/enrichment/job_postings_promotion.py
+++ b/enrichment/job_postings_promotion.py
@@ -669,6 +669,13 @@ def apply_enrichment_to_job_postings(
             normalized_job_id=normalized_job_id,
             job_posting_id=str(job_posting_id),
         )
+        # JIE #289: stamp promoted_at on the source normalized_jobs row so the
+        # sweeper can distinguish "promoted" from "still pending" rows. Same
+        # session as the job_postings UPDATE above — atomic via session.commit().
+        session.execute(
+            text("UPDATE dbo.normalized_jobs SET promoted_at = NOW() WHERE id = :nj_id"),
+            {"nj_id": normalized_job_id},
+        )
         return True
 
     if tier == "uncertain" or spam_score is None:

--- a/enrichment/tests/test_job_postings_promotion.py
+++ b/enrichment/tests/test_job_postings_promotion.py
@@ -295,17 +295,22 @@ def test_apply_enrichment_to_job_postings_logs_and_continues_on_dedup_failure() 
 
     assert applied is True
     session.begin_nested.assert_called_once_with()
-    assert session.execute.call_count == 1
+    # JIE #289: 2 calls now — the original promotion UPDATE plus the
+    # promoted_at timestamp stamp on dbo.normalized_jobs that runs after
+    # fuzzy dedup (regardless of dedup success/failure) so the row is
+    # observable to scripts/sweep_unpromoted_normalized_jobs.py.
+    assert session.execute.call_count == 2
 
 
 def _apply_with_resolved_row_for_temporal_borderplex(resolved_row: dict[str, object]) -> tuple[bool, MagicMock]:
-    """Promotion UPDATE + patched fuzzy dedup (no extra SQL from dedup path)."""
+    """Promotion UPDATE + promoted_at stamp (#289) + patched fuzzy dedup (no extra SQL from dedup path)."""
     session = MagicMock()
     session.begin_nested.return_value = nullcontext()
     resolve_result = MagicMock()
     resolve_result.mappings.return_value.first.return_value = resolved_row
     update_result = MagicMock()
-    session.execute.side_effect = [resolve_result, update_result]
+    promoted_at_stamp_result = MagicMock()
+    session.execute.side_effect = [resolve_result, update_result, promoted_at_stamp_result]
     dedup_result = FuzzyDedupResult(
         is_duplicate=False,
         duplicate_cluster_id=None,
@@ -340,7 +345,8 @@ def test_apply_enrichment_binds_temporal_period_from_date_posted() -> None:
     )
 
     assert out is True
-    assert session.execute.call_count == 2
+    # JIE #289: 3 calls now — resolve + UPDATE + promoted_at stamp.
+    assert session.execute.call_count == 3
     _stmt, params = session.execute.call_args_list[1][0]
     assert params["temporal_period"] == "post_gpt4"
     assert "soc_code" in params
@@ -391,7 +397,8 @@ def test_apply_enrichment_binds_borderplex_subregion_from_normalized_location() 
     )
 
     assert out is True
-    assert session.execute.call_count == 2
+    # JIE #289: 3 calls now — resolve + UPDATE + promoted_at stamp.
+    assert session.execute.call_count == 3
     _stmt, params = session.execute.call_args_list[1][0]
     assert params["borderplex_subregion"] == "el_paso"
 
@@ -424,7 +431,13 @@ def test_apply_enrichment_binds_soc_code_column_from_payload() -> None:
         "date_posted": datetime(2023, 6, 15, 12, 0, 0, tzinfo=timezone.utc),
     }
     update_result = MagicMock()
-    session.execute.side_effect = [resolve_result, update_result]
+    # JIE #289: extra mocks cover any session.execute() calls inside the
+    # un-patched fuzzy dedup path plus the new promoted_at stamp.
+    session.execute.side_effect = [
+        resolve_result,
+        update_result,
+        *[MagicMock() for _ in range(10)],
+    ]
 
     with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
         out = apply_enrichment_to_job_postings(
@@ -522,7 +535,13 @@ def test_apply_enrichment_persists_sector_id_for_known_role() -> None:
         return_value=sector_uuid,
     ) as mock_resolve_sector:
         # Two execute calls: resolve_job_posting_row + UPDATE
-        session.execute.side_effect = [resolve_result, update_result]
+        # JIE #289: extra mocks cover any session.execute() calls inside the
+        # un-patched fuzzy dedup path plus the new promoted_at stamp.
+        session.execute.side_effect = [
+            resolve_result,
+            update_result,
+            *[MagicMock() for _ in range(10)],
+        ]
         out = apply_enrichment_to_job_postings(
             session,
             42,
@@ -556,7 +575,13 @@ def test_apply_enrichment_persists_sector_id_for_unknown_role_fallback() -> None
         "enrichment.job_postings_promotion.resolve_sector",
         return_value=other_sector_uuid,
     ) as mock_resolve_sector:
-        session.execute.side_effect = [resolve_result, update_result]
+        # JIE #289: extra mocks cover any session.execute() calls inside the
+        # un-patched fuzzy dedup path plus the new promoted_at stamp.
+        session.execute.side_effect = [
+            resolve_result,
+            update_result,
+            *[MagicMock() for _ in range(10)],
+        ]
         out = apply_enrichment_to_job_postings(
             session,
             42,
@@ -592,7 +617,13 @@ def test_apply_enrichment_sector_id_is_in_params_base_for_all_tiers() -> None:
             "enrichment.job_postings_promotion.resolve_sector",
             return_value=sector_uuid,
         ):
-            session.execute.side_effect = [resolve_result, update_result]
+            # JIE #289: extra mocks cover any session.execute() calls inside the
+            # un-patched fuzzy dedup path plus the new promoted_at stamp.
+            session.execute.side_effect = [
+                resolve_result,
+                update_result,
+                *[MagicMock() for _ in range(10)],
+            ]
             payload: dict[str, object] = {
                 "spam_tier": tier,
                 "quality_score": 0.85,
@@ -639,7 +670,14 @@ def _apply_with_qna_payload(session: MagicMock, resolved_row: dict, payload_over
     resolve_result = MagicMock()
     resolve_result.mappings.return_value.first.return_value = resolved_row
     update_result = MagicMock()
-    session.execute.side_effect = [resolve_result, update_result]
+    # JIE #289: extra mocks cover any session.execute() calls inside the
+    # un-patched fuzzy dedup path plus the new promoted_at stamp on
+    # dbo.normalized_jobs that runs at the end of _finish_with_dedup.
+    session.execute.side_effect = [
+        resolve_result,
+        update_result,
+        *[MagicMock() for _ in range(10)],
+    ]
 
     payload: dict[str, object] = {
         "spam_tier": "clean",
@@ -783,7 +821,13 @@ def test_apply_enrichment_qna_fields_present_for_all_tiers(tier: str, spam_score
         "is_remote": True,
     }
     update_result = MagicMock()
-    session.execute.side_effect = [resolve_result, update_result]
+    # JIE #289: extra mocks cover any session.execute() calls inside the
+    # un-patched fuzzy dedup path plus the new promoted_at stamp.
+    session.execute.side_effect = [
+        resolve_result,
+        update_result,
+        *[MagicMock() for _ in range(10)],
+    ]
 
     payload: dict[str, object] = {
         "spam_tier": tier,

--- a/scripts/sweep_unpromoted_normalized_jobs.py
+++ b/scripts/sweep_unpromoted_normalized_jobs.py
@@ -1,0 +1,194 @@
+# ruff: noqa: T201
+"""Sweep unpromoted normalized_jobs rows — JIE #289 defense in depth.
+
+Background
+----------
+The live enrichment loop has guards (now loud at ERROR) that skip promotion
+when ``normalized_job_id`` is missing from the enriched payload, when the
+DB session fails mid-batch, or when the DB is unreachable. Without an audit
+trail, those skipped rows used to disappear silently into ``normalized_jobs``
+with no matching ``job_postings`` row — 469 such orphans accumulated by
+2026-04-28.
+
+This script reads ``normalized_jobs WHERE promoted_at IS NULL`` rows older
+than the grace window (default 1 hour, set via ``--grace-minutes``), and
+re-attempts promotion via the standard ``_insert_job_posting_from_normalized``
+helper — bypassing the broken payload contract entirely. On success, it
+stamps ``promoted_at = NOW()`` so the row is no longer in the sweep set.
+
+The grace window avoids racing live ingestion (rows that were just inserted
+and are about to be promoted by the live loop should not be touched here).
+
+Usage
+-----
+.. code-block:: bash
+
+    # Dry run (default — shows what would be promoted, makes no writes)
+    python scripts/sweep_unpromoted_normalized_jobs.py
+
+    # Promote up to 200 rows
+    python scripts/sweep_unpromoted_normalized_jobs.py --apply
+
+    # Tune the limit and grace window
+    python scripts/sweep_unpromoted_normalized_jobs.py --apply --limit 500 --grace-minutes 30
+
+Idempotent — safe to re-run. Reads ``PYTHON_DATABASE_URL`` from ``.env``.
+
+Suitable for cron / GitHub Actions hourly schedule. The query uses an
+indexed predicate on ``normalized_jobs.created_at WHERE promoted_at IS NULL``
+(``ix_normalized_jobs_promoted_at_null``), so it stays cheap as the table grows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import structlog
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import text  # noqa: E402
+
+from common.data_store.database import get_engine, session_scope  # noqa: E402
+from common.env import load_repo_root_dotenv  # noqa: E402
+from enrichment.job_postings_promotion import (  # noqa: E402
+    _insert_job_posting_from_normalized,
+    resolve_job_posting_row,
+)
+
+log = structlog.get_logger()
+
+_FETCH_UNPROMOTED_SQL = text(
+    """
+    SELECT id
+    FROM dbo.normalized_jobs
+    WHERE promoted_at IS NULL
+      AND created_at < NOW() - (:grace_minutes || ' minutes')::interval
+    ORDER BY created_at ASC
+    LIMIT :lim
+    """
+)
+
+_STAMP_PROMOTED_SQL = text("UPDATE dbo.normalized_jobs SET promoted_at = NOW() WHERE id = :nj_id")
+
+
+def sweep(
+    *,
+    grace_minutes: int = 60,
+    limit: int = 200,
+    apply: bool = False,
+) -> dict[str, int]:
+    """Sweep up to ``limit`` unpromoted rows older than ``grace_minutes``.
+
+    Returns a counts dict: ``{"candidates": N, "promoted": N, "already_present": N,
+    "failed": N}``.
+
+    When ``apply=False`` (default), only counts candidates and what would happen.
+    """
+    engine = get_engine()
+    counts = {"candidates": 0, "promoted": 0, "already_present": 0, "failed": 0}
+
+    with engine.connect() as conn:
+        ids = [
+            int(r[0])
+            for r in conn.execute(
+                _FETCH_UNPROMOTED_SQL,
+                {"grace_minutes": str(grace_minutes), "lim": limit},
+            ).fetchall()
+        ]
+
+    counts["candidates"] = len(ids)
+    if not ids:
+        log.info("sweep_no_candidates", grace_minutes=grace_minutes, limit=limit)
+        return counts
+
+    log.info("sweep_candidates_found", n=len(ids), grace_minutes=grace_minutes, apply=apply)
+
+    if not apply:
+        # Dry run — just report what would be touched
+        for nj_id in ids[:10]:
+            print(f"  [dry-run] would attempt promotion for normalized_job id={nj_id}")
+        if len(ids) > 10:
+            print(f"  [dry-run] ... and {len(ids) - 10} more")
+        return counts
+
+    for nj_id in ids:
+        try:
+            with session_scope() as session:
+                # If a job_postings row already exists, it just needs the stamp.
+                if resolve_job_posting_row(session, nj_id):
+                    session.execute(_STAMP_PROMOTED_SQL, {"nj_id": nj_id})
+                    counts["already_present"] += 1
+                    log.info("sweep_already_present_stamped", normalized_job_id=nj_id)
+                    continue
+
+                resolved = _insert_job_posting_from_normalized(session, nj_id)
+                if resolved is None:
+                    counts["failed"] += 1
+                    log.warning(
+                        "sweep_insert_returned_none",
+                        normalized_job_id=nj_id,
+                        reason="likely missing required normalized_jobs fields",
+                    )
+                    continue
+
+                session.execute(_STAMP_PROMOTED_SQL, {"nj_id": nj_id})
+                counts["promoted"] += 1
+                log.info(
+                    "sweep_promoted",
+                    normalized_job_id=nj_id,
+                    job_posting_id=resolved.get("job_posting_id"),
+                )
+        except Exception as exc:
+            counts["failed"] += 1
+            log.warning("sweep_failed", normalized_job_id=nj_id, error=str(exc))
+
+    log.info("sweep_complete", **counts)
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Sweep unpromoted normalized_jobs rows (JIE #289 defense). "
+            "Default is dry-run; pass --apply to actually promote rows."
+        )
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually promote rows (without this flag, runs in dry-run mode).",
+    )
+    parser.add_argument(
+        "--grace-minutes",
+        type=int,
+        default=60,
+        help="Skip rows newer than this many minutes (avoid racing live ingestion). Default: 60.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=200,
+        help="Maximum rows to attempt per run. Default: 200.",
+    )
+    args = parser.parse_args()
+
+    load_repo_root_dotenv()
+    counts = sweep(grace_minutes=args.grace_minutes, limit=args.limit, apply=args.apply)
+
+    print()
+    print("=" * 60)
+    print(f"Sweep summary ({'APPLY' if args.apply else 'DRY-RUN'}):")
+    print(f"  candidates     : {counts['candidates']}")
+    if args.apply:
+        print(f"  promoted       : {counts['promoted']}")
+        print(f"  already present: {counts['already_present']}")
+        print(f"  failed         : {counts['failed']}")
+    print("=" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Bryan's manual scoring of golden questions gq-041..050 (Discord update 2026-04-28 12:20) traced *"No data in scope"* refusals on Borderplex geographic Q&A to **two** upstream data gaps. This PR addresses the [#289](https://github.com/Building-With-Agents/job-intelligence-engine/issues/289) half — the structural defect in the live ingestion → enrichment → promotion loop that produced 469 orphan rows in `normalized_jobs` over **multiple ingestion runs** (Apr 8, 12, 15, 26 — the leak is still active as of today).

**Diagnostic** confirmed via `scripts/employer_drill_down_audit.py` + targeted SQL:
- 469 orphans (4,802 normalized → 4,333 promoted)
- Case-insensitive + trim JOIN delta = 0 → orphans are **truly missing**, not casing-mismatched
- Latest orphan created 2026-04-26 (one day before latest promoted) → leak is ongoing

## Three-layer fix (all ship together)

### Fix A — make silent guards loud

Each promotion call site previously had `if nj_promo is not None: ...` with no else branch, so missing `normalized_job_id` silently dropped the row from promotion. Same pattern on session-scope failure (entire batch silenced) and DB-unavailable (entire batch silenced).

Touched call sites in `enrichment/agent.py`:
- **791** — batch serial path
- **1085** — single-record path
- **1482** — batch parallel path
- **814-822** — session-scope failure + DB-unavailable fall-throughs

Replaced silent skips with `structlog` `ERROR`-level logs that capture `source`, `external_id`, `call_site`, and `enriched_has_key` / `posting_has_key` flags. Functional behavior (skipping the row) stays the same in the short term; visibility increases dramatically.

### Fix C — `promoted_at` audit column + sweeper

- New column `promoted_at TIMESTAMPTZ NULL` on `dbo.normalized_jobs` + partial index on `(created_at) WHERE promoted_at IS NULL` for the sweeper's hot path
- `apply_enrichment_to_job_postings` now stamps `promoted_at = NOW()` on the source `normalized_jobs` row inside `_finish_with_dedup` — same session as the `job_postings` UPDATE, atomic on commit
- New `scripts/sweep_unpromoted_normalized_jobs.py` reads orphan rows older than the grace window (default 1h) and re-attempts promotion via `_insert_job_posting_from_normalized` — bypasses the broken payload contract entirely. Idempotent. Safe to schedule via cron / GitHub Actions hourly. Defaults to dry-run; `--apply` flag required to actually promote.

### Fix B (deferred)

Root-causing **why** `normalized_job_id` is sometimes missing from the enriched payload is deferred to a follow-up issue. Fix C provides eventual consistency via the sweeper, so Fix B becomes an investigation rather than a blocker. If the sweeper logs reveal an obvious upstream contract drop, we'll fix it then.

## Tests

- Updated `enrichment/tests/test_job_postings_promotion.py` for the added `session.execute()` call (the `promoted_at` stamp). Mock helpers widened with extra `MagicMock()` entries to cover the un-patched fuzzy dedup path.
- **All 220 enrichment unit tests pass.**
- Pre-existing failures in `test_config_loader::test_env_override_emits_warning_once`, `test_scraper_adapter::*`, and `test_enrichment_agent::test_process_passes_none_session_when_db_unavailable` confirmed **unrelated** (fail on clean `development` too).

## Verification plan post-merge

1. Apply migration on Gary's local source-of-truth DB (after fixture export — see JIE database protection rules in `~/.claude/CLAUDE.md`).
2. Companion PR (next): `scripts/backfill_promote_normalized_orphans.py` for the 469 existing orphans.
3. After both land + #244 fixes + aggregate refresh: re-run `scripts/employer_drill_down_audit.py` → orphan count ≤ 5; Bryan re-scores gq-041..050.

## Files

- `common/data_store/migrations.py` — `promoted_at` ALTER + index
- `common/data_store/models.py` — `NormalizedJob.promoted_at` field
- `enrichment/agent.py` — 4 loud guards
- `enrichment/job_postings_promotion.py` — `promoted_at` stamp in `_finish_with_dedup`
- `enrichment/tests/test_job_postings_promotion.py` — mock-count fixes
- `scripts/sweep_unpromoted_normalized_jobs.py` — **NEW** sweeper

Refs JIE [#289](https://github.com/Building-With-Agents/job-intelligence-engine/issues/289). Closes the structural side; the backfill + #244 + smoke + findings + fresh fixtures will follow in PRs 2/3/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)