### PR TITLE
fix(#308): persist spam_tier on every promotion path + sweeper for unclassified rows

### DIFF
--- a/enrichment/job_postings_promotion.py
+++ b/enrichment/job_postings_promotion.py
@@ -79,6 +79,9 @@ _UPDATE_UNCERTAIN_SQL = text(
         soc_code = :soc_code,
         sector_id = :sector_id,
         employer_profile_id = COALESCE(CAST(:employer_profile_id AS uuid), employer_profile_id),
+        is_spam = NULL,
+        spam_score = :spam_score,
+        spam_tier = 'uncertain',
         date_posted = COALESCE(:date_posted, date_posted),
         seniority_level = COALESCE(:seniority_level, seniority_level),
         is_remote = COALESCE(:is_remote, is_remote),
@@ -106,6 +109,7 @@ _UPDATE_CLEAN_SQL = text(
         employer_profile_id = COALESCE(CAST(:employer_profile_id AS uuid), employer_profile_id),
         is_spam = FALSE,
         spam_score = :spam_score,
+        spam_tier = 'clean',
         date_posted = COALESCE(:date_posted, date_posted),
         seniority_level = COALESCE(:seniority_level, seniority_level),
         is_remote = COALESCE(:is_remote, is_remote),
@@ -133,6 +137,7 @@ _UPDATE_FLAGGED_SQL = text(
         employer_profile_id = COALESCE(CAST(:employer_profile_id AS uuid), employer_profile_id),
         is_spam = NULL,
         spam_score = :spam_score,
+        spam_tier = 'flagged',
         date_posted = COALESCE(:date_posted, date_posted),
         seniority_level = COALESCE(:seniority_level, seniority_level),
         is_remote = COALESCE(:is_remote, is_remote),
@@ -151,6 +156,23 @@ _UPDATE_FUZZY_DEDUP_SQL = text(
     UPDATE dbo.job_postings SET
         is_duplicate = :is_duplicate,
         duplicate_cluster_id = CAST(:duplicate_cluster_id AS uuid)
+    WHERE job_posting_id::text = :job_posting_id
+    """
+)
+
+# JIE #308 — spam-only UPDATE used by the sweeper and one-shot backfill to add
+# the spam dimension to rows that missed classification on first promotion.
+# Deliberately narrow: writes is_spam, spam_score, spam_tier ONLY. Does NOT
+# touch quality / employer / role / zip / promoted_at / dedup — those live on
+# enrichment / promotion / dedup paths and a sweeper running post-hoc must
+# never clobber them. Tier is bound (not literal) because the sweeper applies
+# the classifier's actual output, not a routing decision.
+_UPDATE_SPAM_ONLY_SQL = text(
+    """
+    UPDATE dbo.job_postings SET
+        is_spam = :is_spam,
+        spam_score = :spam_score,
+        spam_tier = :spam_tier
     WHERE job_posting_id::text = :job_posting_id
     """
 )
@@ -678,6 +700,10 @@ def apply_enrichment_to_job_postings(
         "salary_currency": salary_currency_param,
         "salary_period": salary_period_param,
         "zip_code": zip_code_param,
+        # JIE #308 — uncertain tier UPDATE binds spam_score; default to None
+        # so the bind succeeds even when the classifier produced no score.
+        # Clean / flagged paths override below with the float value.
+        "spam_score": None,
         **derived_output_fields,
     }
 
@@ -736,9 +762,18 @@ def apply_enrichment_to_job_postings(
         )
         return _finish_with_dedup()
 
-    log.warning(
+    # JIE #308 Fix A — loud guard. After Fix B-1 lands, every classified row
+    # reaches one of the three branches above (clean / flagged / uncertain).
+    # If we hit this fall-through, something upstream produced a tier value
+    # the routing didn't recognize ('unknown', misspelled, etc.) — surface it
+    # at ERROR with full context so the regression is visible at the next
+    # PR-CI run rather than buried in a WARNING dashboard.
+    log.error(
         "enrichment_promotion_unhandled_tier",
         normalized_job_id=normalized_job_id,
-        tier=tier or raw_tier,
+        job_posting_id=job_posting_id,
+        tier_resolved=tier,
+        tier_raw=raw_tier,
+        spam_score_payload=spam_score,
     )
     return False

--- a/enrichment/tests/test_promotion_spam_tier_persistence.py
+++ b/enrichment/tests/test_promotion_spam_tier_persistence.py
@@ -1,0 +1,194 @@
+"""Tests for JIE #308 Fix B-1 + Fix A — `spam_tier` persistence on every promotion path.
+
+Pre-#308, the three UPDATE SQL constants in ``enrichment/job_postings_promotion.py``
+(``_UPDATE_CLEAN_SQL`` / ``_UPDATE_FLAGGED_SQL`` / ``_UPDATE_UNCERTAIN_SQL``) read the
+classifier's tier output to pick which UPDATE to run, but none of them actually
+persisted the ``spam_tier`` column. So ``dbo.job_postings.spam_tier`` was NULL on
+every row, even successfully-classified ones, and there was no way to distinguish
+"classifier ran with tier='flagged'" from "classifier never ran."
+
+Post-#308, each UPDATE writes its tier as a hardcoded literal:
+- ``_UPDATE_CLEAN_SQL`` writes ``spam_tier = 'clean'``
+- ``_UPDATE_FLAGGED_SQL`` writes ``spam_tier = 'flagged'``
+- ``_UPDATE_UNCERTAIN_SQL`` writes ``spam_tier = 'uncertain'`` + ``is_spam = NULL`` + ``spam_score = :spam_score``
+
+Plus Fix A — the previously-WARNING ``enrichment_promotion_unhandled_tier`` log
+is now ERROR-level so future regressions surface in PR-CI rather than buried
+in WARNING dashboards.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from enrichment.job_postings_promotion import (
+    _UPDATE_CLEAN_SQL,
+    _UPDATE_FLAGGED_SQL,
+    _UPDATE_UNCERTAIN_SQL,
+    apply_enrichment_to_job_postings,
+)
+
+
+def _mapping_first(row: dict | None) -> MagicMock:
+    m = MagicMock()
+    m.mappings.return_value.first.return_value = row
+    return m
+
+
+def _mapping_all(rows: list[dict]) -> MagicMock:
+    m = MagicMock()
+    m.mappings.return_value.all.return_value = rows
+    return m
+
+
+def _resolved_row() -> dict:
+    return {
+        "job_posting_id": "00000000-0000-0000-0000-000000000001",
+        "company_id": "00000000-0000-0000-0000-0000000000aa",
+        "date_posted": None,
+        "is_remote": False,
+        "salary_min": None,
+        "salary_max": None,
+        "salary_currency": None,
+        "salary_period": None,
+        "zip_code": None,
+    }
+
+
+def _payload(*, tier: str, score: float | None) -> dict[str, object]:
+    return {
+        "quality_score": 0.84,
+        "field_confidence": {"spam_score": 0.8},
+        "overall_confidence": 0.82,
+        "spam_tier": tier,
+        "spam_score": score,
+        "naics_code": "541110",
+    }
+
+
+def _build_session() -> MagicMock:
+    """Mock session whose execute() handles the resolve / sector / employer / update / dedup calls.
+
+    The promotion path issues several executes in sequence (resolve, employer-id,
+    sector resolve, the tier UPDATE, the dedup load + UPDATE, and the
+    ``promoted_at`` stamp from PR #301). The first ``mappings().first()`` returns
+    the resolved row; the others return generic MagicMocks so any ``.scalar_one_or_none()``
+    or follow-on calls succeed without raising.
+    """
+    session = MagicMock()
+    session.execute.side_effect = [
+        _mapping_first(_resolved_row()),  # resolve_job_posting_row
+        *[MagicMock() for _ in range(20)],  # remaining executes (sector, employer, UPDATE, dedup, stamp)
+    ]
+    return session
+
+
+def _params_for_sql(session: MagicMock, sql_obj) -> dict:
+    """Return the params dict from the execute() call that ran ``sql_obj``."""
+    expected = str(sql_obj)
+    for call in session.execute.call_args_list:
+        if str(call.args[0]) == expected:
+            return call.args[1]
+    raise AssertionError(f"No execute() call matched SQL\n{expected}")
+
+
+def test_clean_tier_sql_includes_spam_tier_literal() -> None:
+    """JIE #308 Fix B-1: _UPDATE_CLEAN_SQL must write spam_tier = 'clean'."""
+    sql = str(_UPDATE_CLEAN_SQL)
+    assert "spam_tier = 'clean'" in sql, "_UPDATE_CLEAN_SQL missing spam_tier literal"
+    assert "is_spam = FALSE" in sql, "Clean tier should still write is_spam = FALSE"
+
+
+def test_flagged_tier_sql_includes_spam_tier_literal() -> None:
+    """JIE #308 Fix B-1: _UPDATE_FLAGGED_SQL must write spam_tier = 'flagged' + keep is_spam = NULL."""
+    sql = str(_UPDATE_FLAGGED_SQL)
+    assert "spam_tier = 'flagged'" in sql
+    # NULL semantics preserved per Gary's HITL rule — flagged rows aren't surfaced
+    # in the natural flow until manually approved.
+    assert "is_spam = NULL" in sql, "Flagged tier MUST keep is_spam = NULL (HITL queue)"
+
+
+def test_uncertain_tier_sql_includes_spam_tier_literal_and_is_spam_null() -> None:
+    """JIE #308 Fix B-1 + B-2: _UPDATE_UNCERTAIN_SQL writes spam_tier = 'uncertain' + is_spam = NULL + spam_score bind."""
+    sql = str(_UPDATE_UNCERTAIN_SQL)
+    assert "spam_tier = 'uncertain'" in sql
+    assert "is_spam = NULL" in sql
+    assert "spam_score = :spam_score" in sql, (
+        "Uncertain tier should bind spam_score (None when classifier produced no score)"
+    )
+
+
+@pytest.mark.parametrize(
+    ("tier", "score", "expected_sql"),
+    [
+        ("clean", 0.2, _UPDATE_CLEAN_SQL),
+        ("flagged", 0.8, _UPDATE_FLAGGED_SQL),
+        ("uncertain", None, _UPDATE_UNCERTAIN_SQL),
+    ],
+)
+def test_apply_enrichment_dispatches_to_correct_tier_update(tier: str, score: float | None, expected_sql) -> None:
+    """JIE #308 Fix B-1: each tier value routes to its own UPDATE constant."""
+    session = _build_session()
+    payload = _payload(tier=tier, score=score)
+
+    apply_enrichment_to_job_postings(session, normalized_job_id=42, record_enriched_payload=payload)
+
+    sqls_executed = [str(c.args[0]) for c in session.execute.call_args_list]
+    assert str(expected_sql) in sqls_executed, f"Expected {tier} tier to execute its dedicated UPDATE constant"
+
+
+def test_uncertain_path_binds_spam_score_none() -> None:
+    """JIE #308 Fix B-2: uncertain UPDATE binds spam_score=None when classifier produced none."""
+    session = _build_session()
+    payload = _payload(tier="uncertain", score=None)
+
+    apply_enrichment_to_job_postings(session, normalized_job_id=42, record_enriched_payload=payload)
+
+    params = _params_for_sql(session, _UPDATE_UNCERTAIN_SQL)
+    assert "spam_score" in params, "uncertain UPDATE missing spam_score bind"
+    assert params["spam_score"] is None
+
+
+def test_unhandled_tier_logs_error_not_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """JIE #308 Fix A: an unrecognized tier value must produce an ERROR log, not WARNING.
+
+    Before Fix A this was a warning that buried in routine dashboards. Now it's
+    a loud ERROR so a future regression introducing a new tier value (typo,
+    case mismatch, classifier output drift) shows up in PR-CI noise immediately.
+
+    The structurally-reachable way to hit this fall-through is for
+    ``apply_spam_tiers`` to return a tier outside the four-state model
+    (clean/flagged/rejected/uncertain). We simulate that via monkeypatch.
+    """
+    import enrichment.job_postings_promotion as promotion_mod
+
+    monkeypatch.setattr(promotion_mod, "apply_spam_tiers", lambda *args, **kwargs: (None, "future_unknown_tier"))
+
+    # Capture log calls directly — structlog's processors don't always feed
+    # caplog cleanly, so we observe the bound logger's error/warning methods.
+    error_calls: list[tuple] = []
+    warning_calls: list[tuple] = []
+    monkeypatch.setattr(promotion_mod.log, "error", lambda *a, **kw: error_calls.append((a, kw)))
+    monkeypatch.setattr(promotion_mod.log, "warning", lambda *a, **kw: warning_calls.append((a, kw)))
+
+    session = _build_session()
+    payload = _payload(tier="bogus_tier", score=0.5)
+
+    applied = apply_enrichment_to_job_postings(session, normalized_job_id=42, record_enriched_payload=payload)
+
+    assert applied is False, "Unhandled tier must return False (don't pretend success)"
+    # Find the unhandled-tier error call — must be ERROR, not WARNING.
+    unhandled_err = [c for c in error_calls if c[0] and "unhandled_tier" in c[0][0]]
+    unhandled_warn = [c for c in warning_calls if c[0] and "unhandled_tier" in c[0][0]]
+    assert unhandled_err, (
+        f"Expected log.error('enrichment_promotion_unhandled_tier', ...). "
+        f"Got error_calls={error_calls!r}, warning_calls={warning_calls!r}"
+    )
+    assert not unhandled_warn, "Fix A regression: unhandled_tier dropped back to WARNING"
+    # Verify the structured fields the guard surfaces (helps debugging future regressions).
+    _, kwargs = unhandled_err[0]
+    assert kwargs.get("tier_resolved") == "future_unknown_tier"
+    assert kwargs.get("tier_raw") == "bogus_tier"
+    assert kwargs.get("spam_score_payload") == 0.5

--- a/scripts/sweep_unclassified_spam.py
+++ b/scripts/sweep_unclassified_spam.py
@@ -1,0 +1,285 @@
+# ruff: noqa: T201
+"""Periodic sweeper: classify ``dbo.job_postings`` rows missing a spam tier — JIE #308 Fix C.
+
+Background
+----------
+Pre-JIE #308, `enrichment/job_postings_promotion.py` had three structural
+defects on the spam classification pipeline:
+
+1. None of `_UPDATE_CLEAN_SQL` / `_UPDATE_FLAGGED_SQL` / `_UPDATE_UNCERTAIN_SQL`
+   wrote `spam_tier`, so the column stayed NULL on every promoted row.
+2. `_UPDATE_UNCERTAIN_SQL` wrote neither `is_spam` nor `spam_score`, so
+   uncertain rows were indistinguishable from "never classified."
+3. PR #303's orphan-promotion path (`_insert_job_posting_from_normalized`)
+   bypasses `apply_enrichment_to_job_postings` entirely, so orphans land in
+   `job_postings` with all spam columns NULL.
+
+The Fix B-1 SQL changes close defects #1 and #2 going forward. This sweeper
+closes defect #3 and provides eventual consistency for any historical or
+future row whose spam classification doesn't reach the live promotion path:
+it finds rows where ``spam_tier IS NULL`` and runs the classifier on them.
+
+Mirrors the pattern of ``scripts/sweep_unpromoted_normalized_jobs.py`` (PR
+#301): default dry-run, a 1-hour grace window to avoid racing live promotion,
+``--limit`` for staged runs, idempotent under re-runs.
+
+Usage
+-----
+.. code-block:: bash
+
+    # Dry run (default — counts candidates, makes no writes, no LLM calls)
+    python scripts/sweep_unclassified_spam.py
+
+    # Apply: classify and update up to 200 rows older than 1 hour
+    python scripts/sweep_unclassified_spam.py --apply
+
+    # Larger run with custom grace window
+    python scripts/sweep_unclassified_spam.py --apply --limit 500 --grace-minutes 30
+
+Idempotent — only touches rows where ``spam_tier IS NULL``. Reads
+``PYTHON_DATABASE_URL`` from ``.env``.
+
+**Important:** export fixtures before running with ``--apply``. Per the
+JIE database protection rules (``~/.claude/CLAUDE.md``), ``job_postings``
+mutations require a fixture snapshot first.
+
+.. code-block:: bash
+
+    python scripts/pg-seed-data/export_fixtures.py --scope all
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import text  # noqa: E402
+
+from common.data_store.database import get_engine, session_scope  # noqa: E402
+from common.env import load_repo_root_dotenv  # noqa: E402
+from enrichment.classifiers.spam_preview import (  # noqa: E402
+    apply_spam_tiers,
+    score_spam_preview,
+)
+from enrichment.job_postings_promotion import _UPDATE_SPAM_ONLY_SQL  # noqa: E402
+
+log = structlog.get_logger()
+
+
+# Find rows that need classification: spam_tier NULL (the ground truth flag
+# for "we never classified this"). Join out to extracted_intelligence so the
+# classifier can read skills / tasks / responsibilities for context — many
+# rows have NULL extraction, in which case the classifier degrades to
+# "uncertain" gracefully.
+_FETCH_CANDIDATES_SQL = text(
+    """
+    WITH unprocessed AS (
+        SELECT DISTINCT ON (jp.job_posting_id)
+               jp.job_posting_id,
+               jp.job_title,
+               jp.job_description,
+               jp.createdat,
+               ei.skills,
+               ei.tools,
+               ei.tasks,
+               ei.responsibilities,
+               ei.context,
+               COALESCE(ei.extraction_failed, FALSE) AS extraction_failed
+        FROM dbo.job_postings AS jp
+        LEFT JOIN dbo.normalized_jobs AS nj
+            ON nj.source = jp.source AND nj.external_id = jp.external_id
+        LEFT JOIN dbo.extracted_intelligence AS ei
+            ON ei.normalized_job_id = nj.id
+        WHERE jp.spam_tier IS NULL
+          AND jp.createdat < NOW() - make_interval(mins => :grace_minutes)
+        ORDER BY jp.job_posting_id, ei.extracted_at DESC NULLS LAST
+    )
+    SELECT job_posting_id::text AS job_posting_id,
+           job_title,
+           job_description,
+           skills,
+           tools,
+           tasks,
+           responsibilities,
+           context,
+           extraction_failed
+    FROM unprocessed
+    ORDER BY createdat ASC
+    LIMIT :lim
+    """
+)
+
+
+def _extraction_dict(row: Any) -> tuple[dict[str, Any], bool, bool]:
+    """Build the ``extraction`` dict the classifier expects + the failure flags."""
+    extraction_failed = bool(row.get("extraction_failed"))
+    extraction: dict[str, Any] = {}
+    for key in ("skills", "tools", "tasks", "responsibilities", "context"):
+        val = row.get(key)
+        if val is not None:
+            extraction[key] = val
+    extraction_empty = not extraction and not extraction_failed
+    return extraction, extraction_failed, extraction_empty
+
+
+def sweep(*, limit: int = 200, grace_minutes: int = 60, apply: bool = False) -> dict[str, int]:
+    """Classify up to ``limit`` rows where ``spam_tier IS NULL``.
+
+    Returns counts: ``{"candidates": N, "classified_clean": N,
+    "classified_flagged": N, "classified_uncertain": N, "failed": N}``.
+
+    When ``apply=False`` (default), counts only — no LLM calls, no writes.
+    """
+    engine = get_engine()
+    counts = {
+        "candidates": 0,
+        "classified_clean": 0,
+        "classified_flagged": 0,
+        "classified_uncertain": 0,
+        "failed": 0,
+    }
+
+    with engine.connect() as conn:
+        rows = (
+            conn.execute(
+                _FETCH_CANDIDATES_SQL,
+                {"lim": limit, "grace_minutes": grace_minutes},
+            )
+            .mappings()
+            .all()
+        )
+
+    counts["candidates"] = len(rows)
+    if not rows:
+        log.info("spam_sweep_no_candidates", limit=limit, grace_minutes=grace_minutes)
+        return counts
+
+    log.info(
+        "spam_sweep_candidates_found",
+        n=len(rows),
+        apply=apply,
+        grace_minutes=grace_minutes,
+    )
+
+    if not apply:
+        for row in rows[:10]:
+            print(f"  [dry-run] job_posting_id={row['job_posting_id']} title={(row.get('job_title') or '')[:60]!r}")
+        if len(rows) > 10:
+            print(f"  [dry-run] ... and {len(rows) - 10} more")
+        return counts
+
+    for row in rows:
+        jp_id = row["job_posting_id"]
+        try:
+            extraction, extraction_failed, extraction_empty = _extraction_dict(dict(row))
+            result = score_spam_preview(
+                job_title=row.get("job_title") or "",
+                job_description=row.get("job_description") or "",
+                extraction=extraction,
+                extraction_failed=extraction_failed,
+                extraction_empty=extraction_empty,
+            )
+
+            # Map the classifier output to the strict 4-state model documented
+            # in the JIE #308 plan: clean / flagged / uncertain / rejected.
+            # Rejected rows are deliberately surfaced (is_spam=TRUE) here,
+            # unlike the live promotion path that skips the UPDATE entirely —
+            # the sweeper's role is to record what the classifier saw, even
+            # for confirmed spam, so the column reflects ground truth.
+            if result.spam_score is None:
+                tier = "uncertain"
+                is_spam: bool | None = None
+                spam_score: float | None = None
+            else:
+                is_spam, tier = apply_spam_tiers(float(result.spam_score))
+                spam_score = float(result.spam_score)
+
+            with session_scope() as session:
+                session.execute(
+                    _UPDATE_SPAM_ONLY_SQL,
+                    {
+                        "job_posting_id": jp_id,
+                        "is_spam": is_spam,
+                        "spam_score": spam_score,
+                        "spam_tier": tier,
+                    },
+                )
+
+            if tier == "clean":
+                counts["classified_clean"] += 1
+            elif tier == "flagged":
+                counts["classified_flagged"] += 1
+            else:
+                counts["classified_uncertain"] += 1
+            log.info(
+                "spam_sweep_classified",
+                job_posting_id=jp_id,
+                tier=tier,
+                spam_score=spam_score,
+            )
+        except Exception as exc:
+            counts["failed"] += 1
+            log.warning(
+                "spam_sweep_failed",
+                job_posting_id=jp_id,
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+
+    log.info("spam_sweep_complete", **counts)
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Periodic sweeper: classify job_postings rows missing spam_tier (JIE #308). "
+            "Default is dry-run; pass --apply to run the classifier and write. "
+            "Export fixtures BEFORE --apply per JIE database protection rules."
+        )
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually run the classifier and write results (without this flag, runs in dry-run mode).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=200,
+        help="Maximum rows to classify per run. Default 200 — safe for hourly cron.",
+    )
+    parser.add_argument(
+        "--grace-minutes",
+        type=int,
+        default=60,
+        help="Skip rows newer than this many minutes — avoids racing live promotion.",
+    )
+    args = parser.parse_args()
+
+    load_repo_root_dotenv()
+    counts = sweep(limit=args.limit, grace_minutes=args.grace_minutes, apply=args.apply)
+
+    print()
+    print("=" * 60)
+    print(f"Spam sweep summary ({'APPLY' if args.apply else 'DRY-RUN'}):")
+    print(f"  candidates found       : {counts['candidates']}")
+    if args.apply:
+        print(f"  classified clean       : {counts['classified_clean']}")
+        print(f"  classified flagged     : {counts['classified_flagged']}")
+        print(f"  classified uncertain   : {counts['classified_uncertain']}")
+        print(f"  failed                 : {counts['failed']}")
+    print("=" * 60)
+    if args.apply and counts["failed"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sweep_unclassified_spam.py
+++ b/tests/test_sweep_unclassified_spam.py
@@ -1,0 +1,187 @@
+"""Tests for scripts/sweep_unclassified_spam.py — JIE #308 Fix C."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import scripts.sweep_unclassified_spam as sweep_module  # noqa: E402
+
+
+def test_module_importable() -> None:
+    """Smoke: the script imports + exposes the public surface."""
+    assert callable(sweep_module.sweep)
+    assert callable(sweep_module.main)
+
+
+def _engine_returning_rows(rows: list[dict]) -> MagicMock:
+    """Mock engine whose .connect() returns rows for the candidate query."""
+    mappings = MagicMock()
+    mappings.all.return_value = rows
+    cursor = MagicMock()
+    cursor.mappings.return_value = mappings
+    conn = MagicMock()
+    conn.execute.return_value = cursor
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    engine = MagicMock()
+    engine.connect.return_value = conn
+    return engine
+
+
+def _candidate_row(**overrides) -> dict:
+    base = {
+        "job_posting_id": "00000000-0000-0000-0000-000000000001",
+        "job_title": "Software Engineer",
+        "job_description": "Build things.",
+        "skills": [{"skill_label": "Python"}],
+        "tools": None,
+        "tasks": None,
+        "responsibilities": None,
+        "context": None,
+        "extraction_failed": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _spam_result(*, score: float | None, tier: str = "clean") -> MagicMock:
+    r = MagicMock()
+    r.spam_score = score
+    r.tier = tier
+    r.is_spam = False if tier == "clean" else None if tier == "flagged" else True if tier == "rejected" else None
+    r.degraded = score is None
+    return r
+
+
+def test_dry_run_counts_candidates_without_writes_or_llm() -> None:
+    """Dry-run mode counts candidates only — no session_scope, no classifier call."""
+    fake_engine = _engine_returning_rows(
+        [_candidate_row(), _candidate_row(job_posting_id="00000000-0000-0000-0000-000000000002")]
+    )
+
+    with (
+        patch.object(sweep_module, "get_engine", return_value=fake_engine),
+        patch.object(sweep_module, "score_spam_preview") as mock_classifier,
+        patch.object(sweep_module, "session_scope") as mock_scope,
+    ):
+        counts = sweep_module.sweep(limit=200, grace_minutes=60, apply=False)
+
+    assert counts["candidates"] == 2
+    assert counts["classified_clean"] == 0
+    mock_classifier.assert_not_called()
+    mock_scope.assert_not_called()
+
+
+def test_no_candidates_returns_zero_counts() -> None:
+    """When the candidate query returns zero rows, all counts stay at 0."""
+    fake_engine = _engine_returning_rows([])
+
+    with patch.object(sweep_module, "get_engine", return_value=fake_engine):
+        counts = sweep_module.sweep(limit=200, grace_minutes=60, apply=False)
+
+    assert counts["candidates"] == 0
+
+
+def test_apply_classifies_clean_writes_via_spam_only_sql() -> None:
+    """Apply: classifier returns score=0.2 → tier=clean → UPDATE writes is_spam=False."""
+    fake_engine = _engine_returning_rows([_candidate_row()])
+
+    session = MagicMock()
+    scope_cm = MagicMock()
+    scope_cm.__enter__.return_value = session
+    scope_cm.__exit__.return_value = False
+
+    with (
+        patch.object(sweep_module, "get_engine", return_value=fake_engine),
+        patch.object(
+            sweep_module,
+            "score_spam_preview",
+            return_value=_spam_result(score=0.2, tier="clean"),
+        ),
+        patch.object(sweep_module, "session_scope", return_value=scope_cm),
+    ):
+        counts = sweep_module.sweep(limit=200, grace_minutes=60, apply=True)
+
+    assert counts["candidates"] == 1
+    assert counts["classified_clean"] == 1
+    # The UPDATE bind params include is_spam=False, spam_tier='clean'.
+    update_call = session.execute.call_args
+    params = update_call.args[1]
+    assert params["is_spam"] is False
+    assert params["spam_tier"] == "clean"
+    assert params["spam_score"] == 0.2
+
+
+def test_apply_classifies_flagged() -> None:
+    """Apply: score=0.8 → tier=flagged → is_spam=None."""
+    fake_engine = _engine_returning_rows([_candidate_row()])
+    session = MagicMock()
+    scope_cm = MagicMock()
+    scope_cm.__enter__.return_value = session
+    scope_cm.__exit__.return_value = False
+
+    with (
+        patch.object(sweep_module, "get_engine", return_value=fake_engine),
+        patch.object(sweep_module, "score_spam_preview", return_value=_spam_result(score=0.8, tier="flagged")),
+        patch.object(sweep_module, "session_scope", return_value=scope_cm),
+    ):
+        counts = sweep_module.sweep(limit=200, grace_minutes=60, apply=True)
+
+    assert counts["classified_flagged"] == 1
+    params = session.execute.call_args.args[1]
+    assert params["is_spam"] is None
+    assert params["spam_tier"] == "flagged"
+
+
+def test_apply_uncertain_when_classifier_returns_no_score() -> None:
+    """Apply: score=None (degraded) → tier=uncertain → is_spam=NULL, spam_score=NULL."""
+    fake_engine = _engine_returning_rows([_candidate_row(extraction_failed=True)])
+    session = MagicMock()
+    scope_cm = MagicMock()
+    scope_cm.__enter__.return_value = session
+    scope_cm.__exit__.return_value = False
+
+    with (
+        patch.object(sweep_module, "get_engine", return_value=fake_engine),
+        patch.object(sweep_module, "score_spam_preview", return_value=_spam_result(score=None)),
+        patch.object(sweep_module, "session_scope", return_value=scope_cm),
+    ):
+        counts = sweep_module.sweep(limit=200, grace_minutes=60, apply=True)
+
+    assert counts["classified_uncertain"] == 1
+    params = session.execute.call_args.args[1]
+    assert params["is_spam"] is None
+    assert params["spam_score"] is None
+    assert params["spam_tier"] == "uncertain"
+
+
+def test_apply_failure_increments_failed_counter() -> None:
+    """An exception during a row's classification is caught and tallied as failure."""
+    fake_engine = _engine_returning_rows([_candidate_row()])
+
+    with (
+        patch.object(sweep_module, "get_engine", return_value=fake_engine),
+        patch.object(sweep_module, "score_spam_preview", side_effect=RuntimeError("LLM exploded")),
+        patch.object(sweep_module, "session_scope") as mock_scope,
+    ):
+        counts = sweep_module.sweep(limit=200, grace_minutes=60, apply=True)
+
+    assert counts["failed"] == 1
+    assert counts["classified_clean"] == 0
+    mock_scope.assert_not_called()
+
+
+def test_grace_window_bind_param() -> None:
+    """The candidate query receives the provided grace_minutes."""
+    fake_engine = _engine_returning_rows([])
+
+    with patch.object(sweep_module, "get_engine", return_value=fake_engine):
+        sweep_module.sweep(limit=200, grace_minutes=42, apply=False)
+
+    conn = fake_engine.connect.return_value
+    _stmt, params = conn.execute.call_args.args
+    assert params == {"lim": 200, "grace_minutes": 42}


### PR DESCRIPTION
## Summary
PR-1 of 2 for closing JIE #308. After PRs #310 + #307 landed the routing fix Bryan needs, the eval still returns ~0 rows on most subregions because **only 27 of 4,710 \`dbo.job_postings\` rows have \`is_spam = FALSE\`** (the strict filter PR #310 enforces). The other 4,683 are NULL — unclassified, awaiting verification.

This PR fixes the workflow going forward (Fix A + B + C, mirroring the #289 pattern). **PR-2 will run the actual backfill** on the ~4,683 historical rows + ship findings v2.3 + fresh fixtures.

## Discovery — what actually broke
Two structural defects + one missing pipeline coverage:

1. **\`spam_tier\` is never persisted.** Migration adds the column (\`migrations.py:118\`); classifier produces the tier; promotion reads it at \`job_postings_promotion.py:563\` to pick which UPDATE to run — but **none of \`_UPDATE_CLEAN_SQL\` / \`_UPDATE_FLAGGED_SQL\` / \`_UPDATE_UNCERTAIN_SQL\` include \`spam_tier = ...\`**. So the column was NULL on every row, even classified ones.
2. **\`_UPDATE_UNCERTAIN_SQL\` writes neither \`is_spam\` nor \`spam_score\`.** Uncertain tier rows look identical to unprocessed.
3. **Orphan-promoted rows skip classification entirely.** PR #303's backfill calls \`_insert_job_posting_from_normalized\` directly, bypassing \`apply_enrichment_to_job_postings\`.

## What lands

**Fix B-1 — Persist \`spam_tier\` in all three UPDATE constants** (\`enrichment/job_postings_promotion.py\`):
- \`_UPDATE_CLEAN_SQL\`: + \`spam_tier = 'clean'\`
- \`_UPDATE_FLAGGED_SQL\`: + \`spam_tier = 'flagged'\` (keeps \`is_spam = NULL\` per Gary's HITL rule — flagged rows must not surface in PR #310's natural flow without manual approval)
- \`_UPDATE_UNCERTAIN_SQL\`: + \`is_spam = NULL\`, \`spam_score = :spam_score\`, \`spam_tier = 'uncertain'\`

Tier is hardcoded literal in each SQL constant — callers can't write the wrong tier through the wrong path.

**Fix C — Sweeper + spam-only UPDATE** (new \`_UPDATE_SPAM_ONLY_SQL\` + \`scripts/sweep_unclassified_spam.py\`):
- New SQL writes \`is_spam\` / \`spam_score\` / \`spam_tier\` only — never touches \`quality_score\`, \`employer_profile_id\`, \`zip_code\`, \`date_posted\`, \`promoted_at\`. Sweeper isn't redoing enrichment; it's adding the spam dimension to rows that missed it.
- Sweeper finds \`spam_tier IS NULL AND createdat < NOW() - grace\`, dedupes via \`DISTINCT ON (job_posting_id)\` (extracted_intelligence fan-out can produce duplicate rows otherwise), calls \`score_spam_preview\`, writes via the new SQL. Default \`--grace-minutes 60\`, \`--limit 200\`, dry-run default.
- Live verified against Gary's DB: dry-run finds **4,710 candidates with \`--limit 5000 --grace-minutes 0\`** (matches the expected backlog).

**Fix A — Loud guard upgrade** (\`enrichment/job_postings_promotion.py\`):
- \`enrichment_promotion_unhandled_tier\` was WARNING; now ERROR with \`tier_resolved\`, \`tier_raw\`, \`spam_score_payload\` fields. Future regressions surface in PR-CI rather than buried in WARNING dashboards. Mirrors PR #301's pattern.

## Regression invariants — preserved
- PR #301's \`promoted_at\` stamp: unchanged. New SQL doesn't touch it.
- PR #303's orphan-promotion path: unchanged. Sweeper picks up new orphans separately.
- PR #304's \`zip_code\` propagation: unchanged. New SQL doesn't include \`zip_code\`.
- PR #307's smoke invariants: unchanged.
- PR #310's \`is_spam = FALSE\` strict filter: unchanged. After PR-2's backfill, more rows pass it (clean), flagged stay excluded.
- Mock-count assertions: still 3 \`execute()\` calls per row in the live promotion path.
- Flagged-tier \`is_spam = NULL\`: preserved (HITL semantic).

## Test plan
- [x] \`pytest enrichment/tests/ tests/test_sweep_unclassified_spam.py\` — 236 pass (16 new)
- [x] \`ruff check + ruff format\` clean
- [x] Live sweeper dry-run against Gary's DB: 4,710 candidates found, 0 errors
- [x] All four SQL constants verified to contain expected \`spam_tier\` literals
- [ ] CI green
- [ ] PR-2 (backfill execution + findings v2.3 + fresh fixtures) — branched off this PR; will close #308 after this merges

Closes nothing yet — PR-2 will close #308 explicitly.