### PR TITLE
fix(#289): one-shot backfill for the 469 normalized_jobs orphans

### DIFF
--- a/scripts/backfill_promote_normalized_orphans.py
+++ b/scripts/backfill_promote_normalized_orphans.py
@@ -1,0 +1,192 @@
+# ruff: noqa: T201
+"""One-shot cleanup: promote the 469 normalized_jobs orphans — JIE #289.
+
+Background
+----------
+PR #301 fixed the structural defect in the live ingestion → enrichment →
+promotion loop that silently skipped promotion when ``normalized_job_id``
+was missing from the enriched payload. New orphans should no longer
+accumulate from now on, and the hourly sweeper at
+``scripts/sweep_unpromoted_normalized_jobs.py`` will catch any that slip.
+
+This script handles the **existing residual** — 469 orphan rows in
+``normalized_jobs`` (Apr 8 / 12 / 15 / 26 vintages) that have no matching
+``job_postings`` row via ``source`` / ``external_id``. Phase 1 diagnostic
+(2026-04-28) confirmed these are **truly missing** rows, not casing
+mismatches: a case-insensitive + trim JOIN returns the same 469 count,
+so the rows were never inserted into ``job_postings`` at all.
+
+The backfill calls the existing ``_insert_job_posting_from_normalized``
+helper for each orphan (the same code path live promotion uses on a
+miss-on-resolve), then stamps ``promoted_at`` so the row exits the
+sweeper's candidate set.
+
+Usage
+-----
+.. code-block:: bash
+
+    # Dry run (default — counts what would be promoted, makes no writes)
+    python scripts/backfill_promote_normalized_orphans.py
+
+    # Promote all orphans
+    python scripts/backfill_promote_normalized_orphans.py --apply
+
+    # Limit a single run (sweeper-style, useful if you want to spread the load)
+    python scripts/backfill_promote_normalized_orphans.py --apply --limit 50
+
+Idempotent — safe to re-run. Reads ``PYTHON_DATABASE_URL`` from ``.env``.
+
+**Important:** export fixtures before running with ``--apply``. Per the
+JIE database protection rules (``~/.claude/CLAUDE.md``), ``normalized_jobs``
+and ``job_postings`` are protected pipeline-audit tables on Gary's
+source-of-truth database.
+
+.. code-block:: bash
+
+    python scripts/pg-seed-data/export_fixtures.py --scope all
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import structlog
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import text  # noqa: E402
+
+from common.data_store.database import get_engine, session_scope  # noqa: E402
+from common.env import load_repo_root_dotenv  # noqa: E402
+from enrichment.job_postings_promotion import (  # noqa: E402
+    _insert_job_posting_from_normalized,
+    resolve_job_posting_row,
+)
+
+log = structlog.get_logger()
+
+# Find orphan rows: normalized_jobs WHERE no matching job_postings AND
+# not yet promoted. Pre-#301 rows have promoted_at IS NULL universally
+# (the column was just added), so this query naturally picks them up.
+_FETCH_ORPHANS_SQL = text(
+    """
+    SELECT nj.id
+    FROM dbo.normalized_jobs nj
+    LEFT JOIN dbo.job_postings jp
+        ON jp.source = nj.source AND jp.external_id = nj.external_id
+    WHERE jp.job_posting_id IS NULL
+      AND nj.promoted_at IS NULL
+    ORDER BY nj.created_at ASC
+    LIMIT :lim
+    """
+)
+
+_STAMP_PROMOTED_SQL = text("UPDATE dbo.normalized_jobs SET promoted_at = NOW() WHERE id = :nj_id")
+
+
+def backfill(*, limit: int = 1000, apply: bool = False) -> dict[str, int]:
+    """Promote up to ``limit`` orphan normalized_jobs rows.
+
+    Returns counts: ``{"orphans": N, "promoted": N, "already_present": N, "failed": N}``.
+
+    When ``apply=False`` (default), only counts orphans and previews.
+    """
+    engine = get_engine()
+    counts = {"orphans": 0, "promoted": 0, "already_present": 0, "failed": 0}
+
+    with engine.connect() as conn:
+        ids = [int(r[0]) for r in conn.execute(_FETCH_ORPHANS_SQL, {"lim": limit}).fetchall()]
+
+    counts["orphans"] = len(ids)
+    if not ids:
+        log.info("backfill_no_orphans", limit=limit)
+        return counts
+
+    log.info("backfill_orphans_found", n=len(ids), apply=apply)
+
+    if not apply:
+        for nj_id in ids[:10]:
+            print(f"  [dry-run] would attempt promotion for normalized_job id={nj_id}")
+        if len(ids) > 10:
+            print(f"  [dry-run] ... and {len(ids) - 10} more")
+        return counts
+
+    for nj_id in ids:
+        try:
+            with session_scope() as session:
+                # Idempotent guard: if a job_postings row was created since we
+                # snapshot the orphan list (e.g., live ingestion re-promoted it,
+                # or the sweeper got there first), just stamp and continue.
+                if resolve_job_posting_row(session, nj_id):
+                    session.execute(_STAMP_PROMOTED_SQL, {"nj_id": nj_id})
+                    counts["already_present"] += 1
+                    log.info("backfill_already_present_stamped", normalized_job_id=nj_id)
+                    continue
+
+                resolved = _insert_job_posting_from_normalized(session, nj_id)
+                if resolved is None:
+                    counts["failed"] += 1
+                    log.warning(
+                        "backfill_insert_returned_none",
+                        normalized_job_id=nj_id,
+                        reason="missing required normalized_jobs fields (e.g., title/company)",
+                    )
+                    continue
+
+                session.execute(_STAMP_PROMOTED_SQL, {"nj_id": nj_id})
+                counts["promoted"] += 1
+                log.info(
+                    "backfill_promoted",
+                    normalized_job_id=nj_id,
+                    job_posting_id=resolved.get("job_posting_id"),
+                )
+        except Exception as exc:
+            counts["failed"] += 1
+            log.warning("backfill_failed", normalized_job_id=nj_id, error=str(exc))
+
+    log.info("backfill_complete", **counts)
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "One-shot backfill: promote the 469 normalized_jobs orphans (JIE #289). "
+            "Default is dry-run; pass --apply to actually promote rows. "
+            "Export fixtures BEFORE --apply per JIE database protection rules."
+        )
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually promote rows (without this flag, runs in dry-run mode).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=1000,
+        help="Maximum rows to attempt per run. Default 1000 covers the full 469 in one pass.",
+    )
+    args = parser.parse_args()
+
+    load_repo_root_dotenv()
+    counts = backfill(limit=args.limit, apply=args.apply)
+
+    print()
+    print("=" * 60)
+    print(f"Backfill summary ({'APPLY' if args.apply else 'DRY-RUN'}):")
+    print(f"  orphans found  : {counts['orphans']}")
+    if args.apply:
+        print(f"  promoted       : {counts['promoted']}")
+        print(f"  already present: {counts['already_present']}")
+        print(f"  failed         : {counts['failed']}")
+    print("=" * 60)
+    if args.apply and counts["failed"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_backfill_promote_normalized_orphans.py
+++ b/tests/test_backfill_promote_normalized_orphans.py
@@ -1,0 +1,74 @@
+"""Tests for scripts/backfill_promote_normalized_orphans.py — JIE #289."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Importing the module exercises the script-level imports + sys.path manipulation.
+import scripts.backfill_promote_normalized_orphans as backfill_module  # noqa: E402
+
+
+def test_module_importable() -> None:
+    """Smoke: the script imports without error and exposes the public surface."""
+    assert callable(backfill_module.backfill)
+    assert callable(backfill_module.main)
+
+
+def _engine_returning_orphan_ids(ids: list[int]) -> MagicMock:
+    """Build a mock engine whose .connect() context returns rows for the orphan query."""
+    rows = [(i,) for i in ids]
+    cursor = MagicMock()
+    cursor.fetchall.return_value = rows
+    conn = MagicMock()
+    conn.execute.return_value = cursor
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    engine = MagicMock()
+    engine.connect.return_value = conn
+    return engine
+
+
+def test_dry_run_counts_orphans_without_writes() -> None:
+    """Dry-run mode reports orphan count and makes no session_scope writes."""
+    fake_engine = _engine_returning_orphan_ids([10, 20, 30])
+
+    with (
+        patch.object(backfill_module, "get_engine", return_value=fake_engine),
+        patch.object(backfill_module, "session_scope") as mock_scope,
+    ):
+        counts = backfill_module.backfill(limit=1000, apply=False)
+
+    assert counts == {"orphans": 3, "promoted": 0, "already_present": 0, "failed": 0}
+    # Dry-run must NOT open any write session
+    mock_scope.assert_not_called()
+
+
+def test_dry_run_with_no_orphans() -> None:
+    """When the orphan query returns zero rows, all counts stay at 0."""
+    fake_engine = _engine_returning_orphan_ids([])
+
+    with patch.object(backfill_module, "get_engine", return_value=fake_engine):
+        counts = backfill_module.backfill(limit=1000, apply=False)
+
+    assert counts == {"orphans": 0, "promoted": 0, "already_present": 0, "failed": 0}
+
+
+@pytest.mark.parametrize("orphan_count,limit", [(0, 1000), (5, 1000), (3, 2)])
+def test_orphan_count_respects_limit(orphan_count: int, limit: int) -> None:
+    """The fetch query uses the provided LIMIT — verify the bind parameter."""
+    fake_engine = _engine_returning_orphan_ids(list(range(orphan_count)))
+
+    with patch.object(backfill_module, "get_engine", return_value=fake_engine):
+        backfill_module.backfill(limit=limit, apply=False)
+
+    # The orphan-fetch execute call should have been made with our limit
+    conn = fake_engine.connect.return_value
+    assert conn.execute.called
+    _stmt, params = conn.execute.call_args[0]
+    assert params == {"lim": limit}


### PR DESCRIPTION
## Summary

Companion to [PR #301](https://github.com/Building-With-Agents/job-intelligence-engine/pull/301) (the structural fix that just merged). PR #301 stops new orphans from accumulating; this PR promotes the **469 existing orphans** in `normalized_jobs` (Apr 8 / 12 / 15 / 26 vintages) that were silently dropped by the buggy live loop.

## Why a separate PR

The structural fix is reviewable on its own merits (does the contract change make sense? do the guards log at the right level?) and the backfill is a one-shot data operation. Splitting them lets reviewers approve each independently and lets the structural foundation stay stable if the backfill needs iteration.

## Approach (Case B only — confirmed by Phase 1 diagnostic)

Phase 1 ran on 2026-04-28:

```
=== Phase 1.3 — Case-insensitive recovery test ===
  Orphans with case-insensitive + trim JOIN: 469
  Original orphan count: 469
  Delta (recovered by case fix): 0
```

→ The orphans are **truly missing rows**, not casing mismatches. Case A (the case-fix path) is ruled out. The script implements **Case B only**: call `_insert_job_posting_from_normalized` for each orphan (same code path live promotion uses on a miss-on-resolve), then stamp `promoted_at = NOW()` so the row exits the sweeper's candidate set.

## Verification

Dry-run against the live source-of-truth DB found exactly 469 orphans:

```
$ python scripts/backfill_promote_normalized_orphans.py
  [dry-run] would attempt promotion for normalized_job id=623
  [dry-run] would attempt promotion for normalized_job id=624
  [dry-run] ... and 459 more
============================================================
Backfill summary (DRY-RUN):
  orphans found  : 469
============================================================
```

This matches the count from `scripts/employer_drill_down_audit.py` exactly.

## Operator runbook

```bash
# 1. Dry-run first to confirm the count (default mode)
python scripts/backfill_promote_normalized_orphans.py

# 2. Export fixtures BEFORE --apply (per JIE database protection rules)
python scripts/pg-seed-data/export_fixtures.py --scope all

# 3. Promote the orphans
python scripts/backfill_promote_normalized_orphans.py --apply

# 4. Verify count drops to 0 (or near-0 for any quarantined rows)
python scripts/employer_drill_down_audit.py
```

The script is idempotent — safe to re-run if interrupted. It also gracefully handles the race where live ingestion or the sweeper promotes a row mid-flight (the `resolve_job_posting_row` guard at the top of each loop iteration).

## Tests

- `tests/test_backfill_promote_normalized_orphans.py` — **6 unit tests, all pass**:
  - `test_module_importable` — smoke
  - `test_dry_run_counts_orphans_without_writes` — asserts `session_scope` is never opened in dry-run
  - `test_dry_run_with_no_orphans` — clean exit when nothing to do
  - `test_orphan_count_respects_limit[3 cases]` — verifies the LIMIT bind parameter propagates correctly

## Files

- `scripts/backfill_promote_normalized_orphans.py` — **NEW** (192 lines)
- `tests/test_backfill_promote_normalized_orphans.py` — **NEW** (74 lines)

## What's next

After this merges + Phase 3.0–3.2 backfill executes:
- **PR 3** — fix #244 (state-name truncation in `jsearch_mapper.py:36` + add `zip_code` to promotion SQL)
- **PR 4** — smoke tests + `findingsv2.2.md` + refreshed fixtures (closes both #244 and #289)

Refs JIE [#289](https://github.com/Building-With-Agents/job-intelligence-engine/issues/289).

🤖 Generated with [Claude Code](https://claude.com/claude-code)