### PR TITLE
fix(#244): zip_code lookup + promotion SQL threading + backfill

### DIFF
--- a/enrichment/job_postings_promotion.py
+++ b/enrichment/job_postings_promotion.py
@@ -45,6 +45,7 @@ _RESOLVE_JOB_POSTING_SQL = text(
            nj.city AS city,
            nj.state_province AS state_province,
            nj.country AS country,
+           nj.zip_code AS zip_code,
            nj.is_remote AS is_remote,
            nj.work_arrangement AS work_arrangement
     FROM dbo.job_postings jp
@@ -85,7 +86,8 @@ _UPDATE_UNCERTAIN_SQL = text(
         salary_min = COALESCE(:salary_min, salary_min),
         salary_max = COALESCE(:salary_max, salary_max),
         salary_currency = COALESCE(:salary_currency, salary_currency),
-        salary_period = COALESCE(:salary_period, salary_period)
+        salary_period = COALESCE(:salary_period, salary_period),
+        zip_code = COALESCE(:zip_code, zip_code)
     WHERE job_posting_id::text = :job_posting_id
     """
 )
@@ -111,7 +113,8 @@ _UPDATE_CLEAN_SQL = text(
         salary_min = COALESCE(:salary_min, salary_min),
         salary_max = COALESCE(:salary_max, salary_max),
         salary_currency = COALESCE(:salary_currency, salary_currency),
-        salary_period = COALESCE(:salary_period, salary_period)
+        salary_period = COALESCE(:salary_period, salary_period),
+        zip_code = COALESCE(:zip_code, zip_code)
     WHERE job_posting_id::text = :job_posting_id
     """
 )
@@ -137,7 +140,8 @@ _UPDATE_FLAGGED_SQL = text(
         salary_min = COALESCE(:salary_min, salary_min),
         salary_max = COALESCE(:salary_max, salary_max),
         salary_currency = COALESCE(:salary_currency, salary_currency),
-        salary_period = COALESCE(:salary_period, salary_period)
+        salary_period = COALESCE(:salary_period, salary_period),
+        zip_code = COALESCE(:zip_code, zip_code)
     WHERE job_posting_id::text = :job_posting_id
     """
 )
@@ -197,13 +201,13 @@ _INSERT_JOB_POSTING_SQL = text(
         job_posting_id, company_id,
         job_title, job_description, employment_type,
         location, salary_range, source, external_id,
-        ingestion_run_id, status
+        ingestion_run_id, status, zip_code
     ) VALUES (
         CAST(:job_posting_id AS uuid),
         CAST(:company_id AS uuid),
         :job_title, :job_description, :employment_type,
         :location, :salary_range, :source, :external_id,
-        :ingestion_run_id, :status
+        :ingestion_run_id, :status, :zip_code
     )
     ON CONFLICT (job_posting_id) DO NOTHING
     """
@@ -213,7 +217,7 @@ _LOAD_NORMALIZED_JOB_SQL = text(
     """
     SELECT id, source, external_id, ingestion_run_id,
            title, company, description,
-           city, state_province, country,
+           city, state_province, country, zip_code,
            is_remote, work_arrangement,
            employment_type, date_posted,
            salary_min, salary_max, salary_currency, salary_period
@@ -286,6 +290,10 @@ def _insert_job_posting_from_normalized(session: Session, normalized_job_id: int
             "external_id": nj["external_id"],
             "ingestion_run_id": nj["ingestion_run_id"],
             "status": "open",
+            # JIE #244: propagate zip_code on insert so freshly-inserted job_postings
+            # rows carry the value from normalized_jobs (which is populated by the
+            # fixed _resolve_zip_code path in jsearch_mapper.py).
+            "zip_code": nj["zip_code"],
         },
     )
     log.info(
@@ -301,6 +309,7 @@ def _insert_job_posting_from_normalized(session: Session, normalized_job_id: int
         "city": nj["city"],
         "state_province": nj["state_province"],
         "country": nj["country"],
+        "zip_code": nj["zip_code"],
         "is_remote": nj["is_remote"],
         "work_arrangement": nj["work_arrangement"],
     }
@@ -620,6 +629,14 @@ def apply_enrichment_to_job_postings(
     if is_remote_param is not None:
         is_remote_param = bool(is_remote_param)
 
+    # JIE #244: zip_code propagates from normalized_jobs to job_postings on every
+    # promotion. Resolved dict carries it from either the resolve path
+    # (_RESOLVE_JOB_POSTING_SQL added nj.zip_code) or the insert path
+    # (_insert_job_posting_from_normalized populates it directly). The UPDATE
+    # SQL uses COALESCE so a NULL here preserves whatever was already set
+    # (e.g., from a prior promotion before #244 fix landed).
+    zip_code_param = resolved.get("zip_code") if resolved else None
+
     # Structured salary (#174): pulled from normalized_jobs (already in resolved dict).
     # legacy salary_range TEXT is kept for backward compat; structured columns are preferred for analytics.
     salary_min_param = resolved.get("salary_min") if resolved else None
@@ -660,6 +677,7 @@ def apply_enrichment_to_job_postings(
         "salary_max": salary_max_param,
         "salary_currency": salary_currency_param,
         "salary_period": salary_period_param,
+        "zip_code": zip_code_param,
         **derived_output_fields,
     }
 

--- a/normalization/mappers/jsearch.py
+++ b/normalization/mappers/jsearch.py
@@ -1,6 +1,16 @@
-"""Field mapper for records sourced from JSearch API."""
+"""Field mapper for records sourced from JSearch API.
+
+Zip-code resolution: prefer the raw zip if present; otherwise, when city +
+state are available, look up postal_geo_data by city + 2-letter state code.
+JSearch sends `state` as either a 2-letter code (``"TX"``) or a full name
+(``"Texas"``); the prior implementation truncated full names to two letters
+(``"TE"``) and silently failed every lookup. This mapper normalizes both
+forms before querying.
+"""
 
 from __future__ import annotations
+
+import structlog
 
 from common.types.job_record import JobRecord
 from common.types.raw_job_record import RawJobRecord
@@ -11,6 +21,126 @@ from normalization.cleaners import (
     parse_salary,
 )
 from normalization.mappers.base import MapperBase
+
+log = structlog.get_logger()
+
+
+_STATE_NAME_TO_CODE: dict[str, str] = {
+    "alabama": "AL",
+    "alaska": "AK",
+    "arizona": "AZ",
+    "arkansas": "AR",
+    "california": "CA",
+    "colorado": "CO",
+    "connecticut": "CT",
+    "delaware": "DE",
+    "florida": "FL",
+    "georgia": "GA",
+    "hawaii": "HI",
+    "idaho": "ID",
+    "illinois": "IL",
+    "indiana": "IN",
+    "iowa": "IA",
+    "kansas": "KS",
+    "kentucky": "KY",
+    "louisiana": "LA",
+    "maine": "ME",
+    "maryland": "MD",
+    "massachusetts": "MA",
+    "michigan": "MI",
+    "minnesota": "MN",
+    "mississippi": "MS",
+    "missouri": "MO",
+    "montana": "MT",
+    "nebraska": "NE",
+    "nevada": "NV",
+    "new hampshire": "NH",
+    "new jersey": "NJ",
+    "new mexico": "NM",
+    "new york": "NY",
+    "north carolina": "NC",
+    "north dakota": "ND",
+    "ohio": "OH",
+    "oklahoma": "OK",
+    "oregon": "OR",
+    "pennsylvania": "PA",
+    "rhode island": "RI",
+    "south carolina": "SC",
+    "south dakota": "SD",
+    "tennessee": "TN",
+    "texas": "TX",
+    "utah": "UT",
+    "vermont": "VT",
+    "virginia": "VA",
+    "washington": "WA",
+    "west virginia": "WV",
+    "wisconsin": "WI",
+    "wyoming": "WY",
+    "district of columbia": "DC",
+    "puerto rico": "PR",
+}
+
+
+def _normalize_state_to_code(state: str | None) -> str | None:
+    """Accept a 2-letter state code or a full state name; return the code."""
+    if not state:
+        return None
+    cleaned = state.strip()
+    if not cleaned:
+        return None
+    if len(cleaned) == 2:
+        return cleaned.upper()
+    return _STATE_NAME_TO_CODE.get(cleaned.lower())
+
+
+def _resolve_zip_code(city: str | None, state: str | None, raw_zip: str | None) -> str | None:
+    """Resolve zip code: prefer the raw value; else look up postal_geo_data."""
+    if raw_zip:
+        return raw_zip.strip()[:10] or None
+
+    if not city or not state:
+        return None
+
+    state_code = _normalize_state_to_code(state)
+    if not state_code:
+        log.warning("zip_resolution_unknown_state", city=city, state=state)
+        return None
+
+    try:
+        from common.data_store.database import check_db_connection, session_scope
+        from common.data_store.models import PostalGeoData
+
+        if not check_db_connection():
+            return None
+
+        city_clean = city.strip().lower()
+
+        with session_scope() as session:
+            match = (
+                session.query(PostalGeoData.zip)
+                .filter(
+                    PostalGeoData.state_code == state_code,
+                    PostalGeoData.city.ilike(city_clean),
+                )
+                .first()
+            )
+            if match:
+                return match.zip
+            log.warning(
+                "zip_resolution_no_match",
+                city=city,
+                state=state,
+                state_code=state_code,
+            )
+    except Exception as exc:
+        log.warning(
+            "zip_resolution_failed",
+            city=city,
+            state=state,
+            error=str(exc),
+        )
+
+    return None
 
 
 class JSearchMapper(MapperBase):
@@ -36,6 +166,8 @@ class JSearchMapper(MapperBase):
         elif raw.salary_raw:
             salary_data = parse_salary(raw.salary_raw)
 
+        zip_code = _resolve_zip_code(raw.city, raw.state, raw.zip_code)
+
         return JobRecord(
             source=raw.source,
             external_id=raw.external_id,
@@ -47,6 +179,7 @@ class JSearchMapper(MapperBase):
             city=raw.city,
             state_province=raw.state,
             country=raw.country,
+            zip_code=zip_code,
             is_remote=raw.is_remote,
             date_posted=normalize_date(raw.date_posted.isoformat() if raw.date_posted else None),
             salary_raw=raw.salary_raw,

--- a/normalization/tests/test_field_mappers.py
+++ b/normalization/tests/test_field_mappers.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from common.types.raw_job_record import RawJobRecord
 from normalization.field_mappers.jsearch_mapper import JSearchMapper
 from normalization.field_mappers.scraper_mapper import ScraperMapper
+from normalization.mappers.jsearch import (
+    _normalize_state_to_code,
+    _resolve_zip_code,
+)
 
 
 class TestJSearchMapper:
@@ -38,6 +44,88 @@ class TestJSearchMapper:
         result = mapper.map(raw)
         assert result.salary_min is None
         assert result.salary_raw is None
+
+
+class TestNormalizeStateToCode:
+    def test_two_letter_code_passthrough(self) -> None:
+        assert _normalize_state_to_code("TX") == "TX"
+        assert _normalize_state_to_code("tx") == "TX"
+
+    def test_full_name_to_code(self) -> None:
+        assert _normalize_state_to_code("Texas") == "TX"
+        assert _normalize_state_to_code("texas") == "TX"
+        assert _normalize_state_to_code("North Carolina") == "NC"
+        assert _normalize_state_to_code("New York") == "NY"
+        assert _normalize_state_to_code("District of Columbia") == "DC"
+
+    def test_unknown_or_empty(self) -> None:
+        assert _normalize_state_to_code(None) is None
+        assert _normalize_state_to_code("") is None
+        assert _normalize_state_to_code("   ") is None
+        assert _normalize_state_to_code("Atlantis") is None
+
+
+class TestResolveZipCode:
+    def test_raw_zip_passthrough(self) -> None:
+        assert _resolve_zip_code("El Paso", "TX", "79901") == "79901"
+
+    def test_raw_zip_truncated_to_10(self) -> None:
+        assert _resolve_zip_code(None, None, "79901-12345-extra") == "79901-1234"
+
+    def test_missing_city_or_state_returns_none(self) -> None:
+        assert _resolve_zip_code(None, "Texas", None) is None
+        assert _resolve_zip_code("El Paso", None, None) is None
+
+    def test_full_state_name_normalizes_then_looks_up(self) -> None:
+        with (
+            patch("common.data_store.database.check_db_connection", return_value=True),
+            patch("common.data_store.database.session_scope") as mock_scope,
+        ):
+            session = mock_scope.return_value.__enter__.return_value
+            match = type("M", (), {"zip": "79901"})()
+            session.query.return_value.filter.return_value.first.return_value = match
+
+            result = _resolve_zip_code("El Paso", "Texas", None)
+
+            assert result == "79901"
+            filter_call = session.query.return_value.filter.call_args
+            assert len(filter_call.args) == 2
+
+    def test_unknown_state_returns_none_without_querying(self) -> None:
+        with patch("common.data_store.database.check_db_connection") as mock_check:
+            result = _resolve_zip_code("El Paso", "Atlantis", None)
+            assert result is None
+            mock_check.assert_not_called()
+
+
+class TestJSearchMapperZipResolution:
+    def test_map_passes_resolved_zip_to_job_record(self) -> None:
+        raw = RawJobRecord(
+            external_id="abc",
+            source="jsearch",
+            title="Engineer",
+            company="Acme",
+            city="El Paso",
+            state="Texas",
+        )
+        with patch("normalization.mappers.jsearch._resolve_zip_code", return_value="79901") as mock_resolve:
+            result = JSearchMapper().map(raw)
+
+        mock_resolve.assert_called_once_with("El Paso", "Texas", None)
+        assert result.zip_code == "79901"
+
+    def test_map_when_zip_unresolved_sets_none(self) -> None:
+        raw = RawJobRecord(
+            external_id="abc",
+            source="jsearch",
+            title="Engineer",
+            company="Acme",
+            city="Unknown",
+            state="Atlantis",
+        )
+        with patch("normalization.mappers.jsearch._resolve_zip_code", return_value=None):
+            result = JSearchMapper().map(raw)
+        assert result.zip_code is None
 
 
 class TestScraperMapper:

--- a/scripts/backfill_zip_codes_normalized.py
+++ b/scripts/backfill_zip_codes_normalized.py
@@ -1,0 +1,208 @@
+# ruff: noqa: T201
+"""One-shot cleanup: re-resolve ``zip_code`` on existing normalized_jobs — JIE #244.
+
+Background
+----------
+Before PR #304 (this fix), the ``_resolve_zip_code`` lookup in
+``normalization/mappers/jsearch.py`` truncated full state names to two
+letters (``"Texas" → "TE"``), so the ``postal_geo_data`` lookup silently
+failed every time JSearch sent a full state name. The promotion SQL also
+omitted ``zip_code`` entirely, so even rows that had ``raw.zip_code`` set
+in the source feed never propagated the value to ``job_postings``.
+
+PR #304 fixes both gaps going forward (mapper handles full state names;
+promotion threads ``zip_code`` through every SQL constant). This script
+handles the **existing residual**: ``normalized_jobs`` rows where
+``zip_code IS NULL`` but ``city`` and ``state_province`` are populated.
+For each, we re-run the (now-fixed) resolver, ``UPDATE normalized_jobs``,
+and propagate the result to any matching ``job_postings`` row.
+
+Usage
+-----
+.. code-block:: bash
+
+    # Dry run (default — counts what would be resolved, makes no writes)
+    python scripts/backfill_zip_codes_normalized.py
+
+    # Apply — writes resolved zip_code values to normalized_jobs and job_postings
+    python scripts/backfill_zip_codes_normalized.py --apply
+
+    # Limit per-run for staged backfills
+    python scripts/backfill_zip_codes_normalized.py --apply --limit 500
+
+Idempotent — safe to re-run. Reads ``PYTHON_DATABASE_URL`` from ``.env``.
+
+**Important:** export fixtures before running with ``--apply``. Per the
+JIE database protection rules (``~/.claude/CLAUDE.md``), ``normalized_jobs``
+and ``job_postings`` are protected pipeline-audit tables on Gary's
+source-of-truth database.
+
+.. code-block:: bash
+
+    python scripts/pg-seed-data/export_fixtures.py --scope all
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import structlog
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import text  # noqa: E402
+
+from common.data_store.database import get_engine, session_scope  # noqa: E402
+from common.env import load_repo_root_dotenv  # noqa: E402
+from normalization.mappers.jsearch import _resolve_zip_code  # noqa: E402
+
+log = structlog.get_logger()
+
+
+_FETCH_CANDIDATES_SQL = text(
+    """
+    SELECT id, city, state_province
+    FROM dbo.normalized_jobs
+    WHERE zip_code IS NULL
+      AND city IS NOT NULL
+      AND state_province IS NOT NULL
+    ORDER BY id ASC
+    LIMIT :lim
+    """
+)
+
+_UPDATE_NORMALIZED_ZIP_SQL = text("UPDATE dbo.normalized_jobs SET zip_code = :zip WHERE id = :nj_id")
+
+# Propagate to job_postings via the source/external_id key. COALESCE preserves
+# any zip_code that might have already been written there (defensive — should
+# be NULL universally pre-fix, but this is idempotent under re-runs).
+_UPDATE_JOB_POSTINGS_ZIP_SQL = text(
+    """
+    UPDATE dbo.job_postings
+    SET zip_code = COALESCE(zip_code, :zip)
+    WHERE source = (SELECT source FROM dbo.normalized_jobs WHERE id = :nj_id)
+      AND external_id = (SELECT external_id FROM dbo.normalized_jobs WHERE id = :nj_id)
+    """
+)
+
+
+def backfill(*, limit: int = 5000, apply: bool = False) -> dict[str, int]:
+    """Re-resolve zip_code on candidate rows.
+
+    Returns counts: ``{"candidates": N, "resolved": N, "unresolved": N, "failed": N}``.
+
+    When ``apply=False`` (default), only counts and previews — no DB writes.
+    """
+    engine = get_engine()
+    counts = {"candidates": 0, "resolved": 0, "unresolved": 0, "failed": 0}
+
+    with engine.connect() as conn:
+        rows = conn.execute(_FETCH_CANDIDATES_SQL, {"lim": limit}).fetchall()
+
+    counts["candidates"] = len(rows)
+    if not rows:
+        log.info("zip_backfill_no_candidates", limit=limit)
+        return counts
+
+    log.info("zip_backfill_candidates_found", n=len(rows), apply=apply)
+
+    if not apply:
+        previewed = 0
+        for nj_id, city, state in rows:
+            zip_code = _resolve_zip_code(city, state, None)
+            if zip_code:
+                counts["resolved"] += 1
+                if previewed < 10:
+                    print(f"  [dry-run] id={nj_id} ({city}, {state}) -> {zip_code}")
+                    previewed += 1
+            else:
+                counts["unresolved"] += 1
+        if counts["resolved"] > 10:
+            print(f"  [dry-run] ... and {counts['resolved'] - 10} more resolutions")
+        return counts
+
+    for nj_id, city, state in rows:
+        try:
+            zip_code = _resolve_zip_code(city, state, None)
+            if not zip_code:
+                counts["unresolved"] += 1
+                log.info(
+                    "zip_backfill_unresolved",
+                    normalized_job_id=nj_id,
+                    city=city,
+                    state=state,
+                )
+                continue
+
+            with session_scope() as session:
+                session.execute(
+                    _UPDATE_NORMALIZED_ZIP_SQL,
+                    {"zip": zip_code, "nj_id": nj_id},
+                )
+                session.execute(
+                    _UPDATE_JOB_POSTINGS_ZIP_SQL,
+                    {"zip": zip_code, "nj_id": nj_id},
+                )
+
+            counts["resolved"] += 1
+            log.info(
+                "zip_backfill_resolved",
+                normalized_job_id=nj_id,
+                zip_code=zip_code,
+            )
+        except Exception as exc:
+            counts["failed"] += 1
+            log.warning(
+                "zip_backfill_failed",
+                normalized_job_id=nj_id,
+                city=city,
+                state=state,
+                error=str(exc),
+            )
+
+    log.info("zip_backfill_complete", **counts)
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "One-shot backfill: re-resolve zip_code on normalized_jobs (JIE #244). "
+            "Default is dry-run; pass --apply to write. "
+            "Export fixtures BEFORE --apply per JIE database protection rules."
+        )
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually write zip_code values (without this flag, runs in dry-run mode).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=5000,
+        help="Maximum rows to attempt per run. Default 5000 covers the full backlog in one pass.",
+    )
+    args = parser.parse_args()
+
+    load_repo_root_dotenv()
+    counts = backfill(limit=args.limit, apply=args.apply)
+
+    print()
+    print("=" * 60)
+    print(f"Zip backfill summary ({'APPLY' if args.apply else 'DRY-RUN'}):")
+    print(f"  candidates found : {counts['candidates']}")
+    print(f"  resolved         : {counts['resolved']}")
+    print(f"  unresolved       : {counts['unresolved']}")
+    if args.apply:
+        print(f"  failed           : {counts['failed']}")
+    print("=" * 60)
+    if args.apply and counts["failed"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_backfill_zip_codes_normalized.py
+++ b/tests/test_backfill_zip_codes_normalized.py
@@ -1,0 +1,125 @@
+"""Tests for scripts/backfill_zip_codes_normalized.py — JIE #244."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import scripts.backfill_zip_codes_normalized as backfill_module  # noqa: E402
+
+
+def test_module_importable() -> None:
+    """Smoke: the script imports without error and exposes the public surface."""
+    assert callable(backfill_module.backfill)
+    assert callable(backfill_module.main)
+
+
+def _engine_returning_rows(rows: list[tuple[int, str | None, str | None]]) -> MagicMock:
+    """Build a mock engine whose .connect() context returns rows for the candidate query."""
+    cursor = MagicMock()
+    cursor.fetchall.return_value = rows
+    conn = MagicMock()
+    conn.execute.return_value = cursor
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    engine = MagicMock()
+    engine.connect.return_value = conn
+    return engine
+
+
+def test_dry_run_counts_resolved_without_writes() -> None:
+    """Dry-run mode counts resolutions and makes no session_scope writes."""
+    fake_engine = _engine_returning_rows(
+        [
+            (1, "El Paso", "Texas"),
+            (2, "Sterling", "Virginia"),
+            (3, "Atlantis", "Wonderland"),  # unresolvable state
+        ]
+    )
+
+    def fake_resolve(city: str | None, state: str | None, raw_zip: str | None) -> str | None:
+        if state == "Texas":
+            return "79901"
+        if state == "Virginia":
+            return "20164"
+        return None
+
+    with (
+        patch.object(backfill_module, "get_engine", return_value=fake_engine),
+        patch.object(backfill_module, "_resolve_zip_code", side_effect=fake_resolve),
+        patch.object(backfill_module, "session_scope") as mock_scope,
+    ):
+        counts = backfill_module.backfill(limit=5000, apply=False)
+
+    assert counts == {"candidates": 3, "resolved": 2, "unresolved": 1, "failed": 0}
+    mock_scope.assert_not_called()
+
+
+def test_no_candidates_returns_zero_counts() -> None:
+    """When no candidate rows exist, all counts stay at 0."""
+    fake_engine = _engine_returning_rows([])
+
+    with patch.object(backfill_module, "get_engine", return_value=fake_engine):
+        counts = backfill_module.backfill(limit=5000, apply=False)
+
+    assert counts == {"candidates": 0, "resolved": 0, "unresolved": 0, "failed": 0}
+
+
+def test_apply_writes_resolved_rows_and_skips_unresolved() -> None:
+    """Apply mode writes UPDATEs for resolvable rows; unresolved rows are skipped without writes."""
+    fake_engine = _engine_returning_rows(
+        [
+            (1, "El Paso", "Texas"),
+            (2, "Atlantis", "Wonderland"),  # unresolvable
+        ]
+    )
+
+    def fake_resolve(city: str | None, state: str | None, raw_zip: str | None) -> str | None:
+        return "79901" if state == "Texas" else None
+
+    session = MagicMock()
+    scope_cm = MagicMock()
+    scope_cm.__enter__.return_value = session
+    scope_cm.__exit__.return_value = False
+
+    with (
+        patch.object(backfill_module, "get_engine", return_value=fake_engine),
+        patch.object(backfill_module, "_resolve_zip_code", side_effect=fake_resolve),
+        patch.object(backfill_module, "session_scope", return_value=scope_cm),
+    ):
+        counts = backfill_module.backfill(limit=5000, apply=True)
+
+    assert counts == {"candidates": 2, "resolved": 1, "unresolved": 1, "failed": 0}
+    # One resolved row -> two UPDATEs (normalized_jobs + job_postings)
+    assert session.execute.call_count == 2
+
+
+def test_apply_failure_in_session_scope_increments_failed() -> None:
+    """Exceptions during apply are caught per-row and tallied as failures."""
+    fake_engine = _engine_returning_rows([(1, "El Paso", "Texas")])
+
+    with (
+        patch.object(backfill_module, "get_engine", return_value=fake_engine),
+        patch.object(backfill_module, "_resolve_zip_code", return_value="79901"),
+        patch.object(backfill_module, "session_scope", side_effect=RuntimeError("DB exploded")),
+    ):
+        counts = backfill_module.backfill(limit=5000, apply=True)
+
+    assert counts["failed"] == 1
+    assert counts["resolved"] == 0
+
+
+def test_candidate_query_uses_limit_param() -> None:
+    """The fetch query receives the provided LIMIT bind parameter."""
+    fake_engine = _engine_returning_rows([])
+
+    with patch.object(backfill_module, "get_engine", return_value=fake_engine):
+        backfill_module.backfill(limit=42, apply=False)
+
+    conn = fake_engine.connect.return_value
+    assert conn.execute.called
+    _stmt, params = conn.execute.call_args[0]
+    assert params == {"lim": 42}


### PR DESCRIPTION
## Summary
Closes the second of two upstream data gaps blocking Bryan's golden-question scoring (#244 + #289). After PR #301 (structural promotion-skip fix) and PR #303 (469-orphan backfill), this PR addresses the geographic dimension: postings now carry resolved `zip_code` end-to-end, so `dbo.postal_geo_data` joins can place rows in El Paso / Borderplex sub-regions.

Three changes:
1. **Mapper fix** (`normalization/mappers/jsearch.py`) — `_resolve_zip_code` previously truncated full state names to two letters (`"Texas" -> "TE"`), silently failing every `postal_geo_data` lookup. Now accepts both 2-letter codes and full state names via `_STATE_NAME_TO_CODE` (50 states + DC + PR). Failure paths log at WARNING instead of DEBUG.
2. **Promotion SQL threading** (`enrichment/job_postings_promotion.py`) — `zip_code` was missing from the resolve, load, insert, and three update SQL constants. Threaded through every constant + `_insert_job_posting_from_normalized` + `params_base`.
3. **One-shot backfill** (`scripts/backfill_zip_codes_normalized.py`) — re-resolves zip on existing `normalized_jobs` rows where `zip_code IS NULL` AND `city/state` populated; propagates to `job_postings` via `source/external_id`. Idempotent, dry-run default, `--apply` for writes. Mirrors the pattern of #303.

## Validation
Live read-only check against source-of-truth DB confirms the fix:

```
('El Paso', 'Texas', None) -> '79901'
('Sterling', 'Virginia', None) -> '20164'
('El Paso', 'TX', None)  -> '79901'
('Nowhere', 'Atlantis', None) -> None  (logs zip_resolution_unknown_state)
```

## Test plan
- [x] 14 mapper tests added/passing (`normalization/tests/test_field_mappers.py`)
- [x] 6 backfill tests added/passing (`tests/test_backfill_zip_codes_normalized.py`)
- [x] All 45 existing `test_job_postings_promotion.py` tests still pass
- [x] \`ruff check\` + \`ruff format\` clean
- [ ] CI green
- [ ] Backfill execution — gated on Gary go-ahead + fixture export (Phase 3)

Refs JIE #244.