### PR TITLE
fix(#308): one-shot spam-classification backfill + smoke invariants (closes #308)

### DIFF
--- a/enrichment/job_postings_promotion.py
+++ b/enrichment/job_postings_promotion.py
@@ -79,6 +79,9 @@ _UPDATE_UNCERTAIN_SQL = text(
         soc_code = :soc_code,
         sector_id = :sector_id,
         employer_profile_id = COALESCE(CAST(:employer_profile_id AS uuid), employer_profile_id),
+        is_spam = NULL,
+        spam_score = :spam_score,
+        spam_tier = 'uncertain',
         date_posted = COALESCE(:date_posted, date_posted),
         seniority_level = COALESCE(:seniority_level, seniority_level),
         is_remote = COALESCE(:is_remote, is_remote),
@@ -106,6 +109,7 @@ _UPDATE_CLEAN_SQL = text(
         employer_profile_id = COALESCE(CAST(:employer_profile_id AS uuid), employer_profile_id),
         is_spam = FALSE,
         spam_score = :spam_score,
+        spam_tier = 'clean',
         date_posted = COALESCE(:date_posted, date_posted),
         seniority_level = COALESCE(:seniority_level, seniority_level),
         is_remote = COALESCE(:is_remote, is_remote),
@@ -133,6 +137,7 @@ _UPDATE_FLAGGED_SQL = text(
         employer_profile_id = COALESCE(CAST(:employer_profile_id AS uuid), employer_profile_id),
         is_spam = NULL,
         spam_score = :spam_score,
+        spam_tier = 'flagged',
         date_posted = COALESCE(:date_posted, date_posted),
         seniority_level = COALESCE(:seniority_level, seniority_level),
         is_remote = COALESCE(:is_remote, is_remote),
@@ -151,6 +156,23 @@ _UPDATE_FUZZY_DEDUP_SQL = text(
     UPDATE dbo.job_postings SET
         is_duplicate = :is_duplicate,
         duplicate_cluster_id = CAST(:duplicate_cluster_id AS uuid)
+    WHERE job_posting_id::text = :job_posting_id
+    """
+)
+
+# JIE #308 — spam-only UPDATE used by the sweeper and one-shot backfill to add
+# the spam dimension to rows that missed classification on first promotion.
+# Deliberately narrow: writes is_spam, spam_score, spam_tier ONLY. Does NOT
+# touch quality / employer / role / zip / promoted_at / dedup — those live on
+# enrichment / promotion / dedup paths and a sweeper running post-hoc must
+# never clobber them. Tier is bound (not literal) because the sweeper applies
+# the classifier's actual output, not a routing decision.
+_UPDATE_SPAM_ONLY_SQL = text(
+    """
+    UPDATE dbo.job_postings SET
+        is_spam = :is_spam,
+        spam_score = :spam_score,
+        spam_tier = :spam_tier
     WHERE job_posting_id::text = :job_posting_id
     """
 )
@@ -678,6 +700,10 @@ def apply_enrichment_to_job_postings(
         "salary_currency": salary_currency_param,
         "salary_period": salary_period_param,
         "zip_code": zip_code_param,
+        # JIE #308 — uncertain tier UPDATE binds spam_score; default to None
+        # so the bind succeeds even when the classifier produced no score.
+        # Clean / flagged paths override below with the float value.
+        "spam_score": None,
         **derived_output_fields,
     }
 
@@ -736,9 +762,18 @@ def apply_enrichment_to_job_postings(
         )
         return _finish_with_dedup()
 
-    log.warning(
+    # JIE #308 Fix A — loud guard. After Fix B-1 lands, every classified row
+    # reaches one of the three branches above (clean / flagged / uncertain).
+    # If we hit this fall-through, something upstream produced a tier value
+    # the routing didn't recognize ('unknown', misspelled, etc.) — surface it
+    # at ERROR with full context so the regression is visible at the next
+    # PR-CI run rather than buried in a WARNING dashboard.
+    log.error(
         "enrichment_promotion_unhandled_tier",
         normalized_job_id=normalized_job_id,
-        tier=tier or raw_tier,
+        job_posting_id=job_posting_id,
+        tier_resolved=tier,
+        tier_raw=raw_tier,
+        spam_score_payload=spam_score,
     )
     return False

--- a/enrichment/tests/test_promotion_spam_tier_persistence.py
+++ b/enrichment/tests/test_promotion_spam_tier_persistence.py
@@ -1,0 +1,194 @@
+"""Tests for JIE #308 Fix B-1 + Fix A — `spam_tier` persistence on every promotion path.
+
+Pre-#308, the three UPDATE SQL constants in ``enrichment/job_postings_promotion.py``
+(``_UPDATE_CLEAN_SQL`` / ``_UPDATE_FLAGGED_SQL`` / ``_UPDATE_UNCERTAIN_SQL``) read the
+classifier's tier output to pick which UPDATE to run, but none of them actually
+persisted the ``spam_tier`` column. So ``dbo.job_postings.spam_tier`` was NULL on
+every row, even successfully-classified ones, and there was no way to distinguish
+"classifier ran with tier='flagged'" from "classifier never ran."
+
+Post-#308, each UPDATE writes its tier as a hardcoded literal:
+- ``_UPDATE_CLEAN_SQL`` writes ``spam_tier = 'clean'``
+- ``_UPDATE_FLAGGED_SQL`` writes ``spam_tier = 'flagged'``
+- ``_UPDATE_UNCERTAIN_SQL`` writes ``spam_tier = 'uncertain'`` + ``is_spam = NULL`` + ``spam_score = :spam_score``
+
+Plus Fix A — the previously-WARNING ``enrichment_promotion_unhandled_tier`` log
+is now ERROR-level so future regressions surface in PR-CI rather than buried
+in WARNING dashboards.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from enrichment.job_postings_promotion import (
+    _UPDATE_CLEAN_SQL,
+    _UPDATE_FLAGGED_SQL,
+    _UPDATE_UNCERTAIN_SQL,
+    apply_enrichment_to_job_postings,
+)
+
+
+def _mapping_first(row: dict | None) -> MagicMock:
+    m = MagicMock()
+    m.mappings.return_value.first.return_value = row
+    return m
+
+
+def _mapping_all(rows: list[dict]) -> MagicMock:
+    m = MagicMock()
+    m.mappings.return_value.all.return_value = rows
+    return m
+
+
+def _resolved_row() -> dict:
+    return {
+        "job_posting_id": "00000000-0000-0000-0000-000000000001",
+        "company_id": "00000000-0000-0000-0000-0000000000aa",
+        "date_posted": None,
+        "is_remote": False,
+        "salary_min": None,
+        "salary_max": None,
+        "salary_currency": None,
+        "salary_period": None,
+        "zip_code": None,
+    }
+
+
+def _payload(*, tier: str, score: float | None) -> dict[str, object]:
+    return {
+        "quality_score": 0.84,
+        "field_confidence": {"spam_score": 0.8},
+        "overall_confidence": 0.82,
+        "spam_tier": tier,
+        "spam_score": score,
+        "naics_code": "541110",
+    }
+
+
+def _build_session() -> MagicMock:
+    """Mock session whose execute() handles the resolve / sector / employer / update / dedup calls.
+
+    The promotion path issues several executes in sequence (resolve, employer-id,
+    sector resolve, the tier UPDATE, the dedup load + UPDATE, and the
+    ``promoted_at`` stamp from PR #301). The first ``mappings().first()`` returns
+    the resolved row; the others return generic MagicMocks so any ``.scalar_one_or_none()``
+    or follow-on calls succeed without raising.
+    """
+    session = MagicMock()
+    session.execute.side_effect = [
+        _mapping_first(_resolved_row()),  # resolve_job_posting_row
+        *[MagicMock() for _ in range(20)],  # remaining executes (sector, employer, UPDATE, dedup, stamp)
+    ]
+    return session
+
+
+def _params_for_sql(session: MagicMock, sql_obj) -> dict:
+    """Return the params dict from the execute() call that ran ``sql_obj``."""
+    expected = str(sql_obj)
+    for call in session.execute.call_args_list:
+        if str(call.args[0]) == expected:
+            return call.args[1]
+    raise AssertionError(f"No execute() call matched SQL\n{expected}")
+
+
+def test_clean_tier_sql_includes_spam_tier_literal() -> None:
+    """JIE #308 Fix B-1: _UPDATE_CLEAN_SQL must write spam_tier = 'clean'."""
+    sql = str(_UPDATE_CLEAN_SQL)
+    assert "spam_tier = 'clean'" in sql, "_UPDATE_CLEAN_SQL missing spam_tier literal"
+    assert "is_spam = FALSE" in sql, "Clean tier should still write is_spam = FALSE"
+
+
+def test_flagged_tier_sql_includes_spam_tier_literal() -> None:
+    """JIE #308 Fix B-1: _UPDATE_FLAGGED_SQL must write spam_tier = 'flagged' + keep is_spam = NULL."""
+    sql = str(_UPDATE_FLAGGED_SQL)
+    assert "spam_tier = 'flagged'" in sql
+    # NULL semantics preserved per Gary's HITL rule — flagged rows aren't surfaced
+    # in the natural flow until manually approved.
+    assert "is_spam = NULL" in sql, "Flagged tier MUST keep is_spam = NULL (HITL queue)"
+
+
+def test_uncertain_tier_sql_includes_spam_tier_literal_and_is_spam_null() -> None:
+    """JIE #308 Fix B-1 + B-2: _UPDATE_UNCERTAIN_SQL writes spam_tier = 'uncertain' + is_spam = NULL + spam_score bind."""
+    sql = str(_UPDATE_UNCERTAIN_SQL)
+    assert "spam_tier = 'uncertain'" in sql
+    assert "is_spam = NULL" in sql
+    assert "spam_score = :spam_score" in sql, (
+        "Uncertain tier should bind spam_score (None when classifier produced no score)"
+    )
+
+
+@pytest.mark.parametrize(
+    ("tier", "score", "expected_sql"),
+    [
+        ("clean", 0.2, _UPDATE_CLEAN_SQL),
+        ("flagged", 0.8, _UPDATE_FLAGGED_SQL),
+        ("uncertain", None, _UPDATE_UNCERTAIN_SQL),
+    ],
+)
+def test_apply_enrichment_dispatches_to_correct_tier_update(tier: str, score: float | None, expected_sql) -> None:
+    """JIE #308 Fix B-1: each tier value routes to its own UPDATE constant."""
+    session = _build_session()
+    payload = _payload(tier=tier, score=score)
+
+    apply_enrichment_to_job_postings(session, normalized_job_id=42, record_enriched_payload=payload)
+
+    sqls_executed = [str(c.args[0]) for c in session.execute.call_args_list]
+    assert str(expected_sql) in sqls_executed, f"Expected {tier} tier to execute its dedicated UPDATE constant"
+
+
+def test_uncertain_path_binds_spam_score_none() -> None:
+    """JIE #308 Fix B-2: uncertain UPDATE binds spam_score=None when classifier produced none."""
+    session = _build_session()
+    payload = _payload(tier="uncertain", score=None)
+
+    apply_enrichment_to_job_postings(session, normalized_job_id=42, record_enriched_payload=payload)
+
+    params = _params_for_sql(session, _UPDATE_UNCERTAIN_SQL)
+    assert "spam_score" in params, "uncertain UPDATE missing spam_score bind"
+    assert params["spam_score"] is None
+
+
+def test_unhandled_tier_logs_error_not_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """JIE #308 Fix A: an unrecognized tier value must produce an ERROR log, not WARNING.
+
+    Before Fix A this was a warning that buried in routine dashboards. Now it's
+    a loud ERROR so a future regression introducing a new tier value (typo,
+    case mismatch, classifier output drift) shows up in PR-CI noise immediately.
+
+    The structurally-reachable way to hit this fall-through is for
+    ``apply_spam_tiers`` to return a tier outside the four-state model
+    (clean/flagged/rejected/uncertain). We simulate that via monkeypatch.
+    """
+    import enrichment.job_postings_promotion as promotion_mod
+
+    monkeypatch.setattr(promotion_mod, "apply_spam_tiers", lambda *args, **kwargs: (None, "future_unknown_tier"))
+
+    # Capture log calls directly — structlog's processors don't always feed
+    # caplog cleanly, so we observe the bound logger's error/warning methods.
+    error_calls: list[tuple] = []
+    warning_calls: list[tuple] = []
+    monkeypatch.setattr(promotion_mod.log, "error", lambda *a, **kw: error_calls.append((a, kw)))
+    monkeypatch.setattr(promotion_mod.log, "warning", lambda *a, **kw: warning_calls.append((a, kw)))
+
+    session = _build_session()
+    payload = _payload(tier="bogus_tier", score=0.5)
+
+    applied = apply_enrichment_to_job_postings(session, normalized_job_id=42, record_enriched_payload=payload)
+
+    assert applied is False, "Unhandled tier must return False (don't pretend success)"
+    # Find the unhandled-tier error call — must be ERROR, not WARNING.
+    unhandled_err = [c for c in error_calls if c[0] and "unhandled_tier" in c[0][0]]
+    unhandled_warn = [c for c in warning_calls if c[0] and "unhandled_tier" in c[0][0]]
+    assert unhandled_err, (
+        f"Expected log.error('enrichment_promotion_unhandled_tier', ...). "
+        f"Got error_calls={error_calls!r}, warning_calls={warning_calls!r}"
+    )
+    assert not unhandled_warn, "Fix A regression: unhandled_tier dropped back to WARNING"
+    # Verify the structured fields the guard surfaces (helps debugging future regressions).
+    _, kwargs = unhandled_err[0]
+    assert kwargs.get("tier_resolved") == "future_unknown_tier"
+    assert kwargs.get("tier_raw") == "bogus_tier"
+    assert kwargs.get("spam_score_payload") == 0.5

--- a/eval/runs/findingsv2.3.md
+++ b/eval/runs/findingsv2.3.md
@@ -1,0 +1,122 @@
+# v2.3 Eval Findings — Post Spam-Classification Backfill (JIE #308)
+
+**Run name:** `qa-v2.3-post-spam-backfill`
+**Date:** 2026-04-28
+**Subset:** 10 Borderplex / agentic-era geographic questions (`gq-041..050`)
+**Branch / scorer version:** `development` (post PR #311 merge + Phase 6.2 backfill)
+**Run output:** [`qa-v2.3-post-spam-backfill.json`](qa-v2.3-post-spam-backfill.json)
+
+---
+
+## Hypothesis Being Tested
+
+After PR #311 fixed the structural workflow (`spam_tier` now persisted on every promotion path; new sweeper for unclassified rows; loud guard) and Phase 6.2 ran `scripts/backfill_spam_classification.py --apply` against the 4,710 historical rows, re-run Bryan's `gq-041..050` subset to verify whether the spam-coverage gap was the load-bearing blocker after #244+#289+#306 closed the data-and-routing layers.
+
+**Prediction:** if spam coverage was the only remaining structural blocker, `evidence_citation` rises sharply on this subset (synthesis now has rows to cite); `intent_accuracy` stays stuck at 0.000 because Pair C's classifier regression (#305) is still active and unrelated to spam.
+
+---
+
+## Result — confirmed: data layer fully unblocked, classifier regression still owns the residual
+
+The data-and-routing layer is now end-to-end operational. **`evidence_citation` jumped from 0.074 (v2.2) → 0.752 (v2.3) — a 10x improvement** on the same gq-041..050 subset. Synthesis has rows to cite, the citations land, the answers are grounded. As predicted, `intent_accuracy` stays at 0.000 because the classifier regression (JIE #305) hasn't been touched — that's Pair C's work.
+
+The remaining `answerability=0.100` is also classifier-driven: 9 of 10 questions are misclassified as `intent='other'`, which falls through to the unrouted path and never reaches the geographic per-posting query. The single question that reaches geographic routing returns plenty of data. **Once #305 is fixed, the same v2.3 scorecard should jump to ≥0.7 answerability with no further data-layer work needed.**
+
+---
+
+## Layer 1 — Database invariants (post-Phase-6.2)
+
+All six smoke tests in `eval/tests/test_smoke_borderplex_data_gap.py` pass:
+
+| Invariant | Pre-#308 | Post-#308 | Status |
+|---|---:|---:|:---:|
+| `normalized_jobs.zip_code` populated where city+state present | 97.9% | 97.9% | ✅ unchanged |
+| `job_postings.zip_code` populated | 76.7% | 76.7% | ✅ unchanged |
+| Orphan `normalized_jobs` rows | 0 | 0 | ✅ unchanged |
+| El Paso postings reachable via `postal_geo_data` join | 1,015 | 1,015 | ✅ unchanged |
+| `geo_demand_weekly` row count | 6 | 9 | ✅ +3 (post-refresh) |
+| **NEW:** `spam_tier` populated | **0% (0/4,710)** | **100% (4,710/4,710)** | ✅ **NEW** |
+| **NEW:** `spam_tier = 'clean'` row count | **27** | **4,648** | ✅ **NEW** |
+
+Post-backfill spam distribution:
+
+| Tier | Count | `is_spam` | Routes through PR #310's filter? |
+|---|---:|:---:|:---:|
+| clean | 4,648 (98.7%) | FALSE | ✅ surfaced |
+| flagged | 62 (1.3%) | NULL | ❌ HITL queue (correct per Gary's rule) |
+| uncertain | 0 | — | — |
+| (NULL — unclassified) | 0 | — | — |
+
+**Per-region clean rows reachable for Bryan's gq-041..050:**
+
+| Region | Pre-#308 | Post-#308 |
+|---|---:|---:|
+| El Paso (clean) | 22 | **1,008** (45×) |
+| Las Cruces (clean) | 0 | **1,416** (∞×) |
+
+---
+
+## Layer 2 — Answer quality on `gq-041..050`
+
+### Three-way scorecard
+
+| Metric | v2.2 (post data-gap fix) | **v2.3 (post spam-coverage)** | Δ v2.3 vs v2.2 | Smoke 4 target | Met? |
+|---|:---:|:---:|:---:|:---:|:---:|
+| `intent_accuracy` | 0.000 | **0.000** | 0 | ≥ 0.75 | ❌ (blocked by #305) |
+| `evidence_citation` | 0.074 | **0.752** | **+0.678** ⭐ | ≥ 0.55 | ✅ |
+| `confidence_self_consistency` | 0.595 | **0.910** | +0.315 | — | — |
+| `confidence_in_expected_range` | 0.223 | **0.724** | +0.501 | — | — |
+| `latency_sla` | 1.000 | 1.000 | 0 | — | ✅ |
+| `answerability` *(n=10 data-backed)* | 0.100 | **0.100** | 0 | ≥ 0.50 | ❌ (blocked by #305) |
+
+### Direct probes (bypassing the broken intent classifier)
+
+The same questions, asked outside the eval harness so the classifier's `'other'` mismatch doesn't short-circuit routing:
+
+| Question | v2.2 result | **v2.3 result** |
+|---|---|---|
+| "Show all El Paso, TX postings for AI agent developer, prompt engineer, or LLM engineer roles posted in the last 6 months" (gq-041) | 17 evidence items, "no postings explicitly titled" caveat | **101 evidence items**, cites OpenClaw AI Agent Developer, GenAI Full-Stack Lead, Scale-Secure AI Platform Engineer, Enterprise AI Chatbot, etc. |
+| "List all Las Cruces, NM AI/ML researcher and applied-scientist postings, highlighting any university-affiliated employers such as NMSU, UTEP, or EPCC" (gq-050) | "No data in scope" (refusal) | **101 evidence items**, cites Principal Applied Scientist, Responsible AI Research Scientist, Senior Applied ML Engineer, etc. **Includes the gold-required NMSU/UTEP/EPCC caveat verbatim.** |
+
+The pipeline now consistently produces real, cited, ground-truth-grounded answers when reach the geographic-list-style routing. The `intent_accuracy=0.000` in the eval scorecard is not because the synthesis is broken — it's because the classifier short-circuits the question to the wrong handler before synthesis runs.
+
+---
+
+## What this confirms about the dependency chain
+
+| Issue | Status | What it gates |
+|---|---|---|
+| #244 — `_resolve_zip_code` + promotion SQL | ✅ closed (PR #304) | data layer: zip propagation |
+| #289 — silent-skip + `promoted_at` | ✅ closed (PR #301 + #303) | data layer: orphan recovery |
+| #306 — list-style routing | ✅ closed (PR #310) | routing layer: geographic per-posting |
+| **#308 — spam coverage** | ✅ **closed (PR #311 + this PR)** | **answer quality: synthesis can cite** |
+| #305 — intent classifier regression on geographic | 🔴 **OPEN — Pair C** | answer quality: classifier picks the right handler |
+| #309 — embedding role match (replace `_tokenize_role_name`) | 🟡 OPEN, P3 — Pair A | answer quality: niche role-name resolution |
+
+The data-layer + routing-layer fixes (#244/#289/#306/#308) are now complete end-to-end. The only blocker left for full Smoke 5 success on Bryan's gq-041..050 subset is **#305** (Pair C's intent-classifier prompt regression). Once that's fixed, the v2.3 scorecard should re-run cleanly with `intent_accuracy ≥ 0.75` and `answerability ≥ 0.7` without any further pipeline-side changes.
+
+---
+
+## Cohort handoff (after PR-2 merges)
+
+Fresh fixtures committed at `scripts/pg-seed-data/fixtures/*.json`. Devs reseed locally:
+
+```bash
+git pull origin development
+python scripts/pg-seed-data/seed_pg_database.py    # idempotent
+python -m pytest eval/tests/test_smoke_borderplex_data_gap.py -v   # all 6 pass
+```
+
+For Pair C (Bryan + Emilio): re-run `gq-041..050` against the fresh fixtures + after fixing #305 — expect the v2.3 scorecard's `evidence_citation=0.752` floor to hold and `intent_accuracy` + `answerability` to climb into target territory.
+
+For Pair A (Ángel + Fabian): #309 (embedding role match) is now genuinely useful — the data layer it depends on is fully populated. The substring tokenization in PR #310's `_tokenize_role_name` works (gq-041 returned 101 cited postings), but #299's `_match_canonical_role` semantic pattern would tighten precision.
+
+For Pair D (Juan + Enrique): the `canonical_role_id` propagation gap (Juan's blocker) can now be re-investigated against a populated database — previously many rows had no spam classification and were excluded from his query path.
+
+---
+
+## Closes
+
+- JIE #308 — spam-classification coverage gap (~4,683 of 4,710 rows NULL `is_spam`)
+
+Closed at the **data layer**: 100% of `dbo.job_postings` rows now carry a `spam_tier` label; 4,648 are confirmed clean and surface through PR #310's strict `is_spam = FALSE` filter; 62 flagged stay quarantined for HITL review per Gary's standing rule.

--- a/eval/runs/qa-v2.3-post-spam-backfill.json
+++ b/eval/runs/qa-v2.3-post-spam-backfill.json
@@ -1,0 +1,133 @@
+{
+  "prompt_version": "v2.3-post-spam-backfill",
+  "dataset_run_id": null,
+  "dataset_run_url": null,
+  "answerability_summary": {
+    "mean": 0.1,
+    "n_data_backed": 10,
+    "n_intent_only_skipped": 0,
+    "pass_rate": 0.1
+  },
+  "items": [
+    {
+      "gq_id": "gq-041",
+      "trace_id": "00cc1619e6d792b9e905fdd203c3cb70",
+      "scores": {
+        "intent_accuracy": 0.0,
+        "evidence_citation": 0.883,
+        "confidence_self_consistency": 1.0,
+        "confidence_in_expected_range": 1.0,
+        "latency_sla": 1.0,
+        "answerability": 0.0
+      }
+    },
+    {
+      "gq_id": "gq-042",
+      "trace_id": "c7c73d624b9be5227cdf821cb0722f3e",
+      "scores": {
+        "intent_accuracy": 0.0,
+        "evidence_citation": 0.8965,
+        "confidence_self_consistency": 1.0,
+        "confidence_in_expected_range": 1.0,
+        "latency_sla": 1.0,
+        "answerability": 0.0
+      }
+    },
+    {
+      "gq_id": "gq-043",
+      "trace_id": "90cbc65a0ebda870ecab9eb16b469afc",
+      "scores": {
+        "intent_accuracy": 0.0,
+        "evidence_citation": 0.883,
+        "confidence_self_consistency": 1.0,
+        "confidence_in_expected_range": 0.7777777777777779,
+        "latency_sla": 1.0,
+        "answerability": 0.0
+      }
+    },
+    {
+      "gq_id": "gq-044",
+      "trace_id": "0ca4231731967814e441dbef080fca58",
+      "scores": {
+        "intent_accuracy": 0.0,
+        "evidence_citation": 0.8245000000000001,
+        "confidence_self_consistency": 1.0,
+        "confidence_in_expected_range": 0.7777777777777779,
+        "latency_sla": 1.0,
+        "answerability": 0.0
+      }
+    },
+    {
+      "gq_id": "gq-045",
+      "trace_id": "3ffb921e1e3697e8910831723e93b7e7",
+      "scores": {
+        "intent_accuracy": 0.0,
+        "evidence_citation": 0.7514838709677419,
+        "confidence_self_consistency": 1.0,
+        "confidence_in_expected_range": 0.7777777777777779,
+        "latency_sla": 1.0,
+        "answerability": 0.0
+      }
+    },
+    {
+      "gq_id": "gq-046",
+      "trace_id": "d8b3361873cd22dddc75ddbbd057dc99",
+      "scores": {
+        "intent_accuracy": 0.0,
+        "evidence_citation": 0.7978648648648649,
+        "confidence_self_consistency": 0.55,
+        "confidence_in_expected_range": 1.0,
+        "latency_sla": 1.0,
+        "answerability": 0.0
+      }
+    },
+    {
+      "gq_id": "gq-047",
+      "trace_id": "531541779c06f37610777abe24d39ef9",
+      "scores": {
+        "intent_accuracy": 0.0,
+        "evidence_citation": 0.9414999999999999,
+        "confidence_self_consistency": 1.0,
+        "confidence_in_expected_range": 1.0,
+        "latency_sla": 1.0,
+        "answerability": 0.0
+      }
+    },
+    {
+      "gq_id": "gq-048",
+      "trace_id": "0ac1d967940a40b149f93e3381e180a9",
+      "scores": {
+        "intent_accuracy": 0.0,
+        "evidence_citation": 0.0,
+        "confidence_self_consistency": 0.55,
+        "confidence_in_expected_range": 0.0,
+        "latency_sla": 1.0,
+        "answerability": 0.0
+      }
+    },
+    {
+      "gq_id": "gq-049",
+      "trace_id": "94e86587670e694206cdea165fd89316",
+      "scores": {
+        "intent_accuracy": 0.0,
+        "evidence_citation": 0.6445000000000002,
+        "confidence_self_consistency": 1.0,
+        "confidence_in_expected_range": 0.45454545454545436,
+        "latency_sla": 1.0,
+        "answerability": 1.0
+      }
+    },
+    {
+      "gq_id": "gq-050",
+      "trace_id": "e6ee10cf210b3dfe7b9b221a2003c253",
+      "scores": {
+        "intent_accuracy": 0.0,
+        "evidence_citation": 0.9025,
+        "confidence_self_consistency": 1.0,
+        "confidence_in_expected_range": 0.45454545454545436,
+        "latency_sla": 1.0,
+        "answerability": 0.0
+      }
+    }
+  ]
+}

--- a/eval/tests/test_smoke_borderplex_data_gap.py
+++ b/eval/tests/test_smoke_borderplex_data_gap.py
@@ -36,6 +36,9 @@ from common.data_store.database import check_db_connection, get_engine
 _NULL_ZIP_RATIO_THRESHOLD = 0.10  # ≤10% NULL on rows that *should* be resolvable
 _ORPHAN_THRESHOLD = 5  # ≤5 orphans tolerated (sweeper grace + race conditions)
 _EL_PASO_MIN_REACHABLE = 100  # post-fix lower bound; pre-fix was 0
+# JIE #308 floors — applied after PR-2's spam backfill runs.
+_SPAM_TIER_POPULATED_RATIO_FLOOR = 0.80  # ≥80% of rows have a non-NULL spam_tier
+_CLEAN_ROW_MIN_COUNT = 1000  # ≥1,000 confirmed-clean rows post-backfill (was 27 pre-fix)
 
 
 @pytest.fixture(scope="module")
@@ -135,4 +138,48 @@ def test_geo_demand_weekly_has_subregion_rows(db_session) -> None:
     assert geo_rows >= 6, (
         f"geo_demand_weekly only has {geo_rows} rows (expected ≥6 post-Phase-3 refresh). "
         f"Run scripts/refresh_aggregates.py to recompute."
+    )
+
+
+def test_spam_tier_populated_above_floor(db_session) -> None:
+    """JIE #308 invariant: ≥80% of ``dbo.job_postings`` rows have a non-NULL ``spam_tier``.
+
+    Pre-#308 this was 0% (the column was a noop — none of the UPDATE constants
+    persisted it). After PR-1 ships the SQL fix and PR-2 runs the backfill,
+    nearly every row should carry a tier label. Sub-floor rows are likely
+    very recent inserts within the sweeper grace window, or ones the sweeper
+    couldn't classify due to LLM unavailability.
+
+    If this drops below 80% on a future PR, either the SQL constants
+    regressed, the orphan-promotion path started inserting again without
+    classification, or the sweeper cron is broken.
+    """
+    populated = db_session.execute(text("SELECT COUNT(*) FROM dbo.job_postings WHERE spam_tier IS NOT NULL")).scalar()
+    total = db_session.execute(text("SELECT COUNT(*) FROM dbo.job_postings")).scalar()
+    assert total > 0, "expected at least one job_postings row"
+    ratio = populated / total
+    assert ratio >= _SPAM_TIER_POPULATED_RATIO_FLOOR, (
+        f"spam_tier populated on only {ratio:.1%} ({populated}/{total}) — "
+        f"below {_SPAM_TIER_POPULATED_RATIO_FLOOR:.0%} floor. "
+        f"Run scripts/sweep_unclassified_spam.py --apply or "
+        f"scripts/backfill_spam_classification.py --apply."
+    )
+
+
+def test_clean_row_count_above_minimum(db_session) -> None:
+    """JIE #308 invariant: at least 1,000 rows have ``spam_tier = 'clean'``.
+
+    Pre-#308 only 27 rows had ``is_spam = FALSE`` (and 0 had any populated
+    spam_tier). After PR-2's backfill, the bulk of confirmed-not-spam
+    postings should be classified. This is the floor PR #310's list-style
+    geographic routing depends on — its filter is ``is_spam = FALSE``,
+    which is equivalent to ``spam_tier = 'clean'`` post-#308.
+
+    If this drops below 1,000 on a future PR, Bryan's eval will partially
+    refuse again because PR #310's filter has too few rows to surface.
+    """
+    clean = db_session.execute(text("SELECT COUNT(*) FROM dbo.job_postings WHERE spam_tier = 'clean'")).scalar()
+    assert clean >= _CLEAN_ROW_MIN_COUNT, (
+        f"only {clean} rows have spam_tier = 'clean' (expected ≥{_CLEAN_ROW_MIN_COUNT}). "
+        f"Either the spam classifier is over-flagging or the backfill didn't run."
     )

--- a/scripts/backfill_spam_classification.py
+++ b/scripts/backfill_spam_classification.py
@@ -1,0 +1,293 @@
+# ruff: noqa: T201
+"""One-shot backfill: classify ~4,683 ``dbo.job_postings`` rows missing spam_tier — JIE #308.
+
+Background
+----------
+PR-1 of #308 (this branch) closed the structural defects in the live
+spam-classification path — the three UPDATE constants now persist
+``spam_tier``, and the sweeper at ``scripts/sweep_unclassified_spam.py``
+catches any new rows that reach ``job_postings`` without a tier.
+
+This script handles the **existing residual** — ~4,683 rows that landed
+in ``dbo.job_postings`` before #308's structural fix shipped. They have
+``spam_tier IS NULL`` (and most have ``is_spam IS NULL`` + ``spam_score
+IS NULL``). The sweeper would eventually drain this backlog at 200 rows
+per run, but a one-shot is faster: ~10 minutes of LLM time vs ~24 hourly
+sweeper runs.
+
+The classifier internals are reused from
+``scripts/sweep_unclassified_spam.py`` — same SELECT, same dedup,
+same ``score_spam_preview`` call, same ``_UPDATE_SPAM_ONLY_SQL`` write.
+The differences are operational:
+
+* ``--grace-minutes 0`` by default (no grace window — the residual is
+  historical, not in flight).
+* ``--limit 5000`` by default (covers the full backlog in one pass).
+* Optional ``--max-cost-usd`` ceiling (defaults to $30) — stops gracefully
+  when reached and prints a partial-completion summary. At ~$0.001-0.005
+  per row × ~4,683 rows = $5-25 expected, so $30 is generous.
+
+Usage
+-----
+.. code-block:: bash
+
+    # Dry run (default — counts candidates, makes no LLM calls, no writes)
+    python scripts/backfill_spam_classification.py
+
+    # Apply: classify the full backlog up to the cost cap
+    python scripts/backfill_spam_classification.py --apply
+
+    # Apply with a tighter cost cap and smaller batch
+    python scripts/backfill_spam_classification.py --apply --max-cost-usd 5 --limit 1000
+
+Idempotent — only touches rows where ``spam_tier IS NULL``. Reads
+``PYTHON_DATABASE_URL`` from ``.env``.
+
+**Important:** export fixtures before running with ``--apply``. Per the
+JIE database protection rules (``~/.claude/CLAUDE.md``), ``job_postings``
+mutations require a fixture snapshot first.
+
+.. code-block:: bash
+
+    python scripts/pg-seed-data/export_fixtures.py --scope all
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.data_store.database import get_engine, session_scope  # noqa: E402
+from common.env import load_repo_root_dotenv  # noqa: E402
+from enrichment.classifiers.spam_preview import (  # noqa: E402
+    apply_spam_tiers,
+    score_spam_preview,
+)
+from enrichment.job_postings_promotion import _UPDATE_SPAM_ONLY_SQL  # noqa: E402
+from scripts.sweep_unclassified_spam import (  # noqa: E402
+    _FETCH_CANDIDATES_SQL,
+    _extraction_dict,
+)
+
+log = structlog.get_logger()
+
+
+# Default cost ceiling for ``--apply`` mode. The script aborts gracefully
+# when accumulated LLM cost (read from `result.llm_cost_usd` if present, or
+# estimated as a flat per-row figure if not) crosses this. Override via CLI.
+DEFAULT_MAX_COST_USD = 30.0
+# Conservative per-row cost estimate when the classifier doesn't expose its
+# actual spend in the SpamPreviewResult. Used as a fallback only.
+_FALLBACK_ROW_COST_USD = 0.005
+
+
+def _row_cost(result: Any) -> float:
+    """Best-effort per-row cost extraction from the classifier result."""
+    cost = getattr(result, "llm_cost_usd", None)
+    if isinstance(cost, (int, float)) and cost >= 0:
+        return float(cost)
+    cost = getattr(result, "cost_usd", None)
+    if isinstance(cost, (int, float)) and cost >= 0:
+        return float(cost)
+    return _FALLBACK_ROW_COST_USD
+
+
+def backfill(
+    *,
+    limit: int = 5000,
+    grace_minutes: int = 0,
+    apply: bool = False,
+    max_cost_usd: float = DEFAULT_MAX_COST_USD,
+) -> dict[str, Any]:
+    """Classify all rows where ``spam_tier IS NULL`` (subject to ``limit`` and cost cap).
+
+    Returns counts: ``{"candidates": N, "classified_clean": N,
+    "classified_flagged": N, "classified_uncertain": N, "failed": N,
+    "cost_usd": $..., "stopped_on_cost_cap": bool}``.
+
+    When ``apply=False`` (default), counts only — no LLM calls, no writes.
+    """
+    engine = get_engine()
+    counts: dict[str, Any] = {
+        "candidates": 0,
+        "classified_clean": 0,
+        "classified_flagged": 0,
+        "classified_uncertain": 0,
+        "failed": 0,
+        "cost_usd": 0.0,
+        "stopped_on_cost_cap": False,
+    }
+
+    with engine.connect() as conn:
+        rows = (
+            conn.execute(
+                _FETCH_CANDIDATES_SQL,
+                {"lim": limit, "grace_minutes": grace_minutes},
+            )
+            .mappings()
+            .all()
+        )
+
+    counts["candidates"] = len(rows)
+    if not rows:
+        log.info("spam_backfill_no_candidates", limit=limit, grace_minutes=grace_minutes)
+        return counts
+
+    log.info(
+        "spam_backfill_candidates_found",
+        n=len(rows),
+        apply=apply,
+        max_cost_usd=max_cost_usd,
+    )
+
+    if not apply:
+        for row in rows[:10]:
+            print(f"  [dry-run] job_posting_id={row['job_posting_id']} title={(row.get('job_title') or '')[:60]!r}")
+        if len(rows) > 10:
+            print(f"  [dry-run] ... and {len(rows) - 10} more")
+        return counts
+
+    accumulated_cost = 0.0
+    for row in rows:
+        if accumulated_cost >= max_cost_usd:
+            counts["stopped_on_cost_cap"] = True
+            log.warning(
+                "spam_backfill_cost_cap_reached",
+                cost_usd=accumulated_cost,
+                max_cost_usd=max_cost_usd,
+                processed=(counts["classified_clean"] + counts["classified_flagged"] + counts["classified_uncertain"]),
+                remaining=len(rows)
+                - (
+                    counts["classified_clean"]
+                    + counts["classified_flagged"]
+                    + counts["classified_uncertain"]
+                    + counts["failed"]
+                ),
+            )
+            break
+
+        jp_id = row["job_posting_id"]
+        try:
+            extraction, extraction_failed, extraction_empty = _extraction_dict(dict(row))
+            result = score_spam_preview(
+                job_title=row.get("job_title") or "",
+                job_description=row.get("job_description") or "",
+                extraction=extraction,
+                extraction_failed=extraction_failed,
+                extraction_empty=extraction_empty,
+            )
+            accumulated_cost += _row_cost(result)
+
+            if result.spam_score is None:
+                tier = "uncertain"
+                is_spam: bool | None = None
+                spam_score: float | None = None
+            else:
+                is_spam, tier = apply_spam_tiers(float(result.spam_score))
+                spam_score = float(result.spam_score)
+
+            with session_scope() as session:
+                session.execute(
+                    _UPDATE_SPAM_ONLY_SQL,
+                    {
+                        "job_posting_id": jp_id,
+                        "is_spam": is_spam,
+                        "spam_score": spam_score,
+                        "spam_tier": tier,
+                    },
+                )
+
+            if tier == "clean":
+                counts["classified_clean"] += 1
+            elif tier == "flagged":
+                counts["classified_flagged"] += 1
+            else:
+                counts["classified_uncertain"] += 1
+            log.info(
+                "spam_backfill_classified",
+                job_posting_id=jp_id,
+                tier=tier,
+                spam_score=spam_score,
+                cost_running=round(accumulated_cost, 4),
+            )
+        except Exception as exc:
+            counts["failed"] += 1
+            log.warning(
+                "spam_backfill_failed",
+                job_posting_id=jp_id,
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+
+    counts["cost_usd"] = round(accumulated_cost, 4)
+    log.info("spam_backfill_complete", **counts)
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "One-shot backfill: classify job_postings rows missing spam_tier (JIE #308). "
+            "Default is dry-run; pass --apply to run the classifier and write. "
+            "Export fixtures BEFORE --apply per JIE database protection rules."
+        )
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually run the classifier and write results.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=5000,
+        help="Maximum rows to attempt per run. Default 5000 covers full backlog.",
+    )
+    parser.add_argument(
+        "--grace-minutes",
+        type=int,
+        default=0,
+        help="Skip rows newer than this many minutes. Default 0 — backfill is historical.",
+    )
+    parser.add_argument(
+        "--max-cost-usd",
+        type=float,
+        default=DEFAULT_MAX_COST_USD,
+        help=f"Soft ceiling on accumulated LLM cost (default ${DEFAULT_MAX_COST_USD:g}).",
+    )
+    args = parser.parse_args()
+
+    load_repo_root_dotenv()
+    counts = backfill(
+        limit=args.limit,
+        grace_minutes=args.grace_minutes,
+        apply=args.apply,
+        max_cost_usd=args.max_cost_usd,
+    )
+
+    print()
+    print("=" * 60)
+    print(f"Spam backfill summary ({'APPLY' if args.apply else 'DRY-RUN'}):")
+    print(f"  candidates found       : {counts['candidates']}")
+    if args.apply:
+        print(f"  classified clean       : {counts['classified_clean']}")
+        print(f"  classified flagged     : {counts['classified_flagged']}")
+        print(f"  classified uncertain   : {counts['classified_uncertain']}")
+        print(f"  failed                 : {counts['failed']}")
+        print(f"  accumulated cost (USD) : ${counts['cost_usd']:.4f}")
+        if counts["stopped_on_cost_cap"]:
+            print(f"  ⚠ STOPPED at --max-cost-usd ${args.max_cost_usd:g} — re-run to continue")
+    print("=" * 60)
+    if args.apply and counts["failed"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pg-seed-data/fixtures/geo_demand_weekly.json
+++ b/scripts/pg-seed-data/fixtures/geo_demand_weekly.json
@@ -34,5 +34,23 @@
     "week_start": "2026-04-20",
     "borderplex_subregion": "regional",
     "posting_count": 11
+  },
+  {
+    "id": 7,
+    "week_start": "2026-04-20",
+    "borderplex_subregion": "el_paso",
+    "posting_count": 47
+  },
+  {
+    "id": 8,
+    "week_start": "2026-04-20",
+    "borderplex_subregion": "las_cruces",
+    "posting_count": 14
+  },
+  {
+    "id": 9,
+    "week_start": "2026-04-20",
+    "borderplex_subregion": "regional",
+    "posting_count": 11
   }
 ]

--- a/scripts/pg-seed-data/fixtures/job_postings.json
+++ b/scripts/pg-seed-data/fixtures/job_postings.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a73155f7a1ffbae74c4bfe6d63602694dff2e88dbf56eaaeddab23cdcb5e223
-size 59861815
+oid sha256:729832b500be9fad5601ca29476dd2388ffd1e445b8775ce17ecd1b3833fb202
+size 59880155

--- a/scripts/pg-seed-data/fixtures/laborpulse_analytics_conversation.json
+++ b/scripts/pg-seed-data/fixtures/laborpulse_analytics_conversation.json
@@ -1,1 +1,149 @@
-[]
+[
+  {
+    "id": "2129ad52-fad5-4726-8395-ce3b75d6fe14",
+    "tenant_id": "borderplex",
+    "user_email": "gary@local",
+    "created_at": "2026-04-28T23:52:41.615838+00:00",
+    "updated_at": "2026-04-28T23:52:41.615838+00:00"
+  },
+  {
+    "id": "39258365-b1a8-4bba-bb20-9e60bce06ece",
+    "tenant_id": "borderplex",
+    "user_email": "gary@local",
+    "created_at": "2026-04-28T23:52:54.372721+00:00",
+    "updated_at": "2026-04-28T23:52:54.372721+00:00"
+  },
+  {
+    "id": "5d0b21c6-91be-4289-951e-d1cbcd5fb109",
+    "tenant_id": "borderplex",
+    "user_email": "smoke@thewaifinder.com",
+    "created_at": "2026-04-28T23:53:07.291428+00:00",
+    "updated_at": "2026-04-28T23:53:07.291428+00:00"
+  },
+  {
+    "id": "324c11a2-1836-4c8d-a823-ea27cd9243d8",
+    "tenant_id": "borderplex",
+    "user_email": "smoke@thewaifinder.com",
+    "created_at": "2026-04-28T23:53:09.474646+00:00",
+    "updated_at": "2026-04-28T23:53:09.474646+00:00"
+  },
+  {
+    "id": "7fba7bc3-93e9-4966-9b68-e0caa099b929",
+    "tenant_id": "borderplex",
+    "user_email": "smoke@thewaifinder.com",
+    "created_at": "2026-04-28T23:53:11.892899+00:00",
+    "updated_at": "2026-04-28T23:53:11.892899+00:00"
+  },
+  {
+    "id": "333eccbd-bc0a-4c7e-bac4-a9cdcd42fbfd",
+    "tenant_id": "borderplex",
+    "user_email": "smoke@thewaifinder.com",
+    "created_at": "2026-04-28T23:53:14.864220+00:00",
+    "updated_at": "2026-04-28T23:53:14.864220+00:00"
+  },
+  {
+    "id": "a77cc38f-7fd3-439b-b30c-a7eda037f493",
+    "tenant_id": "borderplex",
+    "user_email": "smoke@thewaifinder.com",
+    "created_at": "2026-04-28T23:53:17.730178+00:00",
+    "updated_at": "2026-04-28T23:53:17.730178+00:00"
+  },
+  {
+    "id": "9a7333cd-9c39-40b1-af17-6f0cf86229c0",
+    "tenant_id": "borderplex",
+    "user_email": "smoke@thewaifinder.com",
+    "created_at": "2026-04-28T23:53:20.188704+00:00",
+    "updated_at": "2026-04-28T23:53:20.188704+00:00"
+  },
+  {
+    "id": "25b248fd-3d55-4233-9b0a-fee1efb1db69",
+    "tenant_id": "borderplex",
+    "user_email": "smoke@thewaifinder.com",
+    "created_at": "2026-04-28T23:53:23.057399+00:00",
+    "updated_at": "2026-04-28T23:53:23.057399+00:00"
+  },
+  {
+    "id": "5230b62c-e8ad-4e6e-8866-7248f374ca38",
+    "tenant_id": "borderplex",
+    "user_email": "smoke@thewaifinder.com",
+    "created_at": "2026-04-28T23:53:29.617385+00:00",
+    "updated_at": "2026-04-28T23:53:29.617385+00:00"
+  },
+  {
+    "id": "d30921e7-c1f7-4a72-b2d6-543830a90513",
+    "tenant_id": "borderplex",
+    "user_email": "smoke@thewaifinder.com",
+    "created_at": "2026-04-28T23:53:32.172056+00:00",
+    "updated_at": "2026-04-28T23:53:32.172056+00:00"
+  },
+  {
+    "id": "51748148-387e-4ad1-95f5-4cb0ac96f98a",
+    "tenant_id": "borderplex",
+    "user_email": "smoke@thewaifinder.com",
+    "created_at": "2026-04-28T23:53:35.658695+00:00",
+    "updated_at": "2026-04-28T23:53:35.658695+00:00"
+  },
+  {
+    "id": "23da505a-a1fb-448b-89d6-63e027b73d14",
+    "tenant_id": "borderplex",
+    "user_email": "gary@local",
+    "created_at": "2026-04-29T00:14:00.532593+00:00",
+    "updated_at": "2026-04-29T00:14:00.532593+00:00"
+  },
+  {
+    "id": "a65f55ae-3ceb-436a-8c68-6daf62bf7708",
+    "tenant_id": "borderplex",
+    "user_email": "gary@local",
+    "created_at": "2026-04-29T00:19:32.685569+00:00",
+    "updated_at": "2026-04-29T00:19:32.685569+00:00"
+  },
+  {
+    "id": "4162bf6f-67ab-4bdc-b280-37b89a5576a4",
+    "tenant_id": "borderplex",
+    "user_email": "gary@local",
+    "created_at": "2026-04-29T00:19:53.399589+00:00",
+    "updated_at": "2026-04-29T00:19:53.399589+00:00"
+  },
+  {
+    "id": "84754213-cb0b-4627-ad04-698bc51d9926",
+    "tenant_id": "borderplex",
+    "user_email": "gary@local",
+    "created_at": "2026-04-29T00:19:55.426286+00:00",
+    "updated_at": "2026-04-29T00:19:55.426286+00:00"
+  },
+  {
+    "id": "d21a2d33-02c6-4399-8618-3374d70cdf0f",
+    "tenant_id": "borderplex",
+    "user_email": "gary@local",
+    "created_at": "2026-04-29T00:21:44.052233+00:00",
+    "updated_at": "2026-04-29T00:21:44.052233+00:00"
+  },
+  {
+    "id": "f422b91c-b4c0-4e99-81dd-8d5f56a7c9ce",
+    "tenant_id": "borderplex",
+    "user_email": "gary@local",
+    "created_at": "2026-04-29T00:21:46.252262+00:00",
+    "updated_at": "2026-04-29T00:21:46.252262+00:00"
+  },
+  {
+    "id": "0a6501a9-f466-4384-a685-33cc12e5b72a",
+    "tenant_id": "borderplex",
+    "user_email": "gary@local",
+    "created_at": "2026-04-29T00:23:16.805904+00:00",
+    "updated_at": "2026-04-29T00:23:16.805904+00:00"
+  },
+  {
+    "id": "394bddc6-a750-4cb1-a559-0ddbc3e1bec1",
+    "tenant_id": "borderplex",
+    "user_email": "gary@local",
+    "created_at": "2026-04-29T00:23:25.109268+00:00",
+    "updated_at": "2026-04-29T00:23:25.109268+00:00"
+  },
+  {
+    "id": "ca6b3eee-da0b-47c2-b8a9-01d9f8d007de",
+    "tenant_id": "borderplex",
+    "user_email": "gary@local",
+    "created_at": "2026-04-29T00:25:42.053691+00:00",
+    "updated_at": "2026-04-29T00:25:42.053691+00:00"
+  }
+]

--- a/scripts/pg-seed-data/fixtures/laborpulse_analytics_turn.json
+++ b/scripts/pg-seed-data/fixtures/laborpulse_analytics_turn.json
@@ -1,1 +1,191 @@
-[]
+[
+  {
+    "id": 1,
+    "conversation_id": "2129ad52-fad5-4726-8395-ce3b75d6fe14",
+    "turn_index": 0,
+    "question": "What sub-regions of Borderplex have the highest demand for AI agent developers?",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-28T23:52:41.619978+00:00"
+  },
+  {
+    "id": 2,
+    "conversation_id": "39258365-b1a8-4bba-bb20-9e60bce06ece",
+    "turn_index": 0,
+    "question": "How many job postings are in El Paso?",
+    "answer": "Data period: 2026-04-20.\n\nFor the week starting April 20, 2026, El Paso had between 45 and 47 job postings, based on available data.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-28T23:52:54.375727+00:00"
+  },
+  {
+    "id": 3,
+    "conversation_id": "5d0b21c6-91be-4289-951e-d1cbcd5fb109",
+    "turn_index": 0,
+    "question": "Show all El Paso, TX postings for AI agent developer, prompt engineer, or LLM engineer roles in the agentic_era period.",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-28T23:53:07.292934+00:00"
+  },
+  {
+    "id": 4,
+    "conversation_id": "324c11a2-1836-4c8d-a823-ea27cd9243d8",
+    "turn_index": 0,
+    "question": "List every Las Cruces, NM data engineer posting from the last 90 days with required skills including Python, SQL, and a cloud platform.",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-28T23:53:09.476585+00:00"
+  },
+  {
+    "id": 5,
+    "conversation_id": "7fba7bc3-93e9-4966-9b68-e0caa099b929",
+    "turn_index": 0,
+    "question": "Pull all El Paso, TX healthcare-IT postings — including EHR analyst, health informatics specialist, and clinical data analyst roles — that require AI or ML skills.",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-28T23:53:11.896143+00:00"
+  },
+  {
+    "id": 6,
+    "conversation_id": "333eccbd-bc0a-4c7e-bac4-a9cdcd42fbfd",
+    "turn_index": 0,
+    "question": "Show all Las Cruces, NM DevOps and site-reliability engineer postings requiring Kubernetes or Terraform experience.",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-28T23:53:14.866573+00:00"
+  },
+  {
+    "id": 7,
+    "conversation_id": "a77cc38f-7fd3-439b-b30c-a7eda037f493",
+    "turn_index": 0,
+    "question": "Find all El Paso, TX frontend developer postings mentioning React or Next.js, posted in the post_gpt4 or agentic_era periods.",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-28T23:53:17.731171+00:00"
+  },
+  {
+    "id": 8,
+    "conversation_id": "9a7333cd-9c39-40b1-af17-6f0cf86229c0",
+    "turn_index": 0,
+    "question": "List every Las Cruces, NM cybersecurity posting from the last 12 months requiring a security clearance or a named industry certification such as CISSP, CISA, or CompTIA Security+.",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-28T23:53:20.190703+00:00"
+  },
+  {
+    "id": 9,
+    "conversation_id": "25b248fd-3d55-4233-9b0a-fee1efb1db69",
+    "turn_index": 0,
+    "question": "Retrieve all El Paso, TX entry-level IT postings that have a published salary range, grouped by job family.",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-28T23:53:23.059844+00:00"
+  },
+  {
+    "id": 10,
+    "conversation_id": "5230b62c-e8ad-4e6e-8866-7248f374ca38",
+    "turn_index": 0,
+    "question": "Find all Borderplex (El Paso and Las Cruces combined) fintech or regtech developer postings from the agentic_era period.",
+    "answer": "Data period: 2026-04-20.\n\nFor the week starting April 20, 2026, there were a total of 47 to 45 developer job postings in the El Paso subregion and 14 postings in the Las Cruces subregion of the Borderplex area. These figures reflect the combined demand for fintech or regtech developer roles during this period (c1, c2, c3, c4).",
+    "intent_label": "geographic",
+    "created_at": "2026-04-28T23:53:29.619383+00:00"
+  },
+  {
+    "id": 11,
+    "conversation_id": "d30921e7-c1f7-4a72-b2d6-543830a90513",
+    "turn_index": 0,
+    "question": "Show all El Paso, TX legal-tech and e-discovery analyst postings from the past 6 months, with any that mention AI workflows flagged.",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-28T23:53:32.173054+00:00"
+  },
+  {
+    "id": 12,
+    "conversation_id": "51748148-387e-4ad1-95f5-4cb0ac96f98a",
+    "turn_index": 0,
+    "question": "List all Las Cruces, NM AI/ML researcher and applied-scientist postings, highlighting any university-affiliated employers such as NMSU, UTEP, or EPCC.",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-28T23:53:35.662023+00:00"
+  },
+  {
+    "id": 13,
+    "conversation_id": "23da505a-a1fb-448b-89d6-63e027b73d14",
+    "turn_index": 0,
+    "question": "Show all El Paso, TX frontend developer postings mentioning React or Next.js, posted in the last 90 days.",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-29T00:14:00.536713+00:00"
+  },
+  {
+    "id": 14,
+    "conversation_id": "a65f55ae-3ceb-436a-8c68-6daf62bf7708",
+    "turn_index": 0,
+    "question": "Show all El Paso, TX postings for software engineering roles posted in the last 90 days.",
+    "answer": "Based on available data, there are multiple recent postings for software engineering roles in El Paso, TX, including positions such as Junior/Entry Level Software Engineer, Software Engineer (Product Security), Lead Software Engineer (AI Solutions), Software Engineering Associates, and Principal Software Engineer (React + Node), among others. Some postings include salary ranges, such as 75,000–100,000, 87,000–127,000, and 89,000–143,750. However, the exact period coverage for these postings is not specified, so caution is advised when interpreting recency. [c1–c12]",
+    "intent_label": "geographic",
+    "created_at": "2026-04-29T00:19:32.690978+00:00"
+  },
+  {
+    "id": 15,
+    "conversation_id": "4162bf6f-67ab-4bdc-b280-37b89a5576a4",
+    "turn_index": 0,
+    "question": "Show all El Paso, TX postings for AI agent developer, prompt engineer, or LLM engineer roles posted in the last 6 months.",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-29T00:19:53.403487+00:00"
+  },
+  {
+    "id": 16,
+    "conversation_id": "84754213-cb0b-4627-ad04-698bc51d9926",
+    "turn_index": 0,
+    "question": "List all Las Cruces, NM AI/ML researcher and applied-scientist postings, highlighting any university-affiliated employers such as NMSU, UTEP, or EPCC.",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-29T00:19:55.430787+00:00"
+  },
+  {
+    "id": 17,
+    "conversation_id": "d21a2d33-02c6-4399-8618-3374d70cdf0f",
+    "turn_index": 0,
+    "question": "List all Las Cruces, NM AI/ML researcher and applied-scientist postings, highlighting any university-affiliated employers such as NMSU, UTEP, or EPCC.",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-29T00:21:44.058275+00:00"
+  },
+  {
+    "id": 18,
+    "conversation_id": "f422b91c-b4c0-4e99-81dd-8d5f56a7c9ce",
+    "turn_index": 0,
+    "question": "Show all El Paso, TX postings for AI agent developer, prompt engineer, or LLM engineer roles posted in the last 6 months.",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-29T00:21:46.254769+00:00"
+  },
+  {
+    "id": 19,
+    "conversation_id": "0a6501a9-f466-4384-a685-33cc12e5b72a",
+    "turn_index": 0,
+    "question": "List all Las Cruces, NM AI/ML researcher and applied-scientist postings, highlighting any university-affiliated employers such as NMSU, UTEP, or EPCC.",
+    "answer": "No data in scope for the selected filters.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-29T00:23:16.811417+00:00"
+  },
+  {
+    "id": 20,
+    "conversation_id": "394bddc6-a750-4cb1-a559-0ddbc3e1bec1",
+    "turn_index": 0,
+    "question": "Show all El Paso, TX postings for AI agent developer, prompt engineer, or LLM engineer roles posted in the last 6 months.",
+    "answer": "Based on available data, there are recent El Paso, TX job postings related to artificial intelligence and software engineering, including roles such as Lead Software Engineer, AI Solutions and Software Engineer, AI (Ruby) (c4, c9). However, there are no postings explicitly titled \"AI agent developer,\" \"prompt engineer,\" or \"LLM engineer.\" The closest relevant roles are in AI solutions and software engineering with AI focus. Please note that information on specific AI agent or LLM engineering roles is limited in the current dataset.",
+    "intent_label": "geographic",
+    "created_at": "2026-04-29T00:23:25.111014+00:00"
+  },
+  {
+    "id": 21,
+    "conversation_id": "ca6b3eee-da0b-47c2-b8a9-01d9f8d007de",
+    "turn_index": 0,
+    "question": "List all Las Cruces, NM AI/ML researcher and applied-scientist postings, highlighting any university-affiliated employers such as NMSU, UTEP, or EPCC.",
+    "answer": "Based on available data, there are numerous AI/ML researcher and applied scientist job postings in Las Cruces, NM, including roles such as Senior AI Scientist, Principal Applied Scientist, Responsible AI Research Scientist, AI Research Engineer, Principal Machine Learning Scientist, and Applied ML Engineer (see citations c53, c71, c95, c99, c63, c72). However, the data does not specify any university-affiliated employers such as NMSU, UTEP, or EPCC for these postings. Please note that employer names are not provided in the current dataset, so it is not possible to confirm university involvement at this time. All conclusions are limited to the 100 most recent postings returned (c101).",
+    "intent_label": "geographic",
+    "created_at": "2026-04-29T00:25:42.057380+00:00"
+  }
+]

--- a/scripts/pg-seed-data/fixtures/llm_audit_log.json
+++ b/scripts/pg-seed-data/fixtures/llm_audit_log.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d60ca8b127bb46447e8c53ceba4d4c6c158548b57a0da499d199bce35bb2b62e
-size 21236946
+oid sha256:014ea8e4b759ff0d1d623c7a8835ca1ae973cfb6ac031feb965e8701238493db
+size 23587351

--- a/scripts/pg-seed-data/fixtures/metadata.json
+++ b/scripts/pg-seed-data/fixtures/metadata.json
@@ -1,5 +1,5 @@
 {
-  "exportedAt": "2026-04-28T23:43:39.350411Z",
+  "exportedAt": "2026-04-29T05:54:25.844956Z",
   "scope": "agent",
   "source": "postgresql",
   "schema": "dbo",
@@ -13,7 +13,7 @@
     "companies": 2006,
     "naics": 2125,
     "job_postings": 4710,
-    "llm_audit_log": 41121
+    "llm_audit_log": 45863
   },
   "skipped": []
 }

--- a/scripts/pg-seed-data/fixtures/orchestration_audit_log.json
+++ b/scripts/pg-seed-data/fixtures/orchestration_audit_log.json
@@ -74,5 +74,425 @@
       "needs_clarification": false,
       "classification_confidence": 0.7
     }
+  },
+  {
+    "id": 5,
+    "created_at": "2026-04-28T23:52:41.611039+00:00",
+    "correlation_id": "probe-1777420357",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "6597092d81142b8df5b3a7d524dda7ba5534fae08e911e06a16cd74ced8777eb",
+    "sql_hash": "7a14b5aecb119a36b8345783132dd5aae5ff7b06dddd1ba817cc3e255a96636d",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.85
+    }
+  },
+  {
+    "id": 6,
+    "created_at": "2026-04-28T23:52:54.368216+00:00",
+    "correlation_id": "probe-2-1777420368",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "cddd57cc15c68b920d08cca45fb2b5704ee4fd7f453c3efa18c6620b9e2ede80",
+    "sql_hash": "bd9ff6726152f01fc78f2416eec435ef98bb894dacbc5e62f358b1a6f7e4b83f",
+    "confidence": 0.97,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": false,
+      "citations": 2,
+      "row_count": 2,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 7,
+    "created_at": "2026-04-28T23:53:07.289428+00:00",
+    "correlation_id": "gq-041-v2.2-post-data-gap-fix",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "a2e3dc2ef0c28787623cfc5a02370d0d533a67dea54bca82089d46f633e60d9d",
+    "sql_hash": "873464ae466fb2c564600008451dd3cbf3eeccf89aca5c5a2f949cf8a3343fe8",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 8,
+    "created_at": "2026-04-28T23:53:09.471636+00:00",
+    "correlation_id": "gq-042-v2.2-post-data-gap-fix",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "3582ae6d772dddbbc453f1d0ed2aabde5bf51e5e82c6dc4ac6b464a10fdb0d2f",
+    "sql_hash": "ab517304e086256de9cb1147793daa7d443022431ccdb6e175e3c9939c493ed7",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 9,
+    "created_at": "2026-04-28T23:53:11.891393+00:00",
+    "correlation_id": "gq-043-v2.2-post-data-gap-fix",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "f06207d4ab2a87680bbccf1f1d4e8874f1ce7c84df22363ccc6db8f4598dd814",
+    "sql_hash": "873464ae466fb2c564600008451dd3cbf3eeccf89aca5c5a2f949cf8a3343fe8",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 10,
+    "created_at": "2026-04-28T23:53:14.861805+00:00",
+    "correlation_id": "gq-044-v2.2-post-data-gap-fix",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "00043d813c18b70312e50debcfe1f2800d3998806097adff463e305325aa1e28",
+    "sql_hash": "ab517304e086256de9cb1147793daa7d443022431ccdb6e175e3c9939c493ed7",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 11,
+    "created_at": "2026-04-28T23:53:17.728180+00:00",
+    "correlation_id": "gq-045-v2.2-post-data-gap-fix",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "2840936fedcddb0b98363e5863a1b36186e752cdc13a3f799f6ce63c18904ee5",
+    "sql_hash": "873464ae466fb2c564600008451dd3cbf3eeccf89aca5c5a2f949cf8a3343fe8",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 12,
+    "created_at": "2026-04-28T23:53:20.185703+00:00",
+    "correlation_id": "gq-046-v2.2-post-data-gap-fix",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "4459b44342a90ddea49d27797378e70f2ee2504104bf4159faad6a81b73c633b",
+    "sql_hash": "ab517304e086256de9cb1147793daa7d443022431ccdb6e175e3c9939c493ed7",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 13,
+    "created_at": "2026-04-28T23:53:23.054390+00:00",
+    "correlation_id": "gq-047-v2.2-post-data-gap-fix",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "988e687564becda97b42a4e8739f733df777a516e0e74b32e03457a95163ac71",
+    "sql_hash": "873464ae466fb2c564600008451dd3cbf3eeccf89aca5c5a2f949cf8a3343fe8",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 14,
+    "created_at": "2026-04-28T23:53:29.615380+00:00",
+    "correlation_id": "gq-048-v2.2-post-data-gap-fix",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "e87beab33d7f6f355dc1e2b5cab41dba3c496d2e6ef7b37411d06a69c2dc329e",
+    "sql_hash": "ea492fb01e62bc3ed1c9afcbbcd0b84699dcb2d90aa8cb697aa04f2db13326fc",
+    "confidence": 0.94,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": false,
+      "citations": 4,
+      "row_count": 4,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.9
+    }
+  },
+  {
+    "id": 15,
+    "created_at": "2026-04-28T23:53:32.169055+00:00",
+    "correlation_id": "gq-049-v2.2-post-data-gap-fix",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "dc2877deba130c51e84fff404585777ed380aa16b7373ab89de6be771237ff3b",
+    "sql_hash": "873464ae466fb2c564600008451dd3cbf3eeccf89aca5c5a2f949cf8a3343fe8",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 16,
+    "created_at": "2026-04-28T23:53:35.656689+00:00",
+    "correlation_id": "gq-050-v2.2-post-data-gap-fix",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "3f789860e2ba5715d0b60712655892815c840dbbcf64c82403be479439c56085",
+    "sql_hash": "ab517304e086256de9cb1147793daa7d443022431ccdb6e175e3c9939c493ed7",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 17,
+    "created_at": "2026-04-29T00:14:00.528460+00:00",
+    "correlation_id": "probe-list-1",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "dc6e6c3858e6a788c40a239b29c9fd612c7a075bbcf4d22fb65011b20f288dee",
+    "sql_hash": "873464ae466fb2c564600008451dd3cbf3eeccf89aca5c5a2f949cf8a3343fe8",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 18,
+    "created_at": "2026-04-29T00:19:32.684734+00:00",
+    "correlation_id": "probe-list-fix-1",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "5e7041892e8b8a7fa6dfffc16c084f4f77cdb7008f9e5cf812e9f2d5b08673db",
+    "sql_hash": "0864f3e588d9dd072c4619d178b2fe13b8286501f9db89a60410b0748dca812d",
+    "confidence": 0.867,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": false,
+      "citations": 12,
+      "row_count": 12,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 19,
+    "created_at": "2026-04-29T00:19:53.399589+00:00",
+    "correlation_id": "probe-gq041",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "10ccad1b34dce7f88587ffb7288535060a5bfef2738ba57dd58d3d7cd6b589ed",
+    "sql_hash": "e3588f699e8f27f6e6c17805e5a431ae498f376707ca24ddc4cc6e42dc7d70b7",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 20,
+    "created_at": "2026-04-29T00:19:55.426286+00:00",
+    "correlation_id": "probe-gq050",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "3f789860e2ba5715d0b60712655892815c840dbbcf64c82403be479439c56085",
+    "sql_hash": "c034a0b1584fdb3ad9354c04d5b56dc59edf992ee0e3a97cb0637649bcc955c5",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 21,
+    "created_at": "2026-04-29T00:21:44.047988+00:00",
+    "correlation_id": "probe-gq050-v2",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "3f789860e2ba5715d0b60712655892815c840dbbcf64c82403be479439c56085",
+    "sql_hash": "c034a0b1584fdb3ad9354c04d5b56dc59edf992ee0e3a97cb0637649bcc955c5",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 22,
+    "created_at": "2026-04-29T00:21:46.250259+00:00",
+    "correlation_id": "probe-gq041-v2",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "10ccad1b34dce7f88587ffb7288535060a5bfef2738ba57dd58d3d7cd6b589ed",
+    "sql_hash": "e3588f699e8f27f6e6c17805e5a431ae498f376707ca24ddc4cc6e42dc7d70b7",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 23,
+    "created_at": "2026-04-29T00:23:16.804339+00:00",
+    "correlation_id": "probe-gq050-tok",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "3f789860e2ba5715d0b60712655892815c840dbbcf64c82403be479439c56085",
+    "sql_hash": "c034a0b1584fdb3ad9354c04d5b56dc59edf992ee0e3a97cb0637649bcc955c5",
+    "confidence": 0.0,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": true,
+      "citations": 0,
+      "row_count": 0,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 24,
+    "created_at": "2026-04-29T00:23:25.107028+00:00",
+    "correlation_id": "probe-gq041-tok",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "10ccad1b34dce7f88587ffb7288535060a5bfef2738ba57dd58d3d7cd6b589ed",
+    "sql_hash": "e3588f699e8f27f6e6c17805e5a431ae498f376707ca24ddc4cc6e42dc7d70b7",
+    "confidence": 0.867,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": false,
+      "citations": 17,
+      "row_count": 17,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
+  },
+  {
+    "id": 25,
+    "created_at": "2026-04-29T00:25:42.049633+00:00",
+    "correlation_id": "probe-gq050-final",
+    "endpoint": "POST /analytics/query",
+    "question_hash": "3f789860e2ba5715d0b60712655892815c840dbbcf64c82403be479439c56085",
+    "sql_hash": "c034a0b1584fdb3ad9354c04d5b56dc59edf992ee0e3a97cb0637649bcc955c5",
+    "confidence": 0.852,
+    "success": true,
+    "error_code": null,
+    "payload": {
+      "intent": "geographic",
+      "refused": false,
+      "citations": 101,
+      "row_count": 100,
+      "tenant_id": "borderplex",
+      "needs_clarification": false,
+      "classification_confidence": 0.95
+    }
   }
 ]

--- a/scripts/pg-seed-data/fixtures/sector_summary_weekly.json
+++ b/scripts/pg-seed-data/fixtures/sector_summary_weekly.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": 3,
+    "id": 5,
     "week_start": "2026-04-20",
     "sector": "Information Technology",
     "posting_count": 43,
@@ -18,10 +18,10 @@
       "code review",
       "cybersecurity"
     ],
-    "computed_at": "2026-04-28T23:43:21.696320+00:00"
+    "computed_at": "2026-04-29T05:53:53.923312+00:00"
   },
   {
-    "id": 4,
+    "id": 6,
     "week_start": "2026-04-20",
     "sector": "Other",
     "posting_count": 57,
@@ -39,6 +39,6 @@
       "rest apis",
       "cybersecurity"
     ],
-    "computed_at": "2026-04-28T23:43:21.696320+00:00"
+    "computed_at": "2026-04-29T05:53:53.923312+00:00"
   }
 ]

--- a/scripts/pg-seed-data/fixtures/skill_co_occurrence.json
+++ b/scripts/pg-seed-data/fixtures/skill_co_occurrence.json
@@ -760,14 +760,6 @@
     "computed_at": "2026-04-17T03:27:57.792379+00:00"
   },
   {
-    "id": 962,
-    "skill_a": "English",
-    "skill_b": "Python",
-    "co_occurrence_count": 2,
-    "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
-  },
-  {
     "id": 496,
     "skill_a": "Coding",
     "skill_b": "Malware Analysis",
@@ -1608,1595 +1600,1603 @@
     "computed_at": "2026-04-17T03:27:57.792379+00:00"
   },
   {
-    "id": 801,
+    "id": 1001,
     "skill_a": "Code Review",
     "skill_b": "Software Development",
     "co_occurrence_count": 4,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 802,
+    "id": 1002,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Data Visualization",
     "co_occurrence_count": 4,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 803,
+    "id": 1003,
     "skill_a": "Code Review",
     "skill_b": "Cross-functional Collaboration",
     "co_occurrence_count": 3,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 804,
+    "id": 1004,
     "skill_a": "Code Review",
     "skill_b": "Full Stack Development",
     "co_occurrence_count": 3,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 805,
+    "id": 1005,
     "skill_a": "Code Review",
     "skill_b": "Software Engineering",
     "co_occurrence_count": 3,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 806,
+    "id": 1006,
     "skill_a": "Code Review",
     "skill_b": "Written Communication",
     "co_occurrence_count": 3,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 807,
+    "id": 1007,
     "skill_a": "Communication",
     "skill_b": "Cross-functional Collaboration",
     "co_occurrence_count": 3,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 808,
+    "id": 1008,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Full Stack Development",
     "co_occurrence_count": 3,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 809,
+    "id": 1009,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Machine Learning",
     "co_occurrence_count": 3,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 810,
+    "id": 1010,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Software Development",
     "co_occurrence_count": 3,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 811,
+    "id": 1011,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Software Engineering",
     "co_occurrence_count": 3,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 812,
+    "id": 1012,
     "skill_a": "Data Analysis",
     "skill_b": "Data Visualization",
     "co_occurrence_count": 3,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 813,
+    "id": 1013,
     "skill_a": "Data Analysis",
     "skill_b": "Statistical Analysis",
     "co_occurrence_count": 3,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 814,
+    "id": 1014,
     "skill_a": "Data Visualization",
     "skill_b": "Statistical Analysis",
     "co_occurrence_count": 3,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 815,
+    "id": 1015,
     "skill_a": "Full Stack Development",
     "skill_b": "Software Engineering",
     "co_occurrence_count": 3,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 816,
+    "id": 1016,
     "skill_a": "AI Model Training",
     "skill_b": "Code Review",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 817,
+    "id": 1017,
     "skill_a": "AI Model Training",
     "skill_b": "Cross-functional Collaboration",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 818,
+    "id": 1018,
     "skill_a": "AI Model Training",
     "skill_b": "Data Visualization",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 819,
+    "id": 1019,
     "skill_a": "AI Model Training",
     "skill_b": "Debugging",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 820,
+    "id": 1020,
     "skill_a": "AI Model Training",
     "skill_b": "Full Stack Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 821,
+    "id": 1021,
     "skill_a": "AI Model Training",
     "skill_b": "Software Architecture",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 822,
+    "id": 1022,
     "skill_a": "AI Model Training",
     "skill_b": "Software Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 823,
+    "id": 1023,
     "skill_a": "AI Model Training",
     "skill_b": "Software Engineering",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 824,
+    "id": 1024,
     "skill_a": "API Design",
     "skill_b": "Code Review",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 825,
+    "id": 1025,
     "skill_a": "API Design",
     "skill_b": "Full Stack Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 826,
+    "id": 1026,
     "skill_a": "API Design",
     "skill_b": "Software Engineering",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 827,
+    "id": 1027,
     "skill_a": "Agile Methodology",
     "skill_b": "Cross-functional Collaboration",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 828,
+    "id": 1028,
     "skill_a": "Artificial Intelligence",
     "skill_b": "Cross-functional Collaboration",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 829,
+    "id": 1029,
     "skill_a": "Artificial Intelligence",
     "skill_b": "Machine Learning",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 830,
+    "id": 1030,
     "skill_a": "Artificial Intelligence",
     "skill_b": "REST APIs",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 831,
+    "id": 1031,
     "skill_a": "Authentication",
     "skill_b": "Authorization",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 832,
+    "id": 1032,
     "skill_a": "Authentication",
     "skill_b": "Linux",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 833,
+    "id": 1033,
     "skill_a": "Authentication",
     "skill_b": "Shell Scripting",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 834,
+    "id": 1034,
     "skill_a": "Authorization",
     "skill_b": "Linux",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 835,
+    "id": 1035,
     "skill_a": "Authorization",
     "skill_b": "Shell Scripting",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 836,
+    "id": 1036,
     "skill_a": "Automated Testing",
     "skill_b": "Continuous Integration",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 837,
+    "id": 1037,
     "skill_a": "Automated Testing",
     "skill_b": "Test Automation Frameworks",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 838,
+    "id": 1038,
     "skill_a": "Board Support Package (BSP) Development",
     "skill_b": "Bootloader Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 839,
+    "id": 1039,
     "skill_a": "Board Support Package (BSP) Development",
     "skill_b": "C",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 840,
+    "id": 1040,
     "skill_a": "Board Support Package (BSP) Development",
     "skill_b": "C++",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 841,
+    "id": 1041,
     "skill_a": "Board Support Package (BSP) Development",
     "skill_b": "Communication Protocols",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 842,
+    "id": 1042,
     "skill_a": "Board Support Package (BSP) Development",
     "skill_b": "Device Drivers",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 843,
+    "id": 1043,
     "skill_a": "Board Support Package (BSP) Development",
     "skill_b": "Device Tree Configuration",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 844,
+    "id": 1044,
     "skill_a": "Board Support Package (BSP) Development",
     "skill_b": "Embedded Systems",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 845,
+    "id": 1045,
     "skill_a": "Board Support Package (BSP) Development",
     "skill_b": "Firmware Debugging",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 846,
+    "id": 1046,
     "skill_a": "Board Support Package (BSP) Development",
     "skill_b": "Firmware Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 847,
+    "id": 1047,
     "skill_a": "Board Support Package (BSP) Development",
     "skill_b": "Hardware Abstraction Layer",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 848,
+    "id": 1048,
     "skill_a": "Board Support Package (BSP) Development",
     "skill_b": "Hardware Specifications",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 849,
+    "id": 1049,
     "skill_a": "Board Support Package (BSP) Development",
     "skill_b": "I2C",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 850,
+    "id": 1050,
     "skill_a": "Bootloader Development",
     "skill_b": "C",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 851,
+    "id": 1051,
     "skill_a": "Bootloader Development",
     "skill_b": "C++",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 852,
+    "id": 1052,
     "skill_a": "Bootloader Development",
     "skill_b": "Communication Protocols",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 853,
+    "id": 1053,
     "skill_a": "Bootloader Development",
     "skill_b": "Device Drivers",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 854,
+    "id": 1054,
     "skill_a": "Bootloader Development",
     "skill_b": "Device Tree Configuration",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 855,
+    "id": 1055,
     "skill_a": "Bootloader Development",
     "skill_b": "Embedded Systems",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 856,
+    "id": 1056,
     "skill_a": "Bootloader Development",
     "skill_b": "Firmware Debugging",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 857,
+    "id": 1057,
     "skill_a": "Bootloader Development",
     "skill_b": "Firmware Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 858,
+    "id": 1058,
     "skill_a": "Bootloader Development",
     "skill_b": "Hardware Abstraction Layer",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 859,
+    "id": 1059,
     "skill_a": "Bootloader Development",
     "skill_b": "Hardware Specifications",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 860,
+    "id": 1060,
     "skill_a": "Bootloader Development",
     "skill_b": "I2C",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 861,
+    "id": 1061,
     "skill_a": "C",
     "skill_b": "C++",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 862,
+    "id": 1062,
     "skill_a": "C",
     "skill_b": "Communication Protocols",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 863,
+    "id": 1063,
     "skill_a": "C",
     "skill_b": "Device Drivers",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 864,
+    "id": 1064,
     "skill_a": "C",
     "skill_b": "Device Tree Configuration",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 865,
+    "id": 1065,
     "skill_a": "C",
     "skill_b": "Embedded Systems",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 866,
+    "id": 1066,
     "skill_a": "C",
     "skill_b": "Firmware Debugging",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 867,
+    "id": 1067,
     "skill_a": "C",
     "skill_b": "Firmware Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 868,
+    "id": 1068,
     "skill_a": "C",
     "skill_b": "Hardware Abstraction Layer",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 869,
+    "id": 1069,
     "skill_a": "C",
     "skill_b": "Hardware Specifications",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 870,
+    "id": 1070,
     "skill_a": "C",
     "skill_b": "I2C",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 871,
+    "id": 1071,
     "skill_a": "C++",
     "skill_b": "Code Review",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 872,
+    "id": 1072,
     "skill_a": "C++",
     "skill_b": "Communication Protocols",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 873,
+    "id": 1073,
     "skill_a": "C++",
     "skill_b": "Device Drivers",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 874,
+    "id": 1074,
     "skill_a": "C++",
     "skill_b": "Device Tree Configuration",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 875,
+    "id": 1075,
     "skill_a": "C++",
     "skill_b": "Embedded Systems",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 876,
+    "id": 1076,
     "skill_a": "C++",
     "skill_b": "Firmware Debugging",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 877,
+    "id": 1077,
     "skill_a": "C++",
     "skill_b": "Firmware Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 878,
+    "id": 1078,
     "skill_a": "C++",
     "skill_b": "Hardware Abstraction Layer",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 879,
+    "id": 1079,
     "skill_a": "C++",
     "skill_b": "Hardware Specifications",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 880,
+    "id": 1080,
     "skill_a": "C++",
     "skill_b": "I2C",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 881,
+    "id": 1081,
     "skill_a": "C++",
     "skill_b": "Linux",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 882,
+    "id": 1082,
     "skill_a": "Civil Engineering",
     "skill_b": "English",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 883,
+    "id": 1083,
     "skill_a": "Cloud Computing",
     "skill_b": "Communication",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 884,
+    "id": 1084,
     "skill_a": "Cloud Computing",
     "skill_b": "Cross-functional Collaboration",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 885,
+    "id": 1085,
     "skill_a": "Code Review",
     "skill_b": "Data Visualization",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 886,
+    "id": 1086,
     "skill_a": "Code Review",
     "skill_b": "Debugging",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 887,
+    "id": 1087,
     "skill_a": "Code Review",
     "skill_b": "Generative AI",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 888,
+    "id": 1088,
     "skill_a": "Code Review",
     "skill_b": "Large Language Models",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 889,
+    "id": 1089,
     "skill_a": "Code Review",
     "skill_b": "Logic Error Detection",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 890,
+    "id": 1090,
     "skill_a": "Code Review",
     "skill_b": "Performance Optimization",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 891,
+    "id": 1091,
     "skill_a": "Code Review",
     "skill_b": "Programming Languages",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 892,
+    "id": 1092,
     "skill_a": "Code Review",
     "skill_b": "Python",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 893,
+    "id": 1093,
     "skill_a": "Code Review",
     "skill_b": "Reading Technical Documentation",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 894,
+    "id": 1094,
     "skill_a": "Code Review",
     "skill_b": "Security Analysis",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 895,
+    "id": 1095,
     "skill_a": "Code Review",
     "skill_b": "Software Architecture",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 896,
+    "id": 1096,
     "skill_a": "Code Review",
     "skill_b": "System Performance Evaluation",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 897,
+    "id": 1097,
     "skill_a": "Collaboration",
     "skill_b": "Communication",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 898,
+    "id": 1098,
     "skill_a": "Collaboration",
     "skill_b": "Requirements Gathering",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 899,
+    "id": 1099,
     "skill_a": "Communication",
     "skill_b": "Data Visualization",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 900,
+    "id": 1100,
     "skill_a": "Communication",
     "skill_b": "Inventory Management",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 901,
+    "id": 1101,
     "skill_a": "Communication",
     "skill_b": "Python",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 902,
+    "id": 1102,
     "skill_a": "Communication",
     "skill_b": "SQL",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 903,
+    "id": 1103,
     "skill_a": "Communication",
     "skill_b": "Scheduling",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 904,
+    "id": 1104,
     "skill_a": "Communication",
     "skill_b": "Teamwork",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 905,
+    "id": 1105,
     "skill_a": "Communication Protocols",
     "skill_b": "Device Drivers",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 906,
+    "id": 1106,
     "skill_a": "Communication Protocols",
     "skill_b": "Device Tree Configuration",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 907,
+    "id": 1107,
     "skill_a": "Communication Protocols",
     "skill_b": "Embedded Systems",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 908,
+    "id": 1108,
     "skill_a": "Communication Protocols",
     "skill_b": "Firmware Debugging",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 909,
+    "id": 1109,
     "skill_a": "Communication Protocols",
     "skill_b": "Firmware Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 910,
+    "id": 1110,
     "skill_a": "Communication Protocols",
     "skill_b": "Hardware Abstraction Layer",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 911,
+    "id": 1111,
     "skill_a": "Communication Protocols",
     "skill_b": "Hardware Specifications",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 912,
+    "id": 1112,
     "skill_a": "Communication Protocols",
     "skill_b": "I2C",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 913,
+    "id": 1113,
     "skill_a": "Continuous Integration",
     "skill_b": "Cross-functional Collaboration",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 914,
+    "id": 1114,
     "skill_a": "Continuous Integration",
     "skill_b": "Multithreading",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 915,
+    "id": 1115,
     "skill_a": "Continuous Integration",
     "skill_b": "Software Design Principles",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 916,
+    "id": 1116,
     "skill_a": "Continuous Integration",
     "skill_b": "Swift",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 917,
+    "id": 1117,
     "skill_a": "Continuous Integration",
     "skill_b": "SwiftUI",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 918,
+    "id": 1118,
     "skill_a": "Continuous Integration",
     "skill_b": "Test Automation Frameworks",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 919,
+    "id": 1119,
     "skill_a": "Contract Management",
     "skill_b": "Team Leadership",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 920,
+    "id": 1120,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Cybersecurity",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 921,
+    "id": 1121,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Data Analysis",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 922,
+    "id": 1122,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Data Science",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 923,
+    "id": 1123,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Debugging",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 924,
+    "id": 1124,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Model Deployment",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 925,
+    "id": 1125,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Multithreading",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 926,
+    "id": 1126,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Program Management",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 927,
+    "id": 1127,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Project Management",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 928,
+    "id": 1128,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Software Architecture",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 929,
+    "id": 1129,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Statistical Analysis",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 930,
+    "id": 1130,
     "skill_a": "Cross-functional Collaboration",
     "skill_b": "Teamwork",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 931,
+    "id": 1131,
     "skill_a": "Data Science",
     "skill_b": "Machine Learning",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 932,
+    "id": 1132,
     "skill_a": "Data Science",
     "skill_b": "Predictive Modeling",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 933,
+    "id": 1133,
     "skill_a": "Data Visualization",
     "skill_b": "Debugging",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 934,
+    "id": 1134,
     "skill_a": "Data Visualization",
     "skill_b": "Full Stack Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 935,
+    "id": 1135,
     "skill_a": "Data Visualization",
     "skill_b": "Software Architecture",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 936,
+    "id": 1136,
     "skill_a": "Data Visualization",
     "skill_b": "Software Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 937,
+    "id": 1137,
     "skill_a": "Data Visualization",
     "skill_b": "Software Engineering",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 938,
+    "id": 1138,
     "skill_a": "Debugging",
     "skill_b": "Full Stack Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 939,
+    "id": 1139,
     "skill_a": "Debugging",
     "skill_b": "Software Architecture",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 940,
+    "id": 1140,
     "skill_a": "Debugging",
     "skill_b": "Software Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 941,
+    "id": 1141,
     "skill_a": "Debugging",
     "skill_b": "Software Engineering",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 942,
+    "id": 1142,
     "skill_a": "Device Drivers",
     "skill_b": "Device Tree Configuration",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 943,
+    "id": 1143,
     "skill_a": "Device Drivers",
     "skill_b": "Embedded Systems",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 944,
+    "id": 1144,
     "skill_a": "Device Drivers",
     "skill_b": "Firmware Debugging",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 945,
+    "id": 1145,
     "skill_a": "Device Drivers",
     "skill_b": "Firmware Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 946,
+    "id": 1146,
     "skill_a": "Device Drivers",
     "skill_b": "Hardware Abstraction Layer",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 947,
+    "id": 1147,
     "skill_a": "Device Drivers",
     "skill_b": "Hardware Specifications",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 948,
+    "id": 1148,
     "skill_a": "Device Drivers",
     "skill_b": "I2C",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 949,
+    "id": 1149,
     "skill_a": "Device Tree Configuration",
     "skill_b": "Embedded Systems",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 950,
+    "id": 1150,
     "skill_a": "Device Tree Configuration",
     "skill_b": "Firmware Debugging",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 951,
+    "id": 1151,
     "skill_a": "Device Tree Configuration",
     "skill_b": "Firmware Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 952,
+    "id": 1152,
     "skill_a": "Device Tree Configuration",
     "skill_b": "Hardware Abstraction Layer",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 953,
+    "id": 1153,
     "skill_a": "Device Tree Configuration",
     "skill_b": "Hardware Specifications",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 954,
+    "id": 1154,
     "skill_a": "Device Tree Configuration",
     "skill_b": "I2C",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 955,
+    "id": 1155,
     "skill_a": "Electrical Engineering",
     "skill_b": "Troubleshooting",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 956,
+    "id": 1156,
     "skill_a": "Embedded Systems",
     "skill_b": "Firmware Debugging",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 957,
+    "id": 1157,
     "skill_a": "Embedded Systems",
     "skill_b": "Firmware Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 958,
+    "id": 1158,
     "skill_a": "Embedded Systems",
     "skill_b": "Hardware Abstraction Layer",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 959,
+    "id": 1159,
     "skill_a": "Embedded Systems",
     "skill_b": "Hardware Specifications",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 960,
+    "id": 1160,
     "skill_a": "Embedded Systems",
     "skill_b": "I2C",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 961,
+    "id": 1161,
     "skill_a": "English",
     "skill_b": "Problem Design",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 963,
+    "id": 1162,
+    "skill_a": "English",
+    "skill_b": "Python",
+    "co_occurrence_count": 2,
+    "week_start": "2026-04-20",
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
+  },
+  {
+    "id": 1163,
     "skill_a": "English",
     "skill_b": "Scientific Computing",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 964,
+    "id": 1164,
     "skill_a": "Firmware Debugging",
     "skill_b": "Firmware Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 965,
+    "id": 1165,
     "skill_a": "Firmware Debugging",
     "skill_b": "Hardware Abstraction Layer",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 966,
+    "id": 1166,
     "skill_a": "Firmware Debugging",
     "skill_b": "Hardware Specifications",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 967,
+    "id": 1167,
     "skill_a": "Firmware Debugging",
     "skill_b": "I2C",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 968,
+    "id": 1168,
     "skill_a": "Firmware Development",
     "skill_b": "Hardware Abstraction Layer",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 969,
+    "id": 1169,
     "skill_a": "Firmware Development",
     "skill_b": "Hardware Specifications",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 970,
+    "id": 1170,
     "skill_a": "Firmware Development",
     "skill_b": "I2C",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 971,
+    "id": 1171,
     "skill_a": "Full Stack Development",
     "skill_b": "Software Architecture",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 972,
+    "id": 1172,
     "skill_a": "Full Stack Development",
     "skill_b": "Software Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 973,
+    "id": 1173,
     "skill_a": "Generative AI",
     "skill_b": "Large Language Models",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 974,
+    "id": 1174,
     "skill_a": "Generative AI",
     "skill_b": "Software Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 975,
+    "id": 1175,
     "skill_a": "Generative AI",
     "skill_b": "System Performance Evaluation",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 976,
+    "id": 1176,
     "skill_a": "Hardware Abstraction Layer",
     "skill_b": "Hardware Specifications",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 977,
+    "id": 1177,
     "skill_a": "Hardware Abstraction Layer",
     "skill_b": "I2C",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 978,
+    "id": 1178,
     "skill_a": "Hardware Specifications",
     "skill_b": "I2C",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 979,
+    "id": 1179,
     "skill_a": "Inventory Management",
     "skill_b": "Safety Management",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 980,
+    "id": 1180,
     "skill_a": "Inventory Management",
     "skill_b": "Scheduling",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 981,
+    "id": 1181,
     "skill_a": "Large Language Models",
     "skill_b": "Software Development",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 982,
+    "id": 1182,
     "skill_a": "Large Language Models",
     "skill_b": "System Performance Evaluation",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 983,
+    "id": 1183,
     "skill_a": "Linux",
     "skill_b": "Shell Scripting",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 984,
+    "id": 1184,
     "skill_a": "Logic Error Detection",
     "skill_b": "Performance Optimization",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 985,
+    "id": 1185,
     "skill_a": "Logic Error Detection",
     "skill_b": "Reading Technical Documentation",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 986,
+    "id": 1186,
     "skill_a": "Logic Error Detection",
     "skill_b": "Security Analysis",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 987,
+    "id": 1187,
     "skill_a": "Logic Error Detection",
     "skill_b": "Written Communication",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 988,
+    "id": 1188,
     "skill_a": "Machine Learning",
     "skill_b": "Model Deployment",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 989,
+    "id": 1189,
     "skill_a": "Mentoring",
     "skill_b": "Performance Testing",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 990,
+    "id": 1190,
     "skill_a": "Mentoring",
     "skill_b": "Problem Solving",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 991,
+    "id": 1191,
     "skill_a": "Multithreading",
     "skill_b": "Software Design Principles",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 992,
+    "id": 1192,
     "skill_a": "Multithreading",
     "skill_b": "Swift",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 993,
+    "id": 1193,
     "skill_a": "Multithreading",
     "skill_b": "SwiftUI",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 994,
+    "id": 1194,
     "skill_a": "Node.js",
     "skill_b": "REST APIs",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 995,
+    "id": 1195,
     "skill_a": "Performance Optimization",
     "skill_b": "Reading Technical Documentation",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 996,
+    "id": 1196,
     "skill_a": "Performance Optimization",
     "skill_b": "Security Analysis",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 997,
+    "id": 1197,
     "skill_a": "Performance Optimization",
     "skill_b": "Written Communication",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 998,
+    "id": 1198,
     "skill_a": "Performance Testing",
     "skill_b": "Problem Solving",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 999,
+    "id": 1199,
     "skill_a": "Problem Design",
     "skill_b": "Python",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   },
   {
-    "id": 1000,
+    "id": 1200,
     "skill_a": "Problem Design",
     "skill_b": "Scientific Computing",
     "co_occurrence_count": 2,
     "week_start": "2026-04-20",
-    "computed_at": "2026-04-28T23:43:21.614325+00:00"
+    "computed_at": "2026-04-29T05:53:53.846456+00:00"
   }
 ]

--- a/scripts/pg-seed-data/fixtures/skill_demand_weekly.json
+++ b/scripts/pg-seed-data/fixtures/skill_demand_weekly.json
@@ -9135,6 +9135,15 @@
     "computed_at": "2026-04-17T03:27:57.411647+00:00"
   },
   {
+    "id": 8146,
+    "skill_label": "A/B Testing",
+    "esco_uri": null,
+    "week_start": "2026-04-20",
+    "posting_count": 1,
+    "employer_count": 1,
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
+  },
+  {
     "id": 5496,
     "skill_label": "Industrial Automation",
     "esco_uri": "http://data.europa.eu/esco/skill/e87ec79a-c9ff-46f5-84fa-7a0f394cdf40",
@@ -17325,6 +17334,15 @@
     "computed_at": "2026-04-17T03:27:57.411647+00:00"
   },
   {
+    "id": 8147,
+    "skill_label": "Advanced Data Analysis & Insight Generation",
+    "esco_uri": null,
+    "week_start": "2026-04-20",
+    "posting_count": 1,
+    "employer_count": 1,
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
+  },
+  {
     "id": 6406,
     "skill_label": "Statistical Methods",
     "esco_uri": null,
@@ -20133,6592 +20151,6574 @@
     "computed_at": "2026-04-17T03:27:57.411647+00:00"
   },
   {
-    "id": 7414,
-    "skill_label": "A/B Testing",
-    "esco_uri": null,
-    "week_start": "2026-04-20",
-    "posting_count": 1,
-    "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
-  },
-  {
-    "id": 7415,
-    "skill_label": "Advanced Data Analysis & Insight Generation",
-    "esco_uri": null,
-    "week_start": "2026-04-20",
-    "posting_count": 1,
-    "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
-  },
-  {
-    "id": 7416,
+    "id": 8148,
     "skill_label": "Agentic AI",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7417,
+    "id": 8149,
     "skill_label": "Agile",
     "esco_uri": "http://data.europa.eu/esco/skill/bec4359e-cb92-468f-a997-8fb28e32fba9",
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7418,
+    "id": 8150,
     "skill_label": "Agile Methodologies",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7419,
+    "id": 8151,
     "skill_label": "Agile Methodology",
     "esco_uri": "Agile Methodology",
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7420,
+    "id": 8152,
     "skill_label": "AI Automation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7421,
+    "id": 8153,
     "skill_label": "AI Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7422,
+    "id": 8154,
     "skill_label": "AI Knowledge",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7423,
+    "id": 8155,
     "skill_label": "AI Model Training",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7424,
+    "id": 8156,
     "skill_label": "AI product roadmap",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7425,
+    "id": 8157,
     "skill_label": "Aircraft/Weapons System Integration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7426,
+    "id": 8158,
     "skill_label": "AI Solution Design",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7427,
+    "id": 8159,
     "skill_label": "Alternate Sourcing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7428,
+    "id": 8160,
     "skill_label": "Amazon Marketplace",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7429,
+    "id": 8161,
     "skill_label": "American Registry of Radiologic Technologists (ARRT) Certification",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7430,
+    "id": 8162,
     "skill_label": "Analytical Skills",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7431,
+    "id": 8163,
     "skill_label": "Analytical Thinking",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7432,
+    "id": 8164,
     "skill_label": "Android Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7433,
+    "id": 8165,
     "skill_label": "Anti-Tamper",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7434,
+    "id": 8166,
     "skill_label": "Apache Spark",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7435,
+    "id": 8167,
     "skill_label": "API",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7436,
+    "id": 8168,
     "skill_label": "API Design",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7437,
+    "id": 8169,
     "skill_label": "Appian",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7438,
+    "id": 8170,
     "skill_label": "AppKit",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7439,
+    "id": 8171,
     "skill_label": "Application Deployment",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7440,
+    "id": 8172,
     "skill_label": "Architecture, Engineering, and Construction (AEC) Industry",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7441,
+    "id": 8173,
     "skill_label": "Army Supply System",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7442,
+    "id": 8174,
     "skill_label": "Artificial Intelligence",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 5,
     "employer_count": 5,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7443,
+    "id": 8175,
     "skill_label": "Aruba Switching",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7444,
+    "id": 8176,
     "skill_label": "Aruba Wireless Networks",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7445,
+    "id": 8177,
     "skill_label": "Assembly Language",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7446,
+    "id": 8178,
     "skill_label": "Asynchronous programming",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7447,
+    "id": 8179,
     "skill_label": "Asynchronous Programming",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7448,
+    "id": 8180,
     "skill_label": "Attack Threat Modeling",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7449,
+    "id": 8181,
     "skill_label": "Attention to Detail",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7450,
+    "id": 8182,
     "skill_label": "Authentication",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7451,
+    "id": 8183,
     "skill_label": "Authorization",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7452,
+    "id": 8184,
     "skill_label": "Automated Testing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7453,
+    "id": 8185,
     "skill_label": "Azure",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7454,
+    "id": 8186,
     "skill_label": "Azure Cloud",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7455,
+    "id": 8187,
     "skill_label": "Azure DevOps",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7456,
+    "id": 8188,
     "skill_label": "Azure Identity Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7457,
+    "id": 8189,
     "skill_label": "Azure Key Vault",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7458,
+    "id": 8190,
     "skill_label": "Azure Kubernetes Service",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7459,
+    "id": 8191,
     "skill_label": "Azure Policy",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7460,
+    "id": 8192,
     "skill_label": "Azure Service Bus",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7461,
+    "id": 8193,
     "skill_label": "Azure Storage",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7462,
+    "id": 8194,
     "skill_label": "Azure Virtual Network",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7463,
+    "id": 8195,
     "skill_label": "Bachelor's Degree",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7464,
+    "id": 8196,
     "skill_label": "Bachelor's Degree in Computer Science",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7465,
+    "id": 8197,
     "skill_label": "Bachelor's Degree in Quantitative Field",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7466,
+    "id": 8198,
     "skill_label": "Backend Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7467,
+    "id": 8199,
     "skill_label": "Backlog Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7468,
+    "id": 8200,
     "skill_label": "Backup and Recovery",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7469,
+    "id": 8201,
     "skill_label": "BGP",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7470,
+    "id": 8202,
     "skill_label": "Bilingualism",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7471,
+    "id": 8203,
     "skill_label": "Bill of Materials (BOM) Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7472,
+    "id": 8204,
     "skill_label": "Biology",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7473,
+    "id": 8205,
     "skill_label": "Board Support Package (BSP) Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7474,
+    "id": 8206,
     "skill_label": "Bootloader Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7475,
+    "id": 8207,
     "skill_label": "Brand Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7476,
+    "id": 8208,
     "skill_label": "Budget Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7477,
+    "id": 8209,
     "skill_label": "Buffering Strategies",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7478,
+    "id": 8210,
     "skill_label": "Buffer Overflow",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7479,
+    "id": 8211,
     "skill_label": "Business Acumen",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7480,
+    "id": 8212,
     "skill_label": "Business Administration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7481,
+    "id": 8213,
     "skill_label": "Business Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7482,
+    "id": 8214,
     "skill_label": "C",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7483,
+    "id": 8215,
     "skill_label": "C#",
     "esco_uri": "http://data.europa.eu/esco/skill/4c016b68-4116-468c-9dc6-42710c239e4a",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7484,
+    "id": 8216,
     "skill_label": "C++",
     "esco_uri": "http://data.europa.eu/esco/skill/b633eb55-8f1f-4ae6-ab4c-2022ffe2cb7f",
     "week_start": "2026-04-20",
     "posting_count": 3,
     "employer_count": 3,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7485,
+    "id": 8217,
     "skill_label": "Calendar Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7486,
+    "id": 8218,
     "skill_label": "CAN",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7487,
+    "id": 8219,
     "skill_label": "CAN Protocol",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7488,
+    "id": 8220,
     "skill_label": "Capacity Planning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7489,
+    "id": 8221,
     "skill_label": "Capital Markets",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7490,
+    "id": 8222,
     "skill_label": "Cardiopulmonary Resuscitation (CPR)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7491,
+    "id": 8223,
     "skill_label": "Category Narrative Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7492,
+    "id": 8224,
     "skill_label": "CCNA",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7493,
+    "id": 8225,
     "skill_label": "CCNP",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7494,
+    "id": 8226,
     "skill_label": "Certification Authorities (CAs)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7495,
+    "id": 8227,
     "skill_label": "Certified Texas Contract Developer (CTCD)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7496,
+    "id": 8228,
     "skill_label": "Certified Texas Contract Manager (CTCM)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7497,
+    "id": 8229,
     "skill_label": "Chatbot Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7498,
+    "id": 8230,
     "skill_label": "CI/CD",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7499,
+    "id": 8231,
     "skill_label": "Cisco Certified Network Associate (CCNA)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7500,
+    "id": 8232,
     "skill_label": "Cisco Certified Network Professional (CCNP)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7501,
+    "id": 8233,
     "skill_label": "Cisco Routing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7502,
+    "id": 8234,
     "skill_label": "Cisco SD-WAN",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7503,
+    "id": 8235,
     "skill_label": "Civil Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7504,
+    "id": 8236,
     "skill_label": "Civil Engineering Materials Science",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7505,
+    "id": 8237,
     "skill_label": "Classification",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7506,
+    "id": 8238,
     "skill_label": "Client-Server Architecture",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7507,
+    "id": 8239,
     "skill_label": "Client Training",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7508,
+    "id": 8240,
     "skill_label": "Clinical Data Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7509,
+    "id": 8241,
     "skill_label": "Clinical Systems Knowledge",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7510,
+    "id": 8242,
     "skill_label": "Cloud Architecture",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7511,
+    "id": 8243,
     "skill_label": "Cloud Computing",
     "esco_uri": "http://data.europa.eu/esco/skill/bd14968e-e409-45af-b362-3495ed7b10e0",
     "week_start": "2026-04-20",
     "posting_count": 5,
     "employer_count": 5,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7512,
+    "id": 8244,
     "skill_label": "Cloud Infrastructure",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7513,
+    "id": 8245,
     "skill_label": "Cloud Infrastructure Design",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7514,
+    "id": 8246,
     "skill_label": "Cloud Migration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7515,
+    "id": 8247,
     "skill_label": "Cloud Networking",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7516,
+    "id": 8248,
     "skill_label": "Cloud Security",
     "esco_uri": "http://data.europa.eu/esco/skill/1c2978b8-bb0d-4249-9c23-877571a4dffa",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7517,
+    "id": 8249,
     "skill_label": "Coastal and Ocean Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7518,
+    "id": 8250,
     "skill_label": "Code Evaluation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7519,
+    "id": 8251,
     "skill_label": "Code Quality Assessment",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7520,
+    "id": 8252,
     "skill_label": "Code Refactoring",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7521,
+    "id": 8253,
     "skill_label": "Code Review",
     "esco_uri": "Code Review",
     "week_start": "2026-04-20",
     "posting_count": 10,
     "employer_count": 6,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7522,
+    "id": 8254,
     "skill_label": "Coding",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7523,
+    "id": 8255,
     "skill_label": "Collaboration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 3,
     "employer_count": 3,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7524,
+    "id": 8256,
     "skill_label": "Collaborative Work",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7525,
+    "id": 8257,
     "skill_label": "Commercial Contracting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7526,
+    "id": 8258,
     "skill_label": "Commercial Partnerships",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7527,
+    "id": 8259,
     "skill_label": "Communication",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 8,
     "employer_count": 8,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7528,
+    "id": 8260,
     "skill_label": "Communication and Presentation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7529,
+    "id": 8261,
     "skill_label": "Communication Protocols",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7530,
+    "id": 8262,
     "skill_label": "Communication & Stakeholder Engagement",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7531,
+    "id": 8263,
     "skill_label": "Complex Systems Integration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7532,
+    "id": 8264,
     "skill_label": "Compliance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7533,
+    "id": 8265,
     "skill_label": "Compliance Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7534,
+    "id": 8266,
     "skill_label": "CompTIA Security+",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7535,
+    "id": 8267,
     "skill_label": "Computational Physics",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7536,
+    "id": 8268,
     "skill_label": "Computer Architecture",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7537,
+    "id": 8269,
     "skill_label": "Computer Documentation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7538,
+    "id": 8270,
     "skill_label": "Computer Engineering",
     "esco_uri": "http://data.europa.eu/esco/skill/89f6560b-2194-45c9-9ece-d33049a73eef",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7539,
+    "id": 8271,
     "skill_label": "Computer Science",
     "esco_uri": "http://data.europa.eu/esco/skill/7b5cce4d-c7fe-4119-b48f-70aa05391787",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7540,
+    "id": 8272,
     "skill_label": "Computer Technology",
     "esco_uri": "http://data.europa.eu/esco/skill/ddc3119d-1d6e-4324-9125-a3380d299ac5",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7541,
+    "id": 8273,
     "skill_label": "Computer Vision",
     "esco_uri": "http://data.europa.eu/esco/skill/7b0d5000-00da-4864-b776-6de49a87a669",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7542,
+    "id": 8274,
     "skill_label": "Concurrency",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7543,
+    "id": 8275,
     "skill_label": "Concurrent Programming",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7544,
+    "id": 8276,
     "skill_label": "Conditional Access",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7545,
+    "id": 8277,
     "skill_label": "Construction Engineering and Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7546,
+    "id": 8278,
     "skill_label": "Content Creation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7547,
+    "id": 8279,
     "skill_label": "Context-driven Testing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7548,
+    "id": 8280,
     "skill_label": "Continuous Delivery",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7549,
+    "id": 8281,
     "skill_label": "Continuous Integration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 4,
     "employer_count": 3,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7550,
+    "id": 8282,
     "skill_label": "Contract Administration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7551,
+    "id": 8283,
     "skill_label": "Contract Drafting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7552,
+    "id": 8284,
     "skill_label": "Contract Evaluation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7553,
+    "id": 8285,
     "skill_label": "Contract Execution",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7554,
+    "id": 8286,
     "skill_label": "Contract Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 3,
     "employer_count": 3,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7555,
+    "id": 8287,
     "skill_label": "Contract Negotiation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7556,
+    "id": 8288,
     "skill_label": "Contract Risk Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7557,
+    "id": 8289,
     "skill_label": "Control-M",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7558,
+    "id": 8290,
     "skill_label": "Conversational AI",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7559,
+    "id": 8291,
     "skill_label": "Convolutional Neural Networks",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7560,
+    "id": 8292,
     "skill_label": "Corporate Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7561,
+    "id": 8293,
     "skill_label": "Corporate Finance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7562,
+    "id": 8294,
     "skill_label": "Corrections",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7563,
+    "id": 8295,
     "skill_label": "Corrosion Prevention",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7564,
+    "id": 8296,
     "skill_label": "C Programming",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7565,
+    "id": 8297,
     "skill_label": "C++ Programming",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7566,
+    "id": 8298,
     "skill_label": "Creative Problem Design",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7567,
+    "id": 8299,
     "skill_label": "Criminal Investigation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7568,
+    "id": 8300,
     "skill_label": "Critical Program Information Assessment",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7569,
+    "id": 8301,
     "skill_label": "Critical Thinking",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7570,
+    "id": 8302,
     "skill_label": "cross-functional collaboration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7571,
+    "id": 8303,
     "skill_label": "Cross-functional Collaboration",
     "esco_uri": "Cross-functional collaboration",
     "week_start": "2026-04-20",
     "posting_count": 13,
     "employer_count": 12,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7572,
+    "id": 8304,
     "skill_label": "Cross-functional leadership",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7573,
+    "id": 8305,
     "skill_label": "Cross-Functional Project Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7574,
+    "id": 8306,
     "skill_label": "Crowd Control",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7575,
+    "id": 8307,
     "skill_label": "Cryptography",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7576,
+    "id": 8308,
     "skill_label": "CSS",
     "esco_uri": "http://data.europa.eu/esco/skill/e5d1f825-60ed-4bdd-872a-e748c387f777",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7577,
+    "id": 8309,
     "skill_label": "Customer Focus",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7578,
+    "id": 8310,
     "skill_label": "Customer Interaction Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7579,
+    "id": 8311,
     "skill_label": "Customer Loyalty Programs",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7580,
+    "id": 8312,
     "skill_label": "Customer Needs Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7581,
+    "id": 8313,
     "skill_label": "Customer Obsession",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7582,
+    "id": 8314,
     "skill_label": "Customer Service",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7583,
+    "id": 8315,
     "skill_label": "Customer Training",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7584,
+    "id": 8316,
     "skill_label": "Cybersecurity",
     "esco_uri": "http://data.europa.eu/esco/skill/8088750d-8388-4170-a76f-48354c469c44",
     "week_start": "2026-04-20",
     "posting_count": 5,
     "employer_count": 4,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7585,
+    "id": 8317,
     "skill_label": "Cybersecurity Certification",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7586,
+    "id": 8318,
     "skill_label": "Cybersecurity Certifications",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7587,
+    "id": 8319,
     "skill_label": "data analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7588,
+    "id": 8320,
     "skill_label": "Data Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 7,
     "employer_count": 7,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7589,
+    "id": 8321,
     "skill_label": "Data Annotation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7590,
+    "id": 8322,
     "skill_label": "Data Architecture",
     "esco_uri": "http://data.europa.eu/esco/skill/1bba98a7-92b9-450b-9235-e0c905f8f3c4",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7591,
+    "id": 8323,
     "skill_label": "Data Augmentation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7592,
+    "id": 8324,
     "skill_label": "Database Integration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7593,
+    "id": 8325,
     "skill_label": "Database Migration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7594,
+    "id": 8326,
     "skill_label": "Database Schema Design",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7595,
+    "id": 8327,
     "skill_label": "Database Security",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7596,
+    "id": 8328,
     "skill_label": "Data Cleaning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7597,
+    "id": 8329,
     "skill_label": "Data Collection",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7598,
+    "id": 8330,
     "skill_label": "Data-driven Decision Making",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7599,
+    "id": 8331,
     "skill_label": "Data-driven Insights",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7600,
+    "id": 8332,
     "skill_label": "Data Engineering",
     "esco_uri": "http://data.europa.eu/esco/skill/48db96bf-3314-45c6-bad8-fdb6e20e5639",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7601,
+    "id": 8333,
     "skill_label": "Data Entry",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7602,
+    "id": 8334,
     "skill_label": "Data Extraction",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7603,
+    "id": 8335,
     "skill_label": "Data Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7604,
+    "id": 8336,
     "skill_label": "Data Mapping",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7605,
+    "id": 8337,
     "skill_label": "Data Modeling",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7606,
+    "id": 8338,
     "skill_label": "Data Preprocessing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7607,
+    "id": 8339,
     "skill_label": "Data Presentation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7608,
+    "id": 8340,
     "skill_label": "Data Quality Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7609,
+    "id": 8341,
     "skill_label": "Data Querying",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7610,
+    "id": 8342,
     "skill_label": "Data Reporting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7611,
+    "id": 8343,
     "skill_label": "Data Science",
     "esco_uri": "http://data.europa.eu/esco/skill/edebd83d-35f6-4ed5-a940-6c203d178c01",
     "week_start": "2026-04-20",
     "posting_count": 3,
     "employer_count": 3,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7612,
+    "id": 8344,
     "skill_label": "Data Storytelling & Narrative Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7613,
+    "id": 8345,
     "skill_label": "Data Transformation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7614,
+    "id": 8346,
     "skill_label": "Data Validation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7615,
+    "id": 8347,
     "skill_label": "Data Visualization",
     "esco_uri": "Data visualization",
     "week_start": "2026-04-20",
     "posting_count": 5,
     "employer_count": 4,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7616,
+    "id": 8348,
     "skill_label": "Data Warehousing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7617,
+    "id": 8349,
     "skill_label": "DB2 LUW",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7618,
+    "id": 8350,
     "skill_label": "DB2 z/OS Architecture",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7619,
+    "id": 8351,
     "skill_label": "DB2 z/OS Database Administration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7620,
+    "id": 8352,
     "skill_label": "DB2 z/OS Database Administration Certification",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7621,
+    "id": 8353,
     "skill_label": "Debugging",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7622,
+    "id": 8354,
     "skill_label": "Decision Making",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7623,
+    "id": 8355,
     "skill_label": "Deep Learning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7624,
+    "id": 8356,
     "skill_label": "Defect Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7625,
+    "id": 8357,
     "skill_label": "Defect Tracking",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7626,
+    "id": 8358,
     "skill_label": "Design Calculations",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7627,
+    "id": 8359,
     "skill_label": "Detection Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7628,
+    "id": 8360,
     "skill_label": "Device Driver Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7629,
+    "id": 8361,
     "skill_label": "Device Drivers",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7630,
+    "id": 8362,
     "skill_label": "Device Tree Configuration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7631,
+    "id": 8363,
     "skill_label": "DevOps",
     "esco_uri": "http://data.europa.eu/esco/skill/f0de4973-0a70-4644-8fd4-3a97080476f4",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7632,
+    "id": 8364,
     "skill_label": "DevSecOps",
     "esco_uri": "DevSecOps",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7633,
+    "id": 8365,
     "skill_label": "Diagnostic Imaging",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7634,
+    "id": 8366,
     "skill_label": "Diffusion Models",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7635,
+    "id": 8367,
     "skill_label": "Digital Forensics and Incident Response",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7636,
+    "id": 8368,
     "skill_label": "Digital Marketing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7637,
+    "id": 8369,
     "skill_label": "Digital Signatures",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7638,
+    "id": 8370,
     "skill_label": "Direct-to-Consumer (DTC) E-commerce",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7639,
+    "id": 8371,
     "skill_label": "Disaster Recovery",
     "esco_uri": "http://data.europa.eu/esco/skill/fc2f1d4f-a46f-471e-a618-cbd4d0496a53",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7640,
+    "id": 8372,
     "skill_label": "Distributed Computing",
     "esco_uri": "http://data.europa.eu/esco/skill/897b393f-e7e0-4248-a40d-d77119694e83",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7641,
+    "id": 8373,
     "skill_label": "Django",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7642,
+    "id": 8374,
     "skill_label": "Docker",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7643,
+    "id": 8375,
     "skill_label": "Documentation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7644,
+    "id": 8376,
     "skill_label": "Documentation Reading",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7645,
+    "id": 8377,
     "skill_label": "Document Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7646,
+    "id": 8378,
     "skill_label": "Document Preparation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7647,
+    "id": 8379,
     "skill_label": "DoD Directives Compliance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7648,
+    "id": 8380,
     "skill_label": "DoD Security Clearance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7649,
+    "id": 8381,
     "skill_label": "Earned Value Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7650,
+    "id": 8382,
     "skill_label": "Earthquake Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7651,
+    "id": 8383,
     "skill_label": "E-commerce",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7652,
+    "id": 8384,
     "skill_label": "Economics",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7653,
+    "id": 8385,
     "skill_label": "Electrical Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 4,
     "employer_count": 4,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7654,
+    "id": 8386,
     "skill_label": "Electrical Systems",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7655,
+    "id": 8387,
     "skill_label": "Electronic Medical Records (EMR)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7656,
+    "id": 8388,
     "skill_label": "Embedded Software Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7657,
+    "id": 8389,
     "skill_label": "Embedded Systems",
     "esco_uri": "http://data.europa.eu/esco/skill/2180bd8c-86de-4889-8165-adac902eee9d",
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7658,
+    "id": 8390,
     "skill_label": "Embedded System Security",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7659,
+    "id": 8391,
     "skill_label": "Employee Training",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7660,
+    "id": 8392,
     "skill_label": "Encryption",
     "esco_uri": "Encryption",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7661,
+    "id": 8393,
     "skill_label": "End User Support",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7662,
+    "id": 8394,
     "skill_label": "Engineering Plans and Specifications",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7663,
+    "id": 8395,
     "skill_label": "Engineering Principles",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7664,
+    "id": 8396,
     "skill_label": "English",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 4,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7665,
+    "id": 8397,
     "skill_label": "English Language Proficiency",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7666,
+    "id": 8398,
     "skill_label": "Enterprise Architecture",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7667,
+    "id": 8399,
     "skill_label": "Enterprise Networking",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7668,
+    "id": 8400,
     "skill_label": "Enterprise Network Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7669,
+    "id": 8401,
     "skill_label": "Enterprise Systems Integration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7670,
+    "id": 8402,
     "skill_label": "Entrepreneurial Marketing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7671,
+    "id": 8403,
     "skill_label": "Environmental Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7672,
+    "id": 8404,
     "skill_label": "Epidemiology",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7673,
+    "id": 8405,
     "skill_label": "Evidence Collection",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7674,
+    "id": 8406,
     "skill_label": "Experimental Design",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7675,
+    "id": 8407,
     "skill_label": "Experiment Design",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7676,
+    "id": 8408,
     "skill_label": "Exploit Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7677,
+    "id": 8409,
     "skill_label": "Exploratory Testing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7678,
+    "id": 8410,
     "skill_label": "Express.js",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7679,
+    "id": 8411,
     "skill_label": "Fast-paced Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7680,
+    "id": 8412,
     "skill_label": "FDA Regulatory Compliance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7681,
+    "id": 8413,
     "skill_label": "Federal Contracting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7682,
+    "id": 8414,
     "skill_label": "Federal Procurement",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7683,
+    "id": 8415,
     "skill_label": "Federal Regulations",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7684,
+    "id": 8416,
     "skill_label": "Field Maintenance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7685,
+    "id": 8417,
     "skill_label": "Finance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7686,
+    "id": 8418,
     "skill_label": "Financial Accounting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7687,
+    "id": 8419,
     "skill_label": "Financial Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7688,
+    "id": 8420,
     "skill_label": "Financial Modeling",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7689,
+    "id": 8421,
     "skill_label": "Financial Procedures",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7690,
+    "id": 8422,
     "skill_label": "Financial Reasoning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7691,
+    "id": 8423,
     "skill_label": "Financial Reporting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7692,
+    "id": 8424,
     "skill_label": "fine-tuning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7693,
+    "id": 8425,
     "skill_label": "Firewall Configuration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7694,
+    "id": 8426,
     "skill_label": "Firewall Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7695,
+    "id": 8427,
     "skill_label": "Firewall Rule Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7696,
+    "id": 8428,
     "skill_label": "Firmware Debugging",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7697,
+    "id": 8429,
     "skill_label": "Firmware Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7698,
+    "id": 8430,
     "skill_label": "Force Protection",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7699,
+    "id": 8431,
     "skill_label": "Forecasting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7700,
+    "id": 8432,
     "skill_label": "FPGA Design",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7701,
+    "id": 8433,
     "skill_label": "Full Stack Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 4,
     "employer_count": 3,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7702,
+    "id": 8434,
     "skill_label": "Full-Stack Web Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7703,
+    "id": 8435,
     "skill_label": "Functional Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7704,
+    "id": 8436,
     "skill_label": "Functional Documentation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7705,
+    "id": 8437,
     "skill_label": "Functional & Technical Documentation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7706,
+    "id": 8438,
     "skill_label": "Functional Testing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7707,
+    "id": 8439,
     "skill_label": "Fuzz Testing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7708,
+    "id": 8440,
     "skill_label": "Generative AI",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7709,
+    "id": 8441,
     "skill_label": "Geomatics",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7710,
+    "id": 8442,
     "skill_label": "Geotechnical Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7711,
+    "id": 8443,
     "skill_label": "Git",
     "esco_uri": "http://data.europa.eu/esco/skill/9d2e926f-53d9-41f5-98f3-19dfaa687f3f",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7712,
+    "id": 8444,
     "skill_label": "Glucose Monitoring",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7713,
+    "id": 8445,
     "skill_label": "Go-to-Market Strategy",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7714,
+    "id": 8446,
     "skill_label": "Government Audits",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7715,
+    "id": 8447,
     "skill_label": "Groovy",
     "esco_uri": "http://data.europa.eu/esco/skill/52cf3037-ab53-4806-85ed-7fd21ea7f6a1",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7716,
+    "id": 8448,
     "skill_label": "Harbor Security",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7717,
+    "id": 8449,
     "skill_label": "Hardware Abstraction Layer",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7718,
+    "id": 8450,
     "skill_label": "Hardware and Software Testing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7719,
+    "id": 8451,
     "skill_label": "Hardware Debugging Tools",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7720,
+    "id": 8452,
     "skill_label": "Hardware Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7721,
+    "id": 8453,
     "skill_label": "Hardware Specifications",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7722,
+    "id": 8454,
     "skill_label": "Hardware Troubleshooting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7723,
+    "id": 8455,
     "skill_label": "Healthcare Administration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7724,
+    "id": 8456,
     "skill_label": "Healthcare Data Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7725,
+    "id": 8457,
     "skill_label": "Healthcare Data Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7726,
+    "id": 8458,
     "skill_label": "Hematology",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7727,
+    "id": 8459,
     "skill_label": "HTML",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7728,
+    "id": 8460,
     "skill_label": "Human Machine Interface (HMI)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7729,
+    "id": 8461,
     "skill_label": "Human Machine Interface (HMI) Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7730,
+    "id": 8462,
     "skill_label": "Hydraulic Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7731,
+    "id": 8463,
     "skill_label": "Hydraulics",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7732,
+    "id": 8464,
     "skill_label": "Hypothesis Testing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7733,
+    "id": 8465,
     "skill_label": "I2C",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7734,
+    "id": 8466,
     "skill_label": "Identity and Access Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7735,
+    "id": 8467,
     "skill_label": "Image Classification",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7736,
+    "id": 8468,
     "skill_label": "Incident Investigation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7737,
+    "id": 8469,
     "skill_label": "Incident Response",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7738,
+    "id": 8470,
     "skill_label": "Independent Work",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7739,
+    "id": 8471,
     "skill_label": "Industrial Controls",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7740,
+    "id": 8472,
     "skill_label": "Industry Product Knowledge",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7741,
+    "id": 8473,
     "skill_label": "Information Security",
     "esco_uri": "http://data.europa.eu/esco/skill/8088750d-8388-4170-a76f-48354c469c44",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7742,
+    "id": 8474,
     "skill_label": "Infrastructure as Code",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7743,
+    "id": 8475,
     "skill_label": "Infrastructure Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7744,
+    "id": 8476,
     "skill_label": "Infrastructure Testing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7745,
+    "id": 8477,
     "skill_label": "Input/Output (IO) List Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7746,
+    "id": 8478,
     "skill_label": "instruction tuning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7747,
+    "id": 8479,
     "skill_label": "Insurance Planning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7748,
+    "id": 8480,
     "skill_label": "Integer Truncation Vulnerability",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7749,
+    "id": 8481,
     "skill_label": "Integration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7750,
+    "id": 8482,
     "skill_label": "Integration and Test",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7751,
+    "id": 8483,
     "skill_label": "Interface Definition",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7752,
+    "id": 8484,
     "skill_label": "International Contracting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7753,
+    "id": 8485,
     "skill_label": "International Traffic in Arms Regulations (ITAR) Compliance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7754,
+    "id": 8486,
     "skill_label": "Interpersonal Skills",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7755,
+    "id": 8487,
     "skill_label": "Interprocess Communication",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7756,
+    "id": 8488,
     "skill_label": "Intrusion Detection",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7757,
+    "id": 8489,
     "skill_label": "Inventory Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 4,
     "employer_count": 4,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7758,
+    "id": 8490,
     "skill_label": "Investment Banking",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7759,
+    "id": 8491,
     "skill_label": "ISTQB",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7760,
+    "id": 8492,
     "skill_label": "JavaScript",
     "esco_uri": "http://data.europa.eu/esco/skill/3cd569a2-4f88-4c1e-9995-8dce8c5e51a7",
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7761,
+    "id": 8493,
     "skill_label": "JAX",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7762,
+    "id": 8494,
     "skill_label": "JMeter",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7763,
+    "id": 8495,
     "skill_label": "JNCIA",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7764,
+    "id": 8496,
     "skill_label": "JNCIP",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7765,
+    "id": 8497,
     "skill_label": "Joint Venture Agreements",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7766,
+    "id": 8498,
     "skill_label": "Keyword Research",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7767,
+    "id": 8499,
     "skill_label": "Laboratory Specimen Processing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7768,
+    "id": 8500,
     "skill_label": "large language models",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7769,
+    "id": 8501,
     "skill_label": "Large Language Models",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7770,
+    "id": 8502,
     "skill_label": "Law Enforcement",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7771,
+    "id": 8503,
     "skill_label": "Leadership",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 3,
     "employer_count": 3,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7772,
+    "id": 8504,
     "skill_label": "Legacy Application Modernization",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7773,
+    "id": 8505,
     "skill_label": "Licensing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7774,
+    "id": 8506,
     "skill_label": "Linux",
     "esco_uri": "http://data.europa.eu/esco/skill/f9a6f35b-01a7-40c9-8b61-b6ee46f97272",
     "week_start": "2026-04-20",
     "posting_count": 3,
     "employer_count": 3,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7775,
+    "id": 8507,
     "skill_label": "Linux Applications",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7776,
+    "id": 8508,
     "skill_label": "Local Area Networks (LAN)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7777,
+    "id": 8509,
     "skill_label": "Log Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7778,
+    "id": 8510,
     "skill_label": "Logic Analyzer",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7779,
+    "id": 8511,
     "skill_label": "Logic Analyzer Usage",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7780,
+    "id": 8512,
     "skill_label": "Logic Error Detection",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7781,
+    "id": 8513,
     "skill_label": "Loss Prevention",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7782,
+    "id": 8514,
     "skill_label": "Low-level Code Optimization",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7783,
+    "id": 8515,
     "skill_label": "Low-level Debugging",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7784,
+    "id": 8516,
     "skill_label": "Low-level System Initialization",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7785,
+    "id": 8517,
     "skill_label": "Machine Learning",
     "esco_uri": "http://data.europa.eu/esco/skill/3a2d5b45-56e4-4f5a-a55a-4a4a65afdc43",
     "week_start": "2026-04-20",
     "posting_count": 4,
     "employer_count": 4,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7786,
+    "id": 8518,
     "skill_label": "Machine Learning Research",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7787,
+    "id": 8519,
     "skill_label": "macOS frameworks",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7788,
+    "id": 8520,
     "skill_label": "Mainframe Operating Systems",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7789,
+    "id": 8521,
     "skill_label": "Malware Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7790,
+    "id": 8522,
     "skill_label": "Manual Testing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7791,
+    "id": 8523,
     "skill_label": "Manufacturing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7792,
+    "id": 8524,
     "skill_label": "Marketing Analytics",
     "esco_uri": "http://data.europa.eu/esco/skill/11c56452-fcec-4b00-9695-cca4728e5048",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7793,
+    "id": 8525,
     "skill_label": "Marketing Leadership",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7794,
+    "id": 8526,
     "skill_label": "Market Positioning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7795,
+    "id": 8527,
     "skill_label": "Master's Degree in Computer Science",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7796,
+    "id": 8528,
     "skill_label": "Matlab",
     "esco_uri": "http://data.europa.eu/esco/skill/7b0d5000-00da-4864-b776-6de49a87a669",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7797,
+    "id": 8529,
     "skill_label": "Mechanical Drawings",
     "esco_uri": "http://data.europa.eu/esco/skill/59ea80e1-463a-4dba-82c6-d0b6d577d532",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7798,
+    "id": 8530,
     "skill_label": "Mechanical Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7799,
+    "id": 8531,
     "skill_label": "Mechatronics",
     "esco_uri": "http://data.europa.eu/esco/skill/e87ec79a-c9ff-46f5-84fa-7a0f394cdf40",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7800,
+    "id": 8532,
     "skill_label": "Mechatronics Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7801,
+    "id": 8533,
     "skill_label": "Medical Laboratory Procedures",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7802,
+    "id": 8534,
     "skill_label": "Meeting Coordination",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7803,
+    "id": 8535,
     "skill_label": "Mentoring",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 4,
     "employer_count": 3,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7804,
+    "id": 8536,
     "skill_label": "Metrics definition",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7805,
+    "id": 8537,
     "skill_label": "Microcontrollers",
     "esco_uri": "http://data.europa.eu/esco/skill/9ef0f3a0-9ce2-4ef1-a987-0366b5cb2dbe",
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7806,
+    "id": 8538,
     "skill_label": "Microservices",
     "esco_uri": "Microservices",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7807,
+    "id": 8539,
     "skill_label": "Microsoft Azure AI",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7808,
+    "id": 8540,
     "skill_label": "Microsoft Azure Network Engineer Associate",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7809,
+    "id": 8541,
     "skill_label": "Microsoft Office",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7810,
+    "id": 8542,
     "skill_label": "Microsoft Office Suite",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7811,
+    "id": 8543,
     "skill_label": "Microsoft Teams",
     "esco_uri": "http://data.europa.eu/esco/skill/d7e4a9fa-cfc2-45f9-96eb-13dc6e48c86c",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7812,
+    "id": 8544,
     "skill_label": "Microsoft Windows",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7813,
+    "id": 8545,
     "skill_label": "Military Working Dog Handling",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7814,
+    "id": 8546,
     "skill_label": "Missile Maintenance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7815,
+    "id": 8547,
     "skill_label": "Model Context Protocols",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7816,
+    "id": 8548,
     "skill_label": "Model Deployment",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7817,
+    "id": 8549,
     "skill_label": "model development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7818,
+    "id": 8550,
     "skill_label": "Model Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7819,
+    "id": 8551,
     "skill_label": "Modeling and Simulation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7820,
+    "id": 8552,
     "skill_label": "Model Monitoring",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7821,
+    "id": 8553,
     "skill_label": "Model-View-Controller (MVC)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7822,
+    "id": 8554,
     "skill_label": "Modular Software Design",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7823,
+    "id": 8555,
     "skill_label": "Module Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7824,
+    "id": 8556,
     "skill_label": "Monitoring and Performance Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7825,
+    "id": 8557,
     "skill_label": "MPLS",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7826,
+    "id": 8558,
     "skill_label": "Multi-threaded Programming",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7827,
+    "id": 8559,
     "skill_label": "Multithreading",
     "esco_uri": "Multithreading",
     "week_start": "2026-04-20",
     "posting_count": 3,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7828,
+    "id": 8560,
     "skill_label": "Multi-turn System Interactions",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7829,
+    "id": 8561,
     "skill_label": "MySQL",
     "esco_uri": "http://data.europa.eu/esco/skill/4da171e5-779c-4983-a76f-91c16751e99f",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7830,
+    "id": 8562,
     "skill_label": "natural language processing",
     "esco_uri": "http://data.europa.eu/esco/skill/fff0e2cd-d0bd-4b02-9daf-158b79d9688a",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7831,
+    "id": 8563,
     "skill_label": "Natural Language Processing",
     "esco_uri": "http://data.europa.eu/esco/skill/fff0e2cd-d0bd-4b02-9daf-158b79d9688a",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7832,
+    "id": 8564,
     "skill_label": "NCMA Certification",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7833,
+    "id": 8565,
     "skill_label": "Netezza Performance Server",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7834,
+    "id": 8566,
     "skill_label": "Network Access Control",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7835,
+    "id": 8567,
     "skill_label": "Network Administration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7836,
+    "id": 8568,
     "skill_label": "Network Automation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7837,
+    "id": 8569,
     "skill_label": "Network Configuration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7838,
+    "id": 8570,
     "skill_label": "Network Design",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7839,
+    "id": 8571,
     "skill_label": "Network Engineering",
     "esco_uri": "http://data.europa.eu/esco/skill/02058de6-4b98-449f-8a45-8588b0eb2446",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7840,
+    "id": 8572,
     "skill_label": "Network Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7841,
+    "id": 8573,
     "skill_label": "Network Monitoring",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7842,
+    "id": 8574,
     "skill_label": "Network Performance Troubleshooting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7843,
+    "id": 8575,
     "skill_label": "Network Security",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 3,
     "employer_count": 3,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7844,
+    "id": 8576,
     "skill_label": "Network Security Groups",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7845,
+    "id": 8577,
     "skill_label": "Network Security Policies",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7846,
+    "id": 8578,
     "skill_label": "Network Segmentation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7847,
+    "id": 8579,
     "skill_label": "Network Troubleshooting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7848,
+    "id": 8580,
     "skill_label": "NLP",
     "esco_uri": "http://data.europa.eu/esco/skill/fff0e2cd-d0bd-4b02-9daf-158b79d9688a",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7849,
+    "id": 8581,
     "skill_label": "Node.js",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7850,
+    "id": 8582,
     "skill_label": "Non-lethal Weapons Handling",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7851,
+    "id": 8583,
     "skill_label": "Numerical Simulation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7852,
+    "id": 8584,
     "skill_label": "Object Detection",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7853,
+    "id": 8585,
     "skill_label": "Object-Oriented Programming",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7854,
+    "id": 8586,
     "skill_label": "Office 365",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7855,
+    "id": 8587,
     "skill_label": "Operational Maintenance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7856,
+    "id": 8588,
     "skill_label": "Operational Troubleshooting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7857,
+    "id": 8589,
     "skill_label": "Operations Research",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7858,
+    "id": 8590,
     "skill_label": "Optical Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7859,
+    "id": 8591,
     "skill_label": "Optimization",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7860,
+    "id": 8592,
     "skill_label": "Oral Communication",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7861,
+    "id": 8593,
     "skill_label": "Oscilloscope",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7862,
+    "id": 8594,
     "skill_label": "Oscilloscope Usage",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7863,
+    "id": 8595,
     "skill_label": "OSHA Compliance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7864,
+    "id": 8596,
     "skill_label": "OSPF",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7865,
+    "id": 8597,
     "skill_label": "Packaging, Handling, Storage and Transportation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7866,
+    "id": 8598,
     "skill_label": "Palo Alto Networks Firewalls",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7867,
+    "id": 8599,
     "skill_label": "Patrol Procedures",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7868,
+    "id": 8600,
     "skill_label": "Payroll Processing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7869,
+    "id": 8601,
     "skill_label": "Penetration Testing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7870,
+    "id": 8602,
     "skill_label": "Performance Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7871,
+    "id": 8603,
     "skill_label": "Performance Metrics Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7872,
+    "id": 8604,
     "skill_label": "Performance Optimization",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 3,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7873,
+    "id": 8605,
     "skill_label": "Performance Testing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7874,
+    "id": 8606,
     "skill_label": "Performance Test Plan Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7875,
+    "id": 8607,
     "skill_label": "Performance Tuning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7876,
+    "id": 8608,
     "skill_label": "Peripheral Communication Protocols",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7877,
+    "id": 8609,
     "skill_label": "Peripheral Driver Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7878,
+    "id": 8610,
     "skill_label": "Peripheral Drivers",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7879,
+    "id": 8611,
     "skill_label": "PGP Encryption",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7880,
+    "id": 8612,
     "skill_label": "Physical Fitness",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7881,
+    "id": 8613,
     "skill_label": "Physical Security",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7882,
+    "id": 8614,
     "skill_label": "Physics",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7883,
+    "id": 8615,
     "skill_label": "Physics Modeling",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7884,
+    "id": 8616,
     "skill_label": "Platform Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7885,
+    "id": 8617,
     "skill_label": "PLC Programming Languages",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7886,
+    "id": 8618,
     "skill_label": "Point of Sale (POS) Systems",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7887,
+    "id": 8619,
     "skill_label": "Pose Estimation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7888,
+    "id": 8620,
     "skill_label": "Positioning and Messaging",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7889,
+    "id": 8621,
     "skill_label": "Predictive Analytics",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7890,
+    "id": 8622,
     "skill_label": "Predictive Modeling",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7891,
+    "id": 8623,
     "skill_label": "Pre-sales Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7892,
+    "id": 8624,
     "skill_label": "Presentation Skills",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7893,
+    "id": 8625,
     "skill_label": "Pricing Strategy",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7894,
+    "id": 8626,
     "skill_label": "Prisma",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7895,
+    "id": 8627,
     "skill_label": "Problem Design",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7896,
+    "id": 8628,
     "skill_label": "Problem Solving",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 6,
     "employer_count": 6,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7897,
+    "id": 8629,
     "skill_label": "Process Improvement",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7898,
+    "id": 8630,
     "skill_label": "Product Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7899,
+    "id": 8631,
     "skill_label": "Production Implementation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7900,
+    "id": 8632,
     "skill_label": "Product Launch",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7901,
+    "id": 8633,
     "skill_label": "Product Lifecycle Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7902,
+    "id": 8634,
     "skill_label": "Product Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7903,
+    "id": 8635,
     "skill_label": "Product Marketing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7904,
+    "id": 8636,
     "skill_label": "Product Owner Certification",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7905,
+    "id": 8637,
     "skill_label": "Product Planning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7906,
+    "id": 8638,
     "skill_label": "Product Qualification",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7907,
+    "id": 8639,
     "skill_label": "Product Roadmap Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7908,
+    "id": 8640,
     "skill_label": "Product Roadmap Planning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7909,
+    "id": 8641,
     "skill_label": "Product Strategy",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7910,
+    "id": 8642,
     "skill_label": "Product Thinking",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7911,
+    "id": 8643,
     "skill_label": "Programmable Logic Controllers (PLC)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7912,
+    "id": 8644,
     "skill_label": "Programmable Logic Controllers (PLC) Programming",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7913,
+    "id": 8645,
     "skill_label": "Program Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7914,
+    "id": 8646,
     "skill_label": "Programming",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 3,
     "employer_count": 3,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7915,
+    "id": 8647,
     "skill_label": "Programming Languages",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7916,
+    "id": 8648,
     "skill_label": "Project-Based Learning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7917,
+    "id": 8649,
     "skill_label": "Project Cost Estimation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7918,
+    "id": 8650,
     "skill_label": "Project Design",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7919,
+    "id": 8651,
     "skill_label": "Project Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7920,
+    "id": 8652,
     "skill_label": "Project Planning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7921,
+    "id": 8653,
     "skill_label": "Project Quantity Estimation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7922,
+    "id": 8654,
     "skill_label": "Project Work",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7923,
+    "id": 8655,
     "skill_label": "prompt engineering",
     "esco_uri": "http://data.europa.eu/esco/skill/f5369f2f-e52b-43d8-8d31-79a6c11188d8",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7924,
+    "id": 8656,
     "skill_label": "Proposal Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7925,
+    "id": 8657,
     "skill_label": "Proposal Evaluation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7926,
+    "id": 8658,
     "skill_label": "Protective Services",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7927,
+    "id": 8659,
     "skill_label": "Public Health Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7928,
+    "id": 8660,
     "skill_label": "Public Key Infrastructure (PKI)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7929,
+    "id": 8661,
     "skill_label": "Python",
     "esco_uri": "http://data.europa.eu/esco/skill/ccd0a1d9-afda-43d9-b901-96344886e14d",
     "week_start": "2026-04-20",
     "posting_count": 6,
     "employer_count": 5,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7930,
+    "id": 8662,
     "skill_label": "QA Automation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7931,
+    "id": 8663,
     "skill_label": "Quality Assurance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7932,
+    "id": 8664,
     "skill_label": "Quality Control",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7933,
+    "id": 8665,
     "skill_label": "Quality Management System",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7934,
+    "id": 8666,
     "skill_label": "Quantitative Analysis",
     "esco_uri": "http://data.europa.eu/esco/skill/6360a934-cc87-4954-9656-b32db20592e3",
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7935,
+    "id": 8667,
     "skill_label": "Radar Systems Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7936,
+    "id": 8668,
     "skill_label": "Radiologic Technology",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7937,
+    "id": 8669,
     "skill_label": "Radiologic Technology Education",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7938,
+    "id": 8670,
     "skill_label": "Reading and Interpreting Technical Diagrams",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7939,
+    "id": 8671,
     "skill_label": "Reading Technical Documentation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7940,
+    "id": 8672,
     "skill_label": "Real-time Embedded Systems",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7941,
+    "id": 8673,
     "skill_label": "Real-Time Operating Systems (RTOS)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7942,
+    "id": 8674,
     "skill_label": "Red Teaming",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7943,
+    "id": 8675,
     "skill_label": "Regression Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7944,
+    "id": 8676,
     "skill_label": "Regulatory compliance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7945,
+    "id": 8677,
     "skill_label": "Release Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7946,
+    "id": 8678,
     "skill_label": "Reporting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7947,
+    "id": 8679,
     "skill_label": "Report Preparation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7948,
+    "id": 8680,
     "skill_label": "Report Writing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7949,
+    "id": 8681,
     "skill_label": "Requirements Allocation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7950,
+    "id": 8682,
     "skill_label": "Requirements Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7951,
+    "id": 8683,
     "skill_label": "Requirements Gathering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 3,
     "employer_count": 3,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7952,
+    "id": 8684,
     "skill_label": "Research Autonomy",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7953,
+    "id": 8685,
     "skill_label": "Responsive Web Design",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7954,
+    "id": 8686,
     "skill_label": "REST APIs",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 5,
     "employer_count": 5,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7955,
+    "id": 8687,
     "skill_label": "Retail Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7956,
+    "id": 8688,
     "skill_label": "Retail Sales",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7957,
+    "id": 8689,
     "skill_label": "Reverse Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7958,
+    "id": 8690,
     "skill_label": "RFP Responses",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7959,
+    "id": 8691,
     "skill_label": "Risk Assessment",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 3,
     "employer_count": 3,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7960,
+    "id": 8692,
     "skill_label": "Risk-based Testing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7961,
+    "id": 8693,
     "skill_label": "Risk Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7962,
+    "id": 8694,
     "skill_label": "Role-Based Access Control",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7963,
+    "id": 8695,
     "skill_label": "Root Cause Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7964,
+    "id": 8696,
     "skill_label": "Routing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7965,
+    "id": 8697,
     "skill_label": "Rubric Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7966,
+    "id": 8698,
     "skill_label": "Rust",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7967,
+    "id": 8699,
     "skill_label": "Safety Equipment Maintenance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7968,
+    "id": 8700,
     "skill_label": "Safety Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7969,
+    "id": 8701,
     "skill_label": "Sales Enablement",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7970,
+    "id": 8702,
     "skill_label": "Salesforce",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7971,
+    "id": 8703,
     "skill_label": "Sales Promotion",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7972,
+    "id": 8704,
     "skill_label": "SAS",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7973,
+    "id": 8705,
     "skill_label": "Schedule Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7974,
+    "id": 8706,
     "skill_label": "Scheduling",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7975,
+    "id": 8707,
     "skill_label": "Scientific Computing",
     "esco_uri": "http://data.europa.eu/esco/skill/5b26f08b-88bc-45f0-b901-530d7786466b",
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7976,
+    "id": 8708,
     "skill_label": "Scientific Reasoning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7977,
+    "id": 8709,
     "skill_label": "Scientific Research",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7978,
+    "id": 8710,
     "skill_label": "Scikit-Learn",
     "esco_uri": "http://data.europa.eu/esco/skill/484df271-bb52-49f1-8f50-f19624bf4df2",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7979,
+    "id": 8711,
     "skill_label": "SciPy",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7980,
+    "id": 8712,
     "skill_label": "Scripting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7981,
+    "id": 8713,
     "skill_label": "Scripting Languages",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7982,
+    "id": 8714,
     "skill_label": "Search Engine Optimization",
     "esco_uri": "http://data.europa.eu/esco/skill/eda4d727-4374-49af-ace4-118c7c906835",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7983,
+    "id": 8715,
     "skill_label": "Secure Coding",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7984,
+    "id": 8716,
     "skill_label": "Security",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7985,
+    "id": 8717,
     "skill_label": "Security Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7986,
+    "id": 8718,
     "skill_label": "Security Architecture",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7987,
+    "id": 8719,
     "skill_label": "Security Clearance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 5,
     "employer_count": 5,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7988,
+    "id": 8720,
     "skill_label": "Security Compliance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7989,
+    "id": 8721,
     "skill_label": "Security Gap Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7990,
+    "id": 8722,
     "skill_label": "Security Monitoring",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7991,
+    "id": 8723,
     "skill_label": "Security Operations",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7992,
+    "id": 8724,
     "skill_label": "Security Operations Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7993,
+    "id": 8725,
     "skill_label": "Security Patrol",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7994,
+    "id": 8726,
     "skill_label": "Security Reporting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7995,
+    "id": 8727,
     "skill_label": "Security Testing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7996,
+    "id": 8728,
     "skill_label": "Security Training",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7997,
+    "id": 8729,
     "skill_label": "Semantic Segmentation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7998,
+    "id": 8730,
     "skill_label": "Service Bus",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 7999,
+    "id": 8731,
     "skill_label": "SFTP",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8000,
+    "id": 8732,
     "skill_label": "Shell Scripting",
     "esco_uri": "Shell Script",
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8001,
+    "id": 8733,
     "skill_label": "Shift Scheduling",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8002,
+    "id": 8734,
     "skill_label": "Shipping Order Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8003,
+    "id": 8735,
     "skill_label": "Shipping Requirements Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8004,
+    "id": 8736,
     "skill_label": "Simulation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8005,
+    "id": 8737,
     "skill_label": "Small Arms Handling",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8006,
+    "id": 8738,
     "skill_label": "SOAP APIs",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8007,
+    "id": 8739,
     "skill_label": "Social Media Marketing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8008,
+    "id": 8740,
     "skill_label": "Software and System Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8009,
+    "id": 8741,
     "skill_label": "Software Architecture",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8010,
+    "id": 8742,
     "skill_label": "Software as a Service (SaaS)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8011,
+    "id": 8743,
     "skill_label": "Software Assurance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8012,
+    "id": 8744,
     "skill_label": "Software Code Review",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8013,
+    "id": 8745,
     "skill_label": "Software Design",
     "esco_uri": "http://data.europa.eu/esco/skill/89f6560b-2194-45c9-9ece-d33049a73eef",
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8014,
+    "id": 8746,
     "skill_label": "Software Design Principles",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8015,
+    "id": 8747,
     "skill_label": "Software Development",
     "esco_uri": "Software Development",
     "week_start": "2026-04-20",
     "posting_count": 7,
     "employer_count": 4,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8016,
+    "id": 8748,
     "skill_label": "Software Development Lifecycle",
     "esco_uri": "Software Development Life Cycle",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8017,
+    "id": 8749,
     "skill_label": "Software Development Life Cycle",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8018,
+    "id": 8750,
     "skill_label": "Software Development Processes",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8019,
+    "id": 8751,
     "skill_label": "Software Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 5,
     "employer_count": 4,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8020,
+    "id": 8752,
     "skill_label": "Software Monitoring",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8021,
+    "id": 8753,
     "skill_label": "Software Prototyping",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8022,
+    "id": 8754,
     "skill_label": "Software Testing",
     "esco_uri": "Software Testing",
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8023,
+    "id": 8755,
     "skill_label": "Software Troubleshooting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8024,
+    "id": 8756,
     "skill_label": "Software Verification",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8025,
+    "id": 8757,
     "skill_label": "Solution Architecture",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8026,
+    "id": 8758,
     "skill_label": "Solution Selling",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8027,
+    "id": 8759,
     "skill_label": "Special Chemistry",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8028,
+    "id": 8760,
     "skill_label": "SPI",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8029,
+    "id": 8761,
     "skill_label": "SQL",
     "esco_uri": "http://data.europa.eu/esco/skill/ab1e97ed-2319-4293-a8b7-072d2648822f",
     "week_start": "2026-04-20",
     "posting_count": 4,
     "employer_count": 4,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8030,
+    "id": 8762,
     "skill_label": "SQL Databases",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8031,
+    "id": 8763,
     "skill_label": "Staff Supervision",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8032,
+    "id": 8764,
     "skill_label": "Stakeholder Communication",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 3,
     "employer_count": 3,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8033,
+    "id": 8765,
     "skill_label": "Stakeholder Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8034,
+    "id": 8766,
     "skill_label": "Standard Operating Procedures (SOP)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8035,
+    "id": 8767,
     "skill_label": "Statistical Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 4,
     "employer_count": 4,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8036,
+    "id": 8768,
     "skill_label": "Statistical Inference",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8037,
+    "id": 8769,
     "skill_label": "Statistical Methods",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8038,
+    "id": 8770,
     "skill_label": "Statistical Reasoning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8039,
+    "id": 8771,
     "skill_label": "statistical techniques",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8040,
+    "id": 8772,
     "skill_label": "Statistics",
     "esco_uri": "Statistics",
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8041,
+    "id": 8773,
     "skill_label": "STEM Degree",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8042,
+    "id": 8774,
     "skill_label": "Store Operations",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8043,
+    "id": 8775,
     "skill_label": "Strategic Decision-Making with Data",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8044,
+    "id": 8776,
     "skill_label": "Strategic Thinking",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8045,
+    "id": 8777,
     "skill_label": "Structural Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8046,
+    "id": 8778,
     "skill_label": "Supply Chain Risk Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8047,
+    "id": 8779,
     "skill_label": "Surveying",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8048,
+    "id": 8780,
     "skill_label": "Sustainable Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8049,
+    "id": 8781,
     "skill_label": "Swift",
     "esco_uri": "http://data.europa.eu/esco/skill/be80acfc-b6f2-4411-9b8d-b19d9cd2556a",
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8050,
+    "id": 8782,
     "skill_label": "SwiftUI",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8051,
+    "id": 8783,
     "skill_label": "Switching",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8052,
+    "id": 8784,
     "skill_label": "System Initialization",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8053,
+    "id": 8785,
     "skill_label": "System Integration",
     "esco_uri": "http://data.europa.eu/esco/skill/6fa1c2c0-a012-4ca0-9642-e01569ba322c",
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8054,
+    "id": 8786,
     "skill_label": "System-Level Software Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8055,
+    "id": 8787,
     "skill_label": "System Performance Evaluation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8056,
+    "id": 8788,
     "skill_label": "Systems Design",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8057,
+    "id": 8789,
     "skill_label": "Systems Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8058,
+    "id": 8790,
     "skill_label": "System Software Specifications",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8059,
+    "id": 8791,
     "skill_label": "Systems Requirements Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8060,
+    "id": 8792,
     "skill_label": "Systems Security Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8061,
+    "id": 8793,
     "skill_label": "Systems Software Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8062,
+    "id": 8794,
     "skill_label": "System Testing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8063,
+    "id": 8795,
     "skill_label": "Tactical Skills",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8064,
+    "id": 8796,
     "skill_label": "Tailwind CSS",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8065,
+    "id": 8797,
     "skill_label": "TCP/IP",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8066,
+    "id": 8798,
     "skill_label": "Team Leadership",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8067,
+    "id": 8799,
     "skill_label": "Team Scaling",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8068,
+    "id": 8800,
     "skill_label": "Team Supervision",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8069,
+    "id": 8801,
     "skill_label": "Teamwork",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8070,
+    "id": 8802,
     "skill_label": "Technical Documentation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 3,
     "employer_count": 3,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8071,
+    "id": 8803,
     "skill_label": "Technical Feedback",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8072,
+    "id": 8804,
     "skill_label": "Technical Interview Preparation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8073,
+    "id": 8805,
     "skill_label": "Technical Report Writing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8074,
+    "id": 8806,
     "skill_label": "Technical Sales",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8075,
+    "id": 8807,
     "skill_label": "Technical Support / Troubleshooting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8076,
+    "id": 8808,
     "skill_label": "Technical Training",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8077,
+    "id": 8809,
     "skill_label": "Technical Workshops",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8078,
+    "id": 8810,
     "skill_label": "Technical Writing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 4,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8079,
+    "id": 8811,
     "skill_label": "Terraform",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8080,
+    "id": 8812,
     "skill_label": "Test Automation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8081,
+    "id": 8813,
     "skill_label": "Test Automation Frameworks",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8082,
+    "id": 8814,
     "skill_label": "Test Case Design",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8083,
+    "id": 8815,
     "skill_label": "Testing Methodologies",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8084,
+    "id": 8816,
     "skill_label": "Test Planning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8085,
+    "id": 8817,
     "skill_label": "Test Systems Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8086,
+    "id": 8818,
     "skill_label": "Texas Certified Medical Radiological Technologist",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8087,
+    "id": 8819,
     "skill_label": "Threat Intelligence",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8088,
+    "id": 8820,
     "skill_label": "Time Series Analysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8089,
+    "id": 8821,
     "skill_label": "Trade Studies",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8090,
+    "id": 8822,
     "skill_label": "Training and Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8091,
+    "id": 8823,
     "skill_label": "Training and Mentoring",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8092,
+    "id": 8824,
     "skill_label": "Transportation Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8093,
+    "id": 8825,
     "skill_label": "Trauma-Informed Care Knowledge",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8094,
+    "id": 8826,
     "skill_label": "Troubleshooting",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8095,
+    "id": 8827,
     "skill_label": "TS/SCI Security Clearance",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8096,
+    "id": 8828,
     "skill_label": "Type Confusion Vulnerability",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8097,
+    "id": 8829,
     "skill_label": "TypeScript",
     "esco_uri": "http://data.europa.eu/esco/skill/867137fb-ff1b-4ca3-99f3-cb6969aa2c68",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8098,
+    "id": 8830,
     "skill_label": "UART",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8099,
+    "id": 8831,
     "skill_label": "UiPath Developer Certification",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8100,
+    "id": 8832,
     "skill_label": "UiPath REFramework",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8101,
+    "id": 8833,
     "skill_label": "UiPath RPA Development",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8102,
+    "id": 8834,
     "skill_label": "UiPath Studio",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8103,
+    "id": 8835,
     "skill_label": "Unix",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8104,
+    "id": 8836,
     "skill_label": "Urban and Regional Planning",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8105,
+    "id": 8837,
     "skill_label": "Urinalysis",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8106,
+    "id": 8838,
     "skill_label": "U.S. Army Material Maintenance Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8107,
+    "id": 8839,
     "skill_label": "USB",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8108,
+    "id": 8840,
     "skill_label": "USB Protocol",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8109,
+    "id": 8841,
     "skill_label": "Use-After-Free Vulnerability",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8110,
+    "id": 8842,
     "skill_label": "Use of Force",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8111,
+    "id": 8843,
     "skill_label": "User Authentication",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8112,
+    "id": 8844,
     "skill_label": "User Experience",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8113,
+    "id": 8845,
     "skill_label": "Validation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8114,
+    "id": 8846,
     "skill_label": "Vehicle Functional Architecture",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8115,
+    "id": 8847,
     "skill_label": "Vendor and Manufacturer Liaison",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8116,
+    "id": 8848,
     "skill_label": "Vendor management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8117,
+    "id": 8849,
     "skill_label": "Verification",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8118,
+    "id": 8850,
     "skill_label": "Verification and Validation",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8119,
+    "id": 8851,
     "skill_label": "Version Control",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 2,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8120,
+    "id": 8852,
     "skill_label": "Virtual Machines",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8121,
+    "id": 8853,
     "skill_label": "Virtual Networks",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8122,
+    "id": 8854,
     "skill_label": "Virtual Private Networks (VPNs)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8123,
+    "id": 8855,
     "skill_label": "Virtual WAN",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8124,
+    "id": 8856,
     "skill_label": "Vision Transformers",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8125,
+    "id": 8857,
     "skill_label": "Visual Merchandising",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8126,
+    "id": 8858,
     "skill_label": "VPN",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8127,
+    "id": 8859,
     "skill_label": "Vulnerability Discovery",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8128,
+    "id": 8860,
     "skill_label": "Vulnerability Management",
     "esco_uri": "Vulnerability Management",
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8129,
+    "id": 8861,
     "skill_label": "Warehouse Operations",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8130,
+    "id": 8862,
     "skill_label": "Water Resources Engineering",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8131,
+    "id": 8863,
     "skill_label": "Wealth Management",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8132,
+    "id": 8864,
     "skill_label": "Weapons Qualification",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8133,
+    "id": 8865,
     "skill_label": "Web Application Testing",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8134,
+    "id": 8866,
     "skill_label": "Wide Area Networks (WAN)",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8135,
+    "id": 8867,
     "skill_label": "Windows Active Directory",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8136,
+    "id": 8868,
     "skill_label": "Wireless Networking",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8137,
+    "id": 8869,
     "skill_label": "Workday Certification",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8138,
+    "id": 8870,
     "skill_label": "Workday Core Connectors",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8139,
+    "id": 8871,
     "skill_label": "Workday EIB",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8140,
+    "id": 8872,
     "skill_label": "Workday Integrations",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8141,
+    "id": 8873,
     "skill_label": "Workday Studio",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8142,
+    "id": 8874,
     "skill_label": "Workflow Orchestration",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8143,
+    "id": 8875,
     "skill_label": "Writing User Stories",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8144,
+    "id": 8876,
     "skill_label": "Written Communication",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 4,
     "employer_count": 2,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
-    "id": 8145,
+    "id": 8877,
     "skill_label": "Zero Trust Architecture",
     "esco_uri": null,
     "week_start": "2026-04-20",
     "posting_count": 1,
     "employer_count": 1,
-    "computed_at": "2026-04-28T23:43:21.230024+00:00"
+    "computed_at": "2026-04-29T05:53:53.426870+00:00"
   },
   {
     "id": 6718,

--- a/scripts/pg-seed-data/fixtures/skill_velocity.json
+++ b/scripts/pg-seed-data/fixtures/skill_velocity.json
@@ -22400,7 +22400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9299,
+    "id": 11907,
     "skill_label": ".NET",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22410,7 +22410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9300,
+    "id": 11908,
     "skill_label": ".NET Framework",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22420,7 +22420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9301,
+    "id": 11909,
     "skill_label": ".NET MAUI",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22430,7 +22430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9302,
+    "id": 11910,
     "skill_label": "5S",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22440,7 +22440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9303,
+    "id": 11911,
     "skill_label": "A/B Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22450,7 +22450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9304,
+    "id": 11912,
     "skill_label": "ABET Accreditation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22460,7 +22460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9305,
+    "id": 11913,
     "skill_label": "AI",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22470,7 +22470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9306,
+    "id": 11914,
     "skill_label": "AI Agents",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22480,7 +22480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9307,
+    "id": 11915,
     "skill_label": "AI Applications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22490,7 +22490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9308,
+    "id": 11916,
     "skill_label": "AI Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22500,7 +22500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9309,
+    "id": 11917,
     "skill_label": "AI Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22510,7 +22510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9310,
+    "id": 11918,
     "skill_label": "AI Behavioral Safety",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22520,7 +22520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9311,
+    "id": 11919,
     "skill_label": "AI Code Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22530,7 +22530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9312,
+    "id": 11920,
     "skill_label": "AI Configuration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22540,7 +22540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9313,
+    "id": 11921,
     "skill_label": "AI Data Pipelines",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22550,7 +22550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9314,
+    "id": 11922,
     "skill_label": "AI Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22560,7 +22560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9315,
+    "id": 11923,
     "skill_label": "AI Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22570,7 +22570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9316,
+    "id": 11924,
     "skill_label": "AI Ethics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22580,7 +22580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9317,
+    "id": 11925,
     "skill_label": "AI Explainability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22590,7 +22590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9318,
+    "id": 11926,
     "skill_label": "AI Governance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22600,7 +22600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9319,
+    "id": 11927,
     "skill_label": "AI Implementation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22610,7 +22610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9320,
+    "id": 11928,
     "skill_label": "AI Infrastructure",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22620,7 +22620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9321,
+    "id": 11929,
     "skill_label": "AI Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22630,7 +22630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9322,
+    "id": 11930,
     "skill_label": "AI Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22640,7 +22640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9323,
+    "id": 11931,
     "skill_label": "AI Lifecycle Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22650,7 +22650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9324,
+    "id": 11932,
     "skill_label": "AI Model Deployment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22660,7 +22660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9325,
+    "id": 11933,
     "skill_label": "AI Model Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22670,7 +22670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9326,
+    "id": 11934,
     "skill_label": "AI Model Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22680,7 +22680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9327,
+    "id": 11935,
     "skill_label": "AI Model Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22690,7 +22690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9328,
+    "id": 11936,
     "skill_label": "AI Model Retraining",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22700,7 +22700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9329,
+    "id": 11937,
     "skill_label": "AI Model Training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22710,7 +22710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9330,
+    "id": 11938,
     "skill_label": "AI Model Versioning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22720,7 +22720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9331,
+    "id": 11939,
     "skill_label": "AI Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22730,7 +22730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9332,
+    "id": 11940,
     "skill_label": "AI Platform Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22740,7 +22740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9333,
+    "id": 11941,
     "skill_label": "AI Research Translation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22750,7 +22750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9334,
+    "id": 11942,
     "skill_label": "AI Safety",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22760,7 +22760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9335,
+    "id": 11943,
     "skill_label": "AI Safety Design Patterns",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22770,7 +22770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9336,
+    "id": 11944,
     "skill_label": "AI Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22780,7 +22780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9337,
+    "id": 11945,
     "skill_label": "AI Security Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22790,7 +22790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9338,
+    "id": 11946,
     "skill_label": "AI Skill Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22800,7 +22800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9339,
+    "id": 11947,
     "skill_label": "AI Solution Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22810,7 +22810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9340,
+    "id": 11948,
     "skill_label": "AI System Governance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22820,7 +22820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9341,
+    "id": 11949,
     "skill_label": "AI product roadmap",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22830,7 +22830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9342,
+    "id": 11950,
     "skill_label": "AI-assisted Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22840,7 +22840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9343,
+    "id": 11951,
     "skill_label": "AI-assisted Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22850,7 +22850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9344,
+    "id": 11952,
     "skill_label": "AI-assisted Tools",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22860,7 +22860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9345,
+    "id": 11953,
     "skill_label": "AI-based Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22870,7 +22870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9346,
+    "id": 11954,
     "skill_label": "AI/ML Concepts",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22880,7 +22880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9347,
+    "id": 11955,
     "skill_label": "API",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22890,7 +22890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9348,
+    "id": 11956,
     "skill_label": "API Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22900,7 +22900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9349,
+    "id": 11957,
     "skill_label": "API Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22910,7 +22910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9350,
+    "id": 11958,
     "skill_label": "API Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22920,7 +22920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9351,
+    "id": 11959,
     "skill_label": "API Documentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22930,7 +22930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9352,
+    "id": 11960,
     "skill_label": "API Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22940,7 +22940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9353,
+    "id": 11961,
     "skill_label": "API Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22950,7 +22950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9354,
+    "id": 11962,
     "skill_label": "API Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22960,7 +22960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9355,
+    "id": 11963,
     "skill_label": "APICS CSCP",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22970,7 +22970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9356,
+    "id": 11964,
     "skill_label": "APIs",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22980,7 +22980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9357,
+    "id": 11965,
     "skill_label": "ARM Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -22990,7 +22990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9358,
+    "id": 11966,
     "skill_label": "AS9100 Quality Standards",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23000,7 +23000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9359,
+    "id": 11967,
     "skill_label": "ASP.NET MVC",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23010,7 +23010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9360,
+    "id": 11968,
     "skill_label": "AWS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23020,7 +23020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9361,
+    "id": 11969,
     "skill_label": "AWS Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23030,7 +23030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9362,
+    "id": 11970,
     "skill_label": "AWS Certified Security – Specialty",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23040,7 +23040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9363,
+    "id": 11971,
     "skill_label": "AWS Certified Solutions Architect",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23050,7 +23050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9364,
+    "id": 11972,
     "skill_label": "AWS Certified Solutions Architect – Professional",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23060,7 +23060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9365,
+    "id": 11973,
     "skill_label": "AWS Cloud",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23070,7 +23070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9366,
+    "id": 11974,
     "skill_label": "AWS Cloud Development Kit (CDK)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23080,7 +23080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9367,
+    "id": 11975,
     "skill_label": "AWS Cloud Services",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23090,7 +23090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9368,
+    "id": 11976,
     "skill_label": "AWS CloudFormation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23100,7 +23100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9369,
+    "id": 11977,
     "skill_label": "AWS Core Services",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23110,7 +23110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9370,
+    "id": 11978,
     "skill_label": "AWS EC2",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23120,7 +23120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9371,
+    "id": 11979,
     "skill_label": "AWS GovCloud",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23130,7 +23130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9372,
+    "id": 11980,
     "skill_label": "AWS IAM",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23140,7 +23140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9373,
+    "id": 11981,
     "skill_label": "AWS Lambda",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23150,7 +23150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9374,
+    "id": 11982,
     "skill_label": "AWS RDS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23160,7 +23160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9375,
+    "id": 11983,
     "skill_label": "AWS S3",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23170,7 +23170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9376,
+    "id": 11984,
     "skill_label": "AWS VPC",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23180,7 +23180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9377,
+    "id": 11985,
     "skill_label": "AWS Well-Architected Framework",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23190,7 +23190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9378,
+    "id": 11986,
     "skill_label": "AWS Workspaces",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23200,7 +23200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9379,
+    "id": 11987,
     "skill_label": "Abstract Algebra",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23210,7 +23210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9380,
+    "id": 11988,
     "skill_label": "Acceptance Criteria Definition",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23220,7 +23220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9381,
+    "id": 11989,
     "skill_label": "Access Control",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23230,7 +23230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9382,
+    "id": 11990,
     "skill_label": "Accessibility Compliance Auditing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23240,7 +23240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9383,
+    "id": 11991,
     "skill_label": "Accessibility Laws",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23250,7 +23250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9384,
+    "id": 11992,
     "skill_label": "Accessibility Standards",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23260,7 +23260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9385,
+    "id": 11993,
     "skill_label": "Account Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23270,7 +23270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9386,
+    "id": 11994,
     "skill_label": "Account Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23280,7 +23280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9387,
+    "id": 11995,
     "skill_label": "Accounting Principles",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23290,7 +23290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9388,
+    "id": 11996,
     "skill_label": "Accounting Software",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23300,7 +23300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9389,
+    "id": 11997,
     "skill_label": "Accounts Payable",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23310,7 +23310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9390,
+    "id": 11998,
     "skill_label": "Accreditation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23320,7 +23320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9391,
+    "id": 11999,
     "skill_label": "Acquisition Strategy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23330,7 +23330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9392,
+    "id": 12000,
     "skill_label": "Active Directory",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23340,7 +23340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9393,
+    "id": 12001,
     "skill_label": "Active Secret Clearance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23350,7 +23350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9394,
+    "id": 12002,
     "skill_label": "Actuarial Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23360,7 +23360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9395,
+    "id": 12003,
     "skill_label": "Adaptability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23370,7 +23370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9396,
+    "id": 12004,
     "skill_label": "Additive Manufacturing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23380,7 +23380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9397,
+    "id": 12005,
     "skill_label": "Advanced Analytics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23390,7 +23390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9398,
+    "id": 12006,
     "skill_label": "Advanced Cardiovascular Life Support (ACLS)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23400,7 +23400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9399,
+    "id": 12007,
     "skill_label": "Advanced Control Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23410,7 +23410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9400,
+    "id": 12008,
     "skill_label": "Advanced Data Analysis & Insight Generation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23420,7 +23420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9401,
+    "id": 12009,
     "skill_label": "Advanced Product Quality Planning (APQP)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23430,7 +23430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9402,
+    "id": 12010,
     "skill_label": "Advanced SQL",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23440,7 +23440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9403,
+    "id": 12011,
     "skill_label": "Adversarial Attacks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23450,7 +23450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9404,
+    "id": 12012,
     "skill_label": "Adversarial Machine Learning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23460,7 +23460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9405,
+    "id": 12013,
     "skill_label": "Adversarial Robustness",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23470,7 +23470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9406,
+    "id": 12014,
     "skill_label": "Adversarial Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23480,7 +23480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9407,
+    "id": 12015,
     "skill_label": "Aesthetic Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23490,7 +23490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9408,
+    "id": 12016,
     "skill_label": "Agency Experience",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23500,7 +23500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9409,
+    "id": 12017,
     "skill_label": "Agent + RAG System",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23510,7 +23510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9410,
+    "id": 12018,
     "skill_label": "Agent Frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23520,7 +23520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9411,
+    "id": 12019,
     "skill_label": "Agent-based Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23530,7 +23530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9412,
+    "id": 12020,
     "skill_label": "Agent-based Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23540,7 +23540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9413,
+    "id": 12021,
     "skill_label": "Agentic AI",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23550,7 +23550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9414,
+    "id": 12022,
     "skill_label": "Agentic Frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23560,7 +23560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9415,
+    "id": 12023,
     "skill_label": "Agentic Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23570,7 +23570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9416,
+    "id": 12024,
     "skill_label": "Agile",
     "esco_uri": "http://data.europa.eu/esco/skill/bec4359e-cb92-468f-a997-8fb28e32fba9",
     "week": "2026-04-20",
@@ -23580,7 +23580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9417,
+    "id": 12025,
     "skill_label": "Agile Business Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23590,7 +23590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9418,
+    "id": 12026,
     "skill_label": "Agile Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23600,7 +23600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9419,
+    "id": 12027,
     "skill_label": "Agile Methodologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23610,7 +23610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9420,
+    "id": 12028,
     "skill_label": "Agile Methodology",
     "esco_uri": "Agile Methodology",
     "week": "2026-04-20",
@@ -23620,7 +23620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9421,
+    "id": 12029,
     "skill_label": "Agile Software Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23630,7 +23630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9422,
+    "id": 12030,
     "skill_label": "Air Force Telecommunications Regulations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23640,7 +23640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9423,
+    "id": 12031,
     "skill_label": "Aircraft/Weapons System Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23650,7 +23650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9424,
+    "id": 12032,
     "skill_label": "Algorithm Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23660,7 +23660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9425,
+    "id": 12033,
     "skill_label": "Algorithms",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23670,7 +23670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9426,
+    "id": 12034,
     "skill_label": "All-Source Intelligence Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23680,7 +23680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9427,
+    "id": 12035,
     "skill_label": "Allen Bradley PLCs",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23690,7 +23690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9428,
+    "id": 12036,
     "skill_label": "Allen-Bradley",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23700,7 +23700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9429,
+    "id": 12037,
     "skill_label": "Alternate Sourcing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23710,7 +23710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9430,
+    "id": 12038,
     "skill_label": "Alternative Payment Models",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23720,7 +23720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9431,
+    "id": 12039,
     "skill_label": "Alteryx",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23730,7 +23730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9432,
+    "id": 12040,
     "skill_label": "Amazon API Gateway",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23740,7 +23740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9433,
+    "id": 12041,
     "skill_label": "Amazon CloudFront",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23750,7 +23750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9434,
+    "id": 12042,
     "skill_label": "Amazon CloudWatch",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23760,7 +23760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9435,
+    "id": 12043,
     "skill_label": "Amazon DynamoDB",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23770,7 +23770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9436,
+    "id": 12044,
     "skill_label": "Amazon EC2",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23780,7 +23780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9437,
+    "id": 12045,
     "skill_label": "Amazon Elastic Container Service (ECS)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23790,7 +23790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9438,
+    "id": 12046,
     "skill_label": "Amazon Elastic Kubernetes Service (EKS)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23800,7 +23800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9439,
+    "id": 12047,
     "skill_label": "Amazon Marketplace",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23810,7 +23810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9440,
+    "id": 12048,
     "skill_label": "Amazon RDS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23820,7 +23820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9441,
+    "id": 12049,
     "skill_label": "Amazon Relational Database Service (RDS)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23830,7 +23830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9442,
+    "id": 12050,
     "skill_label": "Amazon S3",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23840,7 +23840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9443,
+    "id": 12051,
     "skill_label": "Amazon VPC",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23850,7 +23850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9444,
+    "id": 12052,
     "skill_label": "Amazon Virtual Private Cloud (VPC)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23860,7 +23860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9445,
+    "id": 12053,
     "skill_label": "Amazon Web Services",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23870,7 +23870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9446,
+    "id": 12054,
     "skill_label": "Ambulatory Care",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23880,7 +23880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9447,
+    "id": 12055,
     "skill_label": "Ambulatory Revenue Cycle",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23890,7 +23890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9448,
+    "id": 12056,
     "skill_label": "American College of Surgeons Standards",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23900,7 +23900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9449,
+    "id": 12057,
     "skill_label": "American Registry of Radiologic Technologists (ARRT) Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23910,7 +23910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9450,
+    "id": 12058,
     "skill_label": "Analog Electronics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23920,7 +23920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9451,
+    "id": 12059,
     "skill_label": "Analytic Rule Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23930,7 +23930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9452,
+    "id": 12060,
     "skill_label": "Analytical Coding",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23940,7 +23940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9453,
+    "id": 12061,
     "skill_label": "Analytical Methodologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23950,7 +23950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9454,
+    "id": 12062,
     "skill_label": "Analytical Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23960,7 +23960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9455,
+    "id": 12063,
     "skill_label": "Analytical Reporting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23970,7 +23970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9456,
+    "id": 12064,
     "skill_label": "Analytical Skills",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23980,7 +23980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9457,
+    "id": 12065,
     "skill_label": "Analytical Thinking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -23990,7 +23990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9458,
+    "id": 12066,
     "skill_label": "Analytics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24000,7 +24000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9459,
+    "id": 12067,
     "skill_label": "Analytics Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24010,7 +24010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9460,
+    "id": 12068,
     "skill_label": "Android",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24020,7 +24020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9461,
+    "id": 12069,
     "skill_label": "Android Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24030,7 +24030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9462,
+    "id": 12070,
     "skill_label": "Anti-Tamper",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24040,7 +24040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9463,
+    "id": 12071,
     "skill_label": "Apache",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24050,7 +24050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9464,
+    "id": 12072,
     "skill_label": "Apache Airflow",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24060,7 +24060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9465,
+    "id": 12073,
     "skill_label": "Apache Kafka",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24070,7 +24070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9466,
+    "id": 12074,
     "skill_label": "Apache NiFi",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24080,7 +24080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9467,
+    "id": 12075,
     "skill_label": "Apache Spark",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24090,7 +24090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9468,
+    "id": 12076,
     "skill_label": "AppKit",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24100,7 +24100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9469,
+    "id": 12077,
     "skill_label": "Appian",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24110,7 +24110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9470,
+    "id": 12078,
     "skill_label": "Application Deployment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24120,7 +24120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9471,
+    "id": 12079,
     "skill_label": "Application Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24130,7 +24130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9472,
+    "id": 12080,
     "skill_label": "Application Lifecycle Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24140,7 +24140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9473,
+    "id": 12081,
     "skill_label": "Application Performance Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24150,7 +24150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9474,
+    "id": 12082,
     "skill_label": "Application Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24160,7 +24160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9475,
+    "id": 12083,
     "skill_label": "Application Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24170,7 +24170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9476,
+    "id": 12084,
     "skill_label": "Application Systems Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24180,7 +24180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9477,
+    "id": 12085,
     "skill_label": "Applied Analytics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24190,7 +24190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9478,
+    "id": 12086,
     "skill_label": "Applied Artificial Intelligence",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24200,7 +24200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9479,
+    "id": 12087,
     "skill_label": "Applied Machine Learning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24210,7 +24210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9480,
+    "id": 12088,
     "skill_label": "Applied Machine Learning Research",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24220,7 +24220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9481,
+    "id": 12089,
     "skill_label": "Applied Mathematics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24230,7 +24230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9482,
+    "id": 12090,
     "skill_label": "Applied Research",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24240,7 +24240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9483,
+    "id": 12091,
     "skill_label": "Aqua Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24250,7 +24250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9484,
+    "id": 12092,
     "skill_label": "Arc Flash Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24260,7 +24260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9485,
+    "id": 12093,
     "skill_label": "Architectural Standards",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24270,7 +24270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9486,
+    "id": 12094,
     "skill_label": "Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24280,7 +24280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9487,
+    "id": 12095,
     "skill_label": "Architecture Consulting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24290,7 +24290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9488,
+    "id": 12096,
     "skill_label": "Architecture Governance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24300,7 +24300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9489,
+    "id": 12097,
     "skill_label": "Architecture, Engineering, and Construction (AEC) Industry",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24310,7 +24310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9490,
+    "id": 12098,
     "skill_label": "Army Supply System",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24320,7 +24320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9491,
+    "id": 12099,
     "skill_label": "Artifact Repository Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24330,7 +24330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9492,
+    "id": 12100,
     "skill_label": "Artificial Intelligence",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24340,7 +24340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9493,
+    "id": 12101,
     "skill_label": "Aruba Switching",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24350,7 +24350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9494,
+    "id": 12102,
     "skill_label": "Aruba Wireless Networks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24360,7 +24360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9495,
+    "id": 12103,
     "skill_label": "As-a-Service Business Model",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24370,7 +24370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9496,
+    "id": 12104,
     "skill_label": "Assembly Language",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24380,7 +24380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9497,
+    "id": 12105,
     "skill_label": "Asset Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24390,7 +24390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9498,
+    "id": 12106,
     "skill_label": "Assignment Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24400,7 +24400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9499,
+    "id": 12107,
     "skill_label": "Asynchronous Programming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24410,7 +24410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9500,
+    "id": 12108,
     "skill_label": "Asynchronous programming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24420,7 +24420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9501,
+    "id": 12109,
     "skill_label": "Attack Threat Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24430,7 +24430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9502,
+    "id": 12110,
     "skill_label": "Attention to Detail",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24440,7 +24440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9503,
+    "id": 12111,
     "skill_label": "Audience Analytics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24450,7 +24450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9504,
+    "id": 12112,
     "skill_label": "Audit",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24460,7 +24460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9505,
+    "id": 12113,
     "skill_label": "Audit Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24470,7 +24470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9506,
+    "id": 12114,
     "skill_label": "Augmented Reality",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24480,7 +24480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9507,
+    "id": 12115,
     "skill_label": "Authentication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24490,7 +24490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9508,
+    "id": 12116,
     "skill_label": "Authorization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24500,7 +24500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9509,
+    "id": 12117,
     "skill_label": "Authorization to Operate (ATO) Process",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24510,7 +24510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9510,
+    "id": 12118,
     "skill_label": "Auto-scaling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24520,7 +24520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9511,
+    "id": 12119,
     "skill_label": "AutoCAD",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24530,7 +24530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9512,
+    "id": 12120,
     "skill_label": "Automated Red Teaming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24540,7 +24540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9513,
+    "id": 12121,
     "skill_label": "Automated Reporting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24550,7 +24550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9514,
+    "id": 12122,
     "skill_label": "Automated Storage and Retrieval Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24560,7 +24560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9515,
+    "id": 12123,
     "skill_label": "Automated Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24570,7 +24570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9516,
+    "id": 12124,
     "skill_label": "Automated Testing Frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24580,7 +24580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9517,
+    "id": 12125,
     "skill_label": "Automated Valuation Models",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24590,7 +24590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9518,
+    "id": 12126,
     "skill_label": "Automatic Storage Management (ASM)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24600,7 +24600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9519,
+    "id": 12127,
     "skill_label": "Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24610,7 +24610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9520,
+    "id": 12128,
     "skill_label": "Automation Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24620,7 +24620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9521,
+    "id": 12129,
     "skill_label": "Automation Scripting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24630,7 +24630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9522,
+    "id": 12130,
     "skill_label": "Automation Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24640,7 +24640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9523,
+    "id": 12131,
     "skill_label": "Automation Technician",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24650,7 +24650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9524,
+    "id": 12132,
     "skill_label": "Automation Troubleshooting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24660,7 +24660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9525,
+    "id": 12133,
     "skill_label": "Automotive Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24670,7 +24670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9526,
+    "id": 12134,
     "skill_label": "Autonomous Response",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24680,7 +24680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9527,
+    "id": 12135,
     "skill_label": "Azure",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24690,7 +24690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9528,
+    "id": 12136,
     "skill_label": "Azure Active Directory",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24700,7 +24700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9529,
+    "id": 12137,
     "skill_label": "Azure Cloud",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24710,7 +24710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9530,
+    "id": 12138,
     "skill_label": "Azure Cloud Infrastructure",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24720,7 +24720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9531,
+    "id": 12139,
     "skill_label": "Azure Data Factory",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24730,7 +24730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9532,
+    "id": 12140,
     "skill_label": "Azure Data Lake Storage",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24740,7 +24740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9533,
+    "id": 12141,
     "skill_label": "Azure DevOps",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24750,7 +24750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9534,
+    "id": 12142,
     "skill_label": "Azure Functions",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24760,7 +24760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9535,
+    "id": 12143,
     "skill_label": "Azure Identity Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24770,7 +24770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9536,
+    "id": 12144,
     "skill_label": "Azure Key Vault",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24780,7 +24780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9537,
+    "id": 12145,
     "skill_label": "Azure Kubernetes Service",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24790,7 +24790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9538,
+    "id": 12146,
     "skill_label": "Azure Policy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24800,7 +24800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9539,
+    "id": 12147,
     "skill_label": "Azure SQL Database",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24810,7 +24810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9540,
+    "id": 12148,
     "skill_label": "Azure Service Bus",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24820,7 +24820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9541,
+    "id": 12149,
     "skill_label": "Azure Solutions Architect Expert",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24830,7 +24830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9542,
+    "id": 12150,
     "skill_label": "Azure Storage",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24840,7 +24840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9543,
+    "id": 12151,
     "skill_label": "Azure Virtual Network",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24850,7 +24850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9544,
+    "id": 12152,
     "skill_label": "B2B SaaS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24860,7 +24860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9545,
+    "id": 12153,
     "skill_label": "BGP",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24870,7 +24870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9546,
+    "id": 12154,
     "skill_label": "Bachelor of Science in Computer Science",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24880,7 +24880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9547,
+    "id": 12155,
     "skill_label": "Bachelor's Degree",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24890,7 +24890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9548,
+    "id": 12156,
     "skill_label": "Bachelor's Degree in Computer Science",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24900,7 +24900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9549,
+    "id": 12157,
     "skill_label": "Bachelor's Degree in Quantitative Field",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24910,7 +24910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9550,
+    "id": 12158,
     "skill_label": "Back-end Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24920,7 +24920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9551,
+    "id": 12159,
     "skill_label": "Backend Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24930,7 +24930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9552,
+    "id": 12160,
     "skill_label": "Backend Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24940,7 +24940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9553,
+    "id": 12161,
     "skill_label": "Backend Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24950,7 +24950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9554,
+    "id": 12162,
     "skill_label": "Backlog Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24960,7 +24960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9555,
+    "id": 12163,
     "skill_label": "Backup and Recovery",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24970,7 +24970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9556,
+    "id": 12164,
     "skill_label": "Bank Reconciliation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24980,7 +24980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9557,
+    "id": 12165,
     "skill_label": "Banking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -24990,7 +24990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9558,
+    "id": 12166,
     "skill_label": "Bare Metal Infrastructure",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25000,7 +25000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9559,
+    "id": 12167,
     "skill_label": "Bash",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25010,7 +25010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9560,
+    "id": 12168,
     "skill_label": "Basic BGP Concepts",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25020,7 +25020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9561,
+    "id": 12169,
     "skill_label": "Basic Life Support (BLS)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25030,7 +25030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9562,
+    "id": 12170,
     "skill_label": "Basic Quality Control",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25040,7 +25040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9563,
+    "id": 12171,
     "skill_label": "Basic Statistics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25050,7 +25050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9564,
+    "id": 12172,
     "skill_label": "Batch Processing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25060,7 +25060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9565,
+    "id": 12173,
     "skill_label": "Behavioral AI Safety",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25070,7 +25070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9566,
+    "id": 12174,
     "skill_label": "Behavioral AI Safety Techniques",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25080,7 +25080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9567,
+    "id": 12175,
     "skill_label": "Behavioral Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25090,7 +25090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9568,
+    "id": 12176,
     "skill_label": "Benchmarking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25100,7 +25100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9569,
+    "id": 12177,
     "skill_label": "Bias Detection",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25110,7 +25110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9570,
+    "id": 12178,
     "skill_label": "Big Data",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25120,7 +25120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9571,
+    "id": 12179,
     "skill_label": "Big Data Analytics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25130,7 +25130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9572,
+    "id": 12180,
     "skill_label": "Big Data Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25140,7 +25140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9573,
+    "id": 12181,
     "skill_label": "Big Data Processing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25150,7 +25150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9574,
+    "id": 12182,
     "skill_label": "Big Data Technologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25160,7 +25160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9575,
+    "id": 12183,
     "skill_label": "Bilingualism",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25170,7 +25170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9576,
+    "id": 12184,
     "skill_label": "Bill of Materials (BOM) Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25180,7 +25180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9577,
+    "id": 12185,
     "skill_label": "Bill of Materials Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25190,7 +25190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9578,
+    "id": 12186,
     "skill_label": "Billing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25200,7 +25200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9579,
+    "id": 12187,
     "skill_label": "Billing Processes",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25210,7 +25210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9580,
+    "id": 12188,
     "skill_label": "Bills of Material",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25220,7 +25220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9581,
+    "id": 12189,
     "skill_label": "Biology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25230,7 +25230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9582,
+    "id": 12190,
     "skill_label": "Biometric Authentication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25240,7 +25240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9583,
+    "id": 12191,
     "skill_label": "Blockchain",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25250,7 +25250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9584,
+    "id": 12192,
     "skill_label": "Blockchain Bridges",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25260,7 +25260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9585,
+    "id": 12193,
     "skill_label": "Blockchain Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25270,7 +25270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9586,
+    "id": 12194,
     "skill_label": "Blockchain Fundamentals",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25280,7 +25280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9587,
+    "id": 12195,
     "skill_label": "Blockchain Indexing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25290,7 +25290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9588,
+    "id": 12196,
     "skill_label": "Blockchain Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25300,7 +25300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9589,
+    "id": 12197,
     "skill_label": "Blue Yonder WMS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25310,7 +25310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9590,
+    "id": 12198,
     "skill_label": "Blueprint Interpretation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25320,7 +25320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9591,
+    "id": 12199,
     "skill_label": "Board Communication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25330,7 +25330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9592,
+    "id": 12200,
     "skill_label": "Board Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25340,7 +25340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9593,
+    "id": 12201,
     "skill_label": "Board Support Package (BSP) Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25350,7 +25350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9594,
+    "id": 12202,
     "skill_label": "Bookkeeping",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25360,7 +25360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9595,
+    "id": 12203,
     "skill_label": "Bootloader Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25370,7 +25370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9596,
+    "id": 12204,
     "skill_label": "Bootstrap",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25380,7 +25380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9597,
+    "id": 12205,
     "skill_label": "Boundary Protection",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25390,7 +25390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9598,
+    "id": 12206,
     "skill_label": "Brand Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25400,7 +25400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9599,
+    "id": 12207,
     "skill_label": "Budget Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25410,7 +25410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9600,
+    "id": 12208,
     "skill_label": "Budgetary Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25420,7 +25420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9601,
+    "id": 12209,
     "skill_label": "Buffer Overflow",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25430,7 +25430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9602,
+    "id": 12210,
     "skill_label": "Buffering Strategies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25440,7 +25440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9603,
+    "id": 12211,
     "skill_label": "Bug Bounty Programs",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25450,7 +25450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9604,
+    "id": 12212,
     "skill_label": "Bug Fixing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25460,7 +25460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9605,
+    "id": 12213,
     "skill_label": "Bug Tracking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25470,7 +25470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9606,
+    "id": 12214,
     "skill_label": "Build Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25480,7 +25480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9607,
+    "id": 12215,
     "skill_label": "Building Codes Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25490,7 +25490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9608,
+    "id": 12216,
     "skill_label": "Building Management Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25500,7 +25500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9609,
+    "id": 12217,
     "skill_label": "Business Acumen",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25510,7 +25510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9610,
+    "id": 12218,
     "skill_label": "Business Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25520,7 +25520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9611,
+    "id": 12219,
     "skill_label": "Business Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25530,7 +25530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9612,
+    "id": 12220,
     "skill_label": "Business Case Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25540,7 +25540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9613,
+    "id": 12221,
     "skill_label": "Business Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25550,7 +25550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9614,
+    "id": 12222,
     "skill_label": "Business Intelligence",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25560,7 +25560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9615,
+    "id": 12223,
     "skill_label": "Business Mathematics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25570,7 +25570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9616,
+    "id": 12224,
     "skill_label": "Business Modeling Techniques",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25580,7 +25580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9617,
+    "id": 12225,
     "skill_label": "Business Process Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25590,7 +25590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9618,
+    "id": 12226,
     "skill_label": "Business Process Improvement",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25600,7 +25600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9619,
+    "id": 12227,
     "skill_label": "Business Process Mapping",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25610,7 +25610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9620,
+    "id": 12228,
     "skill_label": "Business Process Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25620,7 +25620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9621,
+    "id": 12229,
     "skill_label": "Business Requirements Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25630,7 +25630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9622,
+    "id": 12230,
     "skill_label": "Business Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25640,7 +25640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9623,
+    "id": 12231,
     "skill_label": "C",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25650,7 +25650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9624,
+    "id": 12232,
     "skill_label": "C Programming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25660,7 +25660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9625,
+    "id": 12233,
     "skill_label": "C#",
     "esco_uri": "http://data.europa.eu/esco/skill/4c016b68-4116-468c-9dc6-42710c239e4a",
     "week": "2026-04-20",
@@ -25670,7 +25670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9626,
+    "id": 12234,
     "skill_label": "C++",
     "esco_uri": "http://data.europa.eu/esco/skill/b633eb55-8f1f-4ae6-ab4c-2022ffe2cb7f",
     "week": "2026-04-20",
@@ -25680,7 +25680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9627,
+    "id": 12235,
     "skill_label": "C++ Programming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25690,7 +25690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9628,
+    "id": 12236,
     "skill_label": "CAD",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25700,7 +25700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9629,
+    "id": 12237,
     "skill_label": "CAD Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25710,7 +25710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9630,
+    "id": 12238,
     "skill_label": "CAN",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25720,7 +25720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9631,
+    "id": 12239,
     "skill_label": "CAN Protocol",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25730,7 +25730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9632,
+    "id": 12240,
     "skill_label": "CCNA",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25740,7 +25740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9633,
+    "id": 12241,
     "skill_label": "CCNP",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25750,7 +25750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9634,
+    "id": 12242,
     "skill_label": "CCTV Systems Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25760,7 +25760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9635,
+    "id": 12243,
     "skill_label": "CEH",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25770,7 +25770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9636,
+    "id": 12244,
     "skill_label": "CI/CD",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25780,7 +25780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9637,
+    "id": 12245,
     "skill_label": "CI/CD Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25790,7 +25790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9638,
+    "id": 12246,
     "skill_label": "CI/CD Pipelines",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25800,7 +25800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9639,
+    "id": 12247,
     "skill_label": "CI/CD Troubleshooting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25810,7 +25810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9640,
+    "id": 12248,
     "skill_label": "CISSP",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25820,7 +25820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9641,
+    "id": 12249,
     "skill_label": "CISSP Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25830,7 +25830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9642,
+    "id": 12250,
     "skill_label": "CLI Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25840,7 +25840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9643,
+    "id": 12251,
     "skill_label": "COBOL",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25850,7 +25850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9644,
+    "id": 12252,
     "skill_label": "CRTO",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25860,7 +25860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9645,
+    "id": 12253,
     "skill_label": "CSS",
     "esco_uri": "http://data.europa.eu/esco/skill/e5d1f825-60ed-4bdd-872a-e748c387f777",
     "week": "2026-04-20",
@@ -25870,7 +25870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9646,
+    "id": 12254,
     "skill_label": "Cable Termination",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25880,7 +25880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9647,
+    "id": 12255,
     "skill_label": "Caching",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25890,7 +25890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9648,
+    "id": 12256,
     "skill_label": "Calculus",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25900,7 +25900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9649,
+    "id": 12257,
     "skill_label": "Calendar Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25910,7 +25910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9650,
+    "id": 12258,
     "skill_label": "Calibration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25920,7 +25920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9651,
+    "id": 12259,
     "skill_label": "Call Flow Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25930,7 +25930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9652,
+    "id": 12260,
     "skill_label": "Call Routing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25940,7 +25940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9653,
+    "id": 12261,
     "skill_label": "Canvas",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25950,7 +25950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9654,
+    "id": 12262,
     "skill_label": "Capability Studies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25960,7 +25960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9655,
+    "id": 12263,
     "skill_label": "Capacity Planning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25970,7 +25970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9656,
+    "id": 12264,
     "skill_label": "Capital Expenditure Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25980,7 +25980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9657,
+    "id": 12265,
     "skill_label": "Capital Markets",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -25990,7 +25990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9658,
+    "id": 12266,
     "skill_label": "Cardiac Catheterization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26000,7 +26000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9659,
+    "id": 12267,
     "skill_label": "Cardiopulmonary Resuscitation (CPR)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26010,7 +26010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9660,
+    "id": 12268,
     "skill_label": "Cassandra",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26020,7 +26020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9661,
+    "id": 12269,
     "skill_label": "Category Narrative Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26030,7 +26030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9662,
+    "id": 12270,
     "skill_label": "Causal Inference",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26040,7 +26040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9663,
+    "id": 12271,
     "skill_label": "Cerner EMR",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26050,7 +26050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9664,
+    "id": 12272,
     "skill_label": "Certification Authorities (CAs)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26060,7 +26060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9665,
+    "id": 12273,
     "skill_label": "Certified Business Analysis Professional (CBAP)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26070,7 +26070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9666,
+    "id": 12274,
     "skill_label": "Certified Construction Quality Management (CQM)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26080,7 +26080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9667,
+    "id": 12275,
     "skill_label": "Certified Residential Appraiser License",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26090,7 +26090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9668,
+    "id": 12276,
     "skill_label": "Certified ScrumMaster (CSM)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26100,7 +26100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9669,
+    "id": 12277,
     "skill_label": "Certified Texas Contract Developer (CTCD)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26110,7 +26110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9670,
+    "id": 12278,
     "skill_label": "Certified Texas Contract Manager (CTCM)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26120,7 +26120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9671,
+    "id": 12279,
     "skill_label": "Chainlink",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26130,7 +26130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9672,
+    "id": 12280,
     "skill_label": "Change Control",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26140,7 +26140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9673,
+    "id": 12281,
     "skill_label": "Change Data Capture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26150,7 +26150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9674,
+    "id": 12282,
     "skill_label": "Change Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26160,7 +26160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9675,
+    "id": 12283,
     "skill_label": "Channel Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26170,7 +26170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9676,
+    "id": 12284,
     "skill_label": "Chatbot Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26180,7 +26180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9677,
+    "id": 12285,
     "skill_label": "Circuit Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26190,7 +26190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9678,
+    "id": 12286,
     "skill_label": "Cisco Adaptive Security Appliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26200,7 +26200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9679,
+    "id": 12287,
     "skill_label": "Cisco Adaptive Security Appliance (ASA)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26210,7 +26210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9680,
+    "id": 12288,
     "skill_label": "Cisco Certified Network Associate (CCNA)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26220,7 +26220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9681,
+    "id": 12289,
     "skill_label": "Cisco Certified Network Professional (CCNP)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26230,7 +26230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9682,
+    "id": 12290,
     "skill_label": "Cisco Commerce Workspace",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26240,7 +26240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9683,
+    "id": 12291,
     "skill_label": "Cisco Routing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26250,7 +26250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9684,
+    "id": 12292,
     "skill_label": "Cisco SD-WAN",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26260,7 +26260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9685,
+    "id": 12293,
     "skill_label": "Cisco Software",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26270,7 +26270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9686,
+    "id": 12294,
     "skill_label": "Civil Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26280,7 +26280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9687,
+    "id": 12295,
     "skill_label": "Civil Engineering Materials Science",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26290,7 +26290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9688,
+    "id": 12296,
     "skill_label": "Classification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26300,7 +26300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9689,
+    "id": 12297,
     "skill_label": "Client Communication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26310,7 +26310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9690,
+    "id": 12298,
     "skill_label": "Client Interaction",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26320,7 +26320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9691,
+    "id": 12299,
     "skill_label": "Client Interviewing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26330,7 +26330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9692,
+    "id": 12300,
     "skill_label": "Client Relationship Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26340,7 +26340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9693,
+    "id": 12301,
     "skill_label": "Client Training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26350,7 +26350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9694,
+    "id": 12302,
     "skill_label": "Client-Server Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26360,7 +26360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9695,
+    "id": 12303,
     "skill_label": "Clinical Data Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26370,7 +26370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9696,
+    "id": 12304,
     "skill_label": "Clinical Documentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26380,7 +26380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9697,
+    "id": 12305,
     "skill_label": "Clinical Documentation Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26390,7 +26390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9698,
+    "id": 12306,
     "skill_label": "Clinical Experience",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26400,7 +26400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9699,
+    "id": 12307,
     "skill_label": "Clinical Informatics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26410,7 +26410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9700,
+    "id": 12308,
     "skill_label": "Clinical Information Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26420,7 +26420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9701,
+    "id": 12309,
     "skill_label": "Clinical Insights",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26430,7 +26430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9702,
+    "id": 12310,
     "skill_label": "Clinical Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26440,7 +26440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9703,
+    "id": 12311,
     "skill_label": "Clinical Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26450,7 +26450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9704,
+    "id": 12312,
     "skill_label": "Clinical Systems Implementation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26460,7 +26460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9705,
+    "id": 12313,
     "skill_label": "Clinical Systems Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26470,7 +26470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9706,
+    "id": 12314,
     "skill_label": "Clinical Systems Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26480,7 +26480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9707,
+    "id": 12315,
     "skill_label": "Clinical Technology Validation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26490,7 +26490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9708,
+    "id": 12316,
     "skill_label": "Clinical Workflow",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26500,7 +26500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9709,
+    "id": 12317,
     "skill_label": "Clinical Workflow Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26510,7 +26510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9710,
+    "id": 12318,
     "skill_label": "Cloud Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26520,7 +26520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9711,
+    "id": 12319,
     "skill_label": "Cloud Computing",
     "esco_uri": "http://data.europa.eu/esco/skill/bd14968e-e409-45af-b362-3495ed7b10e0",
     "week": "2026-04-20",
@@ -26530,7 +26530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9712,
+    "id": 12320,
     "skill_label": "Cloud Data Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26540,7 +26540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9713,
+    "id": 12321,
     "skill_label": "Cloud Data Platforms",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26550,7 +26550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9714,
+    "id": 12322,
     "skill_label": "Cloud Data Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26560,7 +26560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9715,
+    "id": 12323,
     "skill_label": "Cloud Data Warehousing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26570,7 +26570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9716,
+    "id": 12324,
     "skill_label": "Cloud Database Services",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26580,7 +26580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9717,
+    "id": 12325,
     "skill_label": "Cloud Economics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26590,7 +26590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9718,
+    "id": 12326,
     "skill_label": "Cloud Governance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26600,7 +26600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9719,
+    "id": 12327,
     "skill_label": "Cloud Infrastructure",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26610,7 +26610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9720,
+    "id": 12328,
     "skill_label": "Cloud Infrastructure Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26620,7 +26620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9721,
+    "id": 12329,
     "skill_label": "Cloud Migration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26630,7 +26630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9722,
+    "id": 12330,
     "skill_label": "Cloud Modernization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26640,7 +26640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9723,
+    "id": 12331,
     "skill_label": "Cloud Native Applications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26650,7 +26650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9724,
+    "id": 12332,
     "skill_label": "Cloud Networking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26660,7 +26660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9725,
+    "id": 12333,
     "skill_label": "Cloud Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26670,7 +26670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9726,
+    "id": 12334,
     "skill_label": "Cloud Platform Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26680,7 +26680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9727,
+    "id": 12335,
     "skill_label": "Cloud Platforms",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26690,7 +26690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9728,
+    "id": 12336,
     "skill_label": "Cloud Security",
     "esco_uri": "http://data.europa.eu/esco/skill/1c2978b8-bb0d-4249-9c23-877571a4dffa",
     "week": "2026-04-20",
@@ -26700,7 +26700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9729,
+    "id": 12337,
     "skill_label": "Cloud Security Certifications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26710,7 +26710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9730,
+    "id": 12338,
     "skill_label": "Cloud Security Clearance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26720,7 +26720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9731,
+    "id": 12339,
     "skill_label": "Cloud Security Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26730,7 +26730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9732,
+    "id": 12340,
     "skill_label": "Cloud Security Concepts",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26740,7 +26740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9733,
+    "id": 12341,
     "skill_label": "Cloud Security Posture Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26750,7 +26750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9734,
+    "id": 12342,
     "skill_label": "Cloud Software",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26760,7 +26760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9735,
+    "id": 12343,
     "skill_label": "Cloud Solution Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26770,7 +26770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9736,
+    "id": 12344,
     "skill_label": "Cloud Solution Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26780,7 +26780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9737,
+    "id": 12345,
     "skill_label": "Cloud Solutions Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26790,7 +26790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9738,
+    "id": 12346,
     "skill_label": "Cloud System Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26800,7 +26800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9739,
+    "id": 12347,
     "skill_label": "Cloud-Native Applications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26810,7 +26810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9740,
+    "id": 12348,
     "skill_label": "Cloud-Native Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26820,7 +26820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9741,
+    "id": 12349,
     "skill_label": "Cloud-native Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26830,7 +26830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9742,
+    "id": 12350,
     "skill_label": "Cloud-native Solutions",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26840,7 +26840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9743,
+    "id": 12351,
     "skill_label": "Cluster Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26850,7 +26850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9744,
+    "id": 12352,
     "skill_label": "Cluster Configuration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26860,7 +26860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9745,
+    "id": 12353,
     "skill_label": "Coaching",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26870,7 +26870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9746,
+    "id": 12354,
     "skill_label": "Coastal and Ocean Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26880,7 +26880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9747,
+    "id": 12355,
     "skill_label": "Code Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26890,7 +26890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9748,
+    "id": 12356,
     "skill_label": "Code Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26900,7 +26900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9749,
+    "id": 12357,
     "skill_label": "Code Generation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26910,7 +26910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9750,
+    "id": 12358,
     "skill_label": "Code Quality",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26920,7 +26920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9751,
+    "id": 12359,
     "skill_label": "Code Quality Assessment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26930,7 +26930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9752,
+    "id": 12360,
     "skill_label": "Code Refactoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26940,7 +26940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9753,
+    "id": 12361,
     "skill_label": "Code Repository Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26950,7 +26950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9754,
+    "id": 12362,
     "skill_label": "Code Review",
     "esco_uri": "Code Review",
     "week": "2026-04-20",
@@ -26960,7 +26960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9755,
+    "id": 12363,
     "skill_label": "Code Scanning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26970,7 +26970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9756,
+    "id": 12364,
     "skill_label": "Code Writing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26980,7 +26980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9757,
+    "id": 12365,
     "skill_label": "Coding",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -26990,7 +26990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9758,
+    "id": 12366,
     "skill_label": "Coding Problem Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27000,7 +27000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9759,
+    "id": 12367,
     "skill_label": "Cognitive Systems Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27010,7 +27010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9760,
+    "id": 12368,
     "skill_label": "Cohort Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27020,7 +27020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9761,
+    "id": 12369,
     "skill_label": "Collaboration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27030,7 +27030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9762,
+    "id": 12370,
     "skill_label": "Collaborative Work",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27040,7 +27040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9763,
+    "id": 12371,
     "skill_label": "Command and Control",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27050,7 +27050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9764,
+    "id": 12372,
     "skill_label": "Commercial Contracting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27060,7 +27060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9765,
+    "id": 12373,
     "skill_label": "Commercial Driver's License (CDL)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27070,7 +27070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9766,
+    "id": 12374,
     "skill_label": "Commercial Engagement Performance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27080,7 +27080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9767,
+    "id": 12375,
     "skill_label": "Commercial Off-The-Shelf Software (COTS)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27090,7 +27090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9768,
+    "id": 12376,
     "skill_label": "Commercial Partnerships",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27100,7 +27100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9769,
+    "id": 12377,
     "skill_label": "Commissioning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27110,7 +27110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9770,
+    "id": 12378,
     "skill_label": "Communicating with Influence",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27120,7 +27120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9771,
+    "id": 12379,
     "skill_label": "Communication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27130,7 +27130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9772,
+    "id": 12380,
     "skill_label": "Communication & Stakeholder Engagement",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27140,7 +27140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9773,
+    "id": 12381,
     "skill_label": "Communication Protocols",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27150,7 +27150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9774,
+    "id": 12382,
     "skill_label": "Communication Services Go-to-Market",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27160,7 +27160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9775,
+    "id": 12383,
     "skill_label": "Communication Skills",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27170,7 +27170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9776,
+    "id": 12384,
     "skill_label": "Communication and Presentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27180,7 +27180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9777,
+    "id": 12385,
     "skill_label": "Communications Equipment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27190,7 +27190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9778,
+    "id": 12386,
     "skill_label": "Communications Intelligence (COMINT)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27200,7 +27200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9779,
+    "id": 12387,
     "skill_label": "Communications Security (COMSEC)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27210,7 +27210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9780,
+    "id": 12388,
     "skill_label": "CompTIA A+ Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27220,7 +27220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9781,
+    "id": 12389,
     "skill_label": "CompTIA Network+ Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27230,7 +27230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9782,
+    "id": 12390,
     "skill_label": "CompTIA Security+",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27240,7 +27240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9783,
+    "id": 12391,
     "skill_label": "CompTIA Security+ Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27250,7 +27250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9784,
+    "id": 12392,
     "skill_label": "Company Scaling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27260,7 +27260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9785,
+    "id": 12393,
     "skill_label": "Comparative Market Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27270,7 +27270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9786,
+    "id": 12394,
     "skill_label": "Competitive Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27280,7 +27280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9787,
+    "id": 12395,
     "skill_label": "Compiled Programming Languages",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27290,7 +27290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9788,
+    "id": 12396,
     "skill_label": "Complex Systems Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27300,7 +27300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9789,
+    "id": 12397,
     "skill_label": "Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27310,7 +27310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9790,
+    "id": 12398,
     "skill_label": "Compliance Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27320,7 +27320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9791,
+    "id": 12399,
     "skill_label": "Compliance Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27330,7 +27330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9792,
+    "id": 12400,
     "skill_label": "Component Obsolescence Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27340,7 +27340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9793,
+    "id": 12401,
     "skill_label": "Component Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27350,7 +27350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9794,
+    "id": 12402,
     "skill_label": "Computational Complexity",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27360,7 +27360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9795,
+    "id": 12403,
     "skill_label": "Computational Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27370,7 +27370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9796,
+    "id": 12404,
     "skill_label": "Computational Physics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27380,7 +27380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9797,
+    "id": 12405,
     "skill_label": "Computer Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27390,7 +27390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9798,
+    "id": 12406,
     "skill_label": "Computer Documentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27400,7 +27400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9799,
+    "id": 12407,
     "skill_label": "Computer Engineering",
     "esco_uri": "http://data.europa.eu/esco/skill/89f6560b-2194-45c9-9ece-d33049a73eef",
     "week": "2026-04-20",
@@ -27410,7 +27410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9800,
+    "id": 12408,
     "skill_label": "Computer Hardware",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27420,7 +27420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9801,
+    "id": 12409,
     "skill_label": "Computer Literacy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27430,7 +27430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9802,
+    "id": 12410,
     "skill_label": "Computer Network Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27440,7 +27440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9803,
+    "id": 12411,
     "skill_label": "Computer Network Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27450,7 +27450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9804,
+    "id": 12412,
     "skill_label": "Computer Networking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27460,7 +27460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9805,
+    "id": 12413,
     "skill_label": "Computer Programming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27470,7 +27470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9806,
+    "id": 12414,
     "skill_label": "Computer Science",
     "esco_uri": "http://data.europa.eu/esco/skill/7b5cce4d-c7fe-4119-b48f-70aa05391787",
     "week": "2026-04-20",
@@ -27480,7 +27480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9807,
+    "id": 12415,
     "skill_label": "Computer Science Education",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27490,7 +27490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9808,
+    "id": 12416,
     "skill_label": "Computer System Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27500,7 +27500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9809,
+    "id": 12417,
     "skill_label": "Computer System Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27510,7 +27510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9810,
+    "id": 12418,
     "skill_label": "Computer Systems Installation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27520,7 +27520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9811,
+    "id": 12419,
     "skill_label": "Computer Systems Maintenance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27530,7 +27530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9812,
+    "id": 12420,
     "skill_label": "Computer Technology",
     "esco_uri": "http://data.europa.eu/esco/skill/ddc3119d-1d6e-4324-9125-a3380d299ac5",
     "week": "2026-04-20",
@@ -27540,7 +27540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9813,
+    "id": 12421,
     "skill_label": "Computer Vision",
     "esco_uri": "http://data.europa.eu/esco/skill/7b0d5000-00da-4864-b776-6de49a87a669",
     "week": "2026-04-20",
@@ -27550,7 +27550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9814,
+    "id": 12422,
     "skill_label": "Computerized Physician Order Entry",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27560,7 +27560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9815,
+    "id": 12423,
     "skill_label": "Concurrency",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27570,7 +27570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9816,
+    "id": 12424,
     "skill_label": "Concurrent Programming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27580,7 +27580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9817,
+    "id": 12425,
     "skill_label": "Conditional Access",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27590,7 +27590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9818,
+    "id": 12426,
     "skill_label": "Confidentiality",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27600,7 +27600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9819,
+    "id": 12427,
     "skill_label": "Configuration Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27610,7 +27610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9820,
+    "id": 12428,
     "skill_label": "Consensus Algorithms",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27620,7 +27620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9821,
+    "id": 12429,
     "skill_label": "Constructability Review",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27630,7 +27630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9822,
+    "id": 12430,
     "skill_label": "Construction Codes and Standards",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27640,7 +27640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9823,
+    "id": 12431,
     "skill_label": "Construction Engineering and Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27650,7 +27650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9824,
+    "id": 12432,
     "skill_label": "Construction Industry Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27660,7 +27660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9825,
+    "id": 12433,
     "skill_label": "Construction Law",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27670,7 +27670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9826,
+    "id": 12434,
     "skill_label": "Construction Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27680,7 +27680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9827,
+    "id": 12435,
     "skill_label": "Construction Materials",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27690,7 +27690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9828,
+    "id": 12436,
     "skill_label": "Construction Oversight",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27700,7 +27700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9829,
+    "id": 12437,
     "skill_label": "Construction Progress Reporting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27710,7 +27710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9830,
+    "id": 12438,
     "skill_label": "Construction Quality Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27720,7 +27720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9831,
+    "id": 12439,
     "skill_label": "Construction Safety Standards",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27730,7 +27730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9832,
+    "id": 12440,
     "skill_label": "Construction Scheduling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27740,7 +27740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9833,
+    "id": 12441,
     "skill_label": "Consultative Advising",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27750,7 +27750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9834,
+    "id": 12442,
     "skill_label": "Consultative Selling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27760,7 +27760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9835,
+    "id": 12443,
     "skill_label": "Consulting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27770,7 +27770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9836,
+    "id": 12444,
     "skill_label": "Contact Center Implementation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27780,7 +27780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9837,
+    "id": 12445,
     "skill_label": "Contact Center Technology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27790,7 +27790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9838,
+    "id": 12446,
     "skill_label": "Container Networking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27800,7 +27800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9839,
+    "id": 12447,
     "skill_label": "Container Orchestration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27810,7 +27810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9840,
+    "id": 12448,
     "skill_label": "Container Platforms",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27820,7 +27820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9841,
+    "id": 12449,
     "skill_label": "Container Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27830,7 +27830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9842,
+    "id": 12450,
     "skill_label": "Containerization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27840,7 +27840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9843,
+    "id": 12451,
     "skill_label": "Containers",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27850,7 +27850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9844,
+    "id": 12452,
     "skill_label": "Containment Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27860,7 +27860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9845,
+    "id": 12453,
     "skill_label": "Content Creation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27870,7 +27870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9846,
+    "id": 12454,
     "skill_label": "Content Marketing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27880,7 +27880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9847,
+    "id": 12455,
     "skill_label": "Context Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27890,7 +27890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9848,
+    "id": 12456,
     "skill_label": "Context-driven Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27900,7 +27900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9849,
+    "id": 12457,
     "skill_label": "Contingency Planning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27910,7 +27910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9850,
+    "id": 12458,
     "skill_label": "Continuous Delivery",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27920,7 +27920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9851,
+    "id": 12459,
     "skill_label": "Continuous Deployment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27930,7 +27930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9852,
+    "id": 12460,
     "skill_label": "Continuous Improvement",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27940,7 +27940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9853,
+    "id": 12461,
     "skill_label": "Continuous Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27950,7 +27950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9854,
+    "id": 12462,
     "skill_label": "Continuous Integration and Continuous Deployment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27960,7 +27960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9855,
+    "id": 12463,
     "skill_label": "Contract Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27970,7 +27970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9856,
+    "id": 12464,
     "skill_label": "Contract Drafting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27980,7 +27980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9857,
+    "id": 12465,
     "skill_label": "Contract Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -27990,7 +27990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9858,
+    "id": 12466,
     "skill_label": "Contract Execution",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28000,7 +28000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9859,
+    "id": 12467,
     "skill_label": "Contract Logistics Cost Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28010,7 +28010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9860,
+    "id": 12468,
     "skill_label": "Contract Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28020,7 +28020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9861,
+    "id": 12469,
     "skill_label": "Contract Negotiation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28030,7 +28030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9862,
+    "id": 12470,
     "skill_label": "Contract Risk Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28040,7 +28040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9863,
+    "id": 12471,
     "skill_label": "Contractor Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28050,7 +28050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9864,
+    "id": 12472,
     "skill_label": "Control Account Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28060,7 +28060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9865,
+    "id": 12473,
     "skill_label": "Control Plans",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28070,7 +28070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9866,
+    "id": 12474,
     "skill_label": "Control Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28080,7 +28080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9867,
+    "id": 12475,
     "skill_label": "Control Systems Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28090,7 +28090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9868,
+    "id": 12476,
     "skill_label": "Control Systems Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28100,7 +28100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9869,
+    "id": 12477,
     "skill_label": "Control Systems Maintenance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28110,7 +28110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9870,
+    "id": 12478,
     "skill_label": "Control Systems Programming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28120,7 +28120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9871,
+    "id": 12479,
     "skill_label": "Control Systems Troubleshooting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28130,7 +28130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9872,
+    "id": 12480,
     "skill_label": "Control-M",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28140,7 +28140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9873,
+    "id": 12481,
     "skill_label": "Controls Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28150,7 +28150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9874,
+    "id": 12482,
     "skill_label": "Conversation Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28160,7 +28160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9875,
+    "id": 12483,
     "skill_label": "Conversational AI",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28170,7 +28170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9876,
+    "id": 12484,
     "skill_label": "Conveyor Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28180,7 +28180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9877,
+    "id": 12485,
     "skill_label": "Convolutional Neural Networks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28190,7 +28190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9878,
+    "id": 12486,
     "skill_label": "Copilot Studio",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28200,7 +28200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9879,
+    "id": 12487,
     "skill_label": "Copper Cabling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28210,7 +28210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9880,
+    "id": 12488,
     "skill_label": "Core Java",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28220,7 +28220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9881,
+    "id": 12489,
     "skill_label": "Core JavaScript Technologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28230,7 +28230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9882,
+    "id": 12490,
     "skill_label": "Corporate Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28240,7 +28240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9883,
+    "id": 12491,
     "skill_label": "Corporate Finance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28250,7 +28250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9884,
+    "id": 12492,
     "skill_label": "Corrections",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28260,7 +28260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9885,
+    "id": 12493,
     "skill_label": "Corrective Maintenance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28270,7 +28270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9886,
+    "id": 12494,
     "skill_label": "Corrosion Prevention",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28280,7 +28280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9887,
+    "id": 12495,
     "skill_label": "Cost Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28290,7 +28290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9888,
+    "id": 12496,
     "skill_label": "Cost Benefit Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28300,7 +28300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9889,
+    "id": 12497,
     "skill_label": "Cost Efficiency",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28310,7 +28310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9890,
+    "id": 12498,
     "skill_label": "Cost Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28320,7 +28320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9891,
+    "id": 12499,
     "skill_label": "Cost Performance Tracking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28330,7 +28330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9892,
+    "id": 12500,
     "skill_label": "Counter-Narcotics Intelligence Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28340,7 +28340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9893,
+    "id": 12501,
     "skill_label": "Crane Operation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28350,7 +28350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9894,
+    "id": 12502,
     "skill_label": "Creative Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28360,7 +28360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9895,
+    "id": 12503,
     "skill_label": "Creative Problem Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28370,7 +28370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9896,
+    "id": 12504,
     "skill_label": "Creative Problem Solving",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28380,7 +28380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9897,
+    "id": 12505,
     "skill_label": "Creative Reasoning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28390,7 +28390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9898,
+    "id": 12506,
     "skill_label": "Credential Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28400,7 +28400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9899,
+    "id": 12507,
     "skill_label": "Credentialing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28410,7 +28410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9900,
+    "id": 12508,
     "skill_label": "Cricket",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28420,7 +28420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9901,
+    "id": 12509,
     "skill_label": "Criminal Investigation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28430,7 +28430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9902,
+    "id": 12510,
     "skill_label": "Critical Facilities Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28440,7 +28440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9903,
+    "id": 12511,
     "skill_label": "Critical Power Reliability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28450,7 +28450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9904,
+    "id": 12512,
     "skill_label": "Critical Program Information Assessment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28460,7 +28460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9905,
+    "id": 12513,
     "skill_label": "Critical Thinking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28470,7 +28470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9906,
+    "id": 12514,
     "skill_label": "Cross-Functional Project Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28480,7 +28480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9907,
+    "id": 12515,
     "skill_label": "Cross-functional Collaboration",
     "esco_uri": "Cross-functional collaboration",
     "week": "2026-04-20",
@@ -28490,7 +28490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9908,
+    "id": 12516,
     "skill_label": "Cross-functional Communication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28500,7 +28500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9909,
+    "id": 12517,
     "skill_label": "Cross-functional Leadership",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28510,7 +28510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9910,
+    "id": 12518,
     "skill_label": "Cross-functional Team Leadership",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28520,7 +28520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9911,
+    "id": 12519,
     "skill_label": "Cross-functional leadership",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28530,7 +28530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9912,
+    "id": 12520,
     "skill_label": "Crowd Control",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28540,7 +28540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9913,
+    "id": 12521,
     "skill_label": "Cryptocurrency",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28550,7 +28550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9914,
+    "id": 12522,
     "skill_label": "Cryptocurrency Markets",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28560,7 +28560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9915,
+    "id": 12523,
     "skill_label": "Cryptographic Verification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28570,7 +28570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9916,
+    "id": 12524,
     "skill_label": "Cryptography",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28580,7 +28580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9917,
+    "id": 12525,
     "skill_label": "Crystal Reports",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28590,7 +28590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9918,
+    "id": 12526,
     "skill_label": "Curriculum Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28600,7 +28600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9919,
+    "id": 12527,
     "skill_label": "Customer Data Platforms",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28610,7 +28610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9920,
+    "id": 12528,
     "skill_label": "Customer Education",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28620,7 +28620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9921,
+    "id": 12529,
     "skill_label": "Customer Experience Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28630,7 +28630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9922,
+    "id": 12530,
     "skill_label": "Customer Focus",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28640,7 +28640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9923,
+    "id": 12531,
     "skill_label": "Customer Interaction Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28650,7 +28650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9924,
+    "id": 12532,
     "skill_label": "Customer Loyalty Programs",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28660,7 +28660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9925,
+    "id": 12533,
     "skill_label": "Customer Needs Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28670,7 +28670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9926,
+    "id": 12534,
     "skill_label": "Customer Obsession",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28680,7 +28680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9927,
+    "id": 12535,
     "skill_label": "Customer Relationship Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28690,7 +28690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9928,
+    "id": 12536,
     "skill_label": "Customer Service",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28700,7 +28700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9929,
+    "id": 12537,
     "skill_label": "Customer Training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28710,7 +28710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9930,
+    "id": 12538,
     "skill_label": "Customer-Facing Experience",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28720,7 +28720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9931,
+    "id": 12539,
     "skill_label": "Customs Clearance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28730,7 +28730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9932,
+    "id": 12540,
     "skill_label": "Customs Declarations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28740,7 +28740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9933,
+    "id": 12541,
     "skill_label": "Customs Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28750,7 +28750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9934,
+    "id": 12542,
     "skill_label": "Cybersecurity",
     "esco_uri": "http://data.europa.eu/esco/skill/8088750d-8388-4170-a76f-48354c469c44",
     "week": "2026-04-20",
@@ -28760,7 +28760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9935,
+    "id": 12543,
     "skill_label": "Cybersecurity Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28770,7 +28770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9936,
+    "id": 12544,
     "skill_label": "Cybersecurity Certifications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28780,7 +28780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9937,
+    "id": 12545,
     "skill_label": "Cybersecurity Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28790,7 +28790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9938,
+    "id": 12546,
     "skill_label": "Cybersecurity Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28800,7 +28800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9939,
+    "id": 12547,
     "skill_label": "DB2",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28810,7 +28810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9940,
+    "id": 12548,
     "skill_label": "DB2 Database Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28820,7 +28820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9941,
+    "id": 12549,
     "skill_label": "DB2 LUW",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28830,7 +28830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9942,
+    "id": 12550,
     "skill_label": "DB2 z/OS Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28840,7 +28840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9943,
+    "id": 12551,
     "skill_label": "DB2 z/OS Database Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28850,7 +28850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9944,
+    "id": 12552,
     "skill_label": "DB2 z/OS Database Administration Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28860,7 +28860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9945,
+    "id": 12553,
     "skill_label": "DDA",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28870,7 +28870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9946,
+    "id": 12554,
     "skill_label": "DDC Controls",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28880,7 +28880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9947,
+    "id": 12555,
     "skill_label": "DHCP",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28890,7 +28890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9948,
+    "id": 12556,
     "skill_label": "DISA STIGs",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28900,7 +28900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9949,
+    "id": 12557,
     "skill_label": "DLP Policy Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28910,7 +28910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9950,
+    "id": 12558,
     "skill_label": "DNS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28920,7 +28920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9951,
+    "id": 12559,
     "skill_label": "DOT Regulations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28930,7 +28930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9952,
+    "id": 12560,
     "skill_label": "Daml",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28940,7 +28940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9953,
+    "id": 12561,
     "skill_label": "Dashboard Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28950,7 +28950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9954,
+    "id": 12562,
     "skill_label": "Dashboard Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28960,7 +28960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9955,
+    "id": 12563,
     "skill_label": "Dashboards",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28970,7 +28970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9956,
+    "id": 12564,
     "skill_label": "Data Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28980,7 +28980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9957,
+    "id": 12565,
     "skill_label": "Data Analytics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -28990,7 +28990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9958,
+    "id": 12566,
     "skill_label": "Data Analytics Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29000,7 +29000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9959,
+    "id": 12567,
     "skill_label": "Data Analytics Software",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29010,7 +29010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9960,
+    "id": 12568,
     "skill_label": "Data Annotation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29020,7 +29020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9961,
+    "id": 12569,
     "skill_label": "Data Architecture",
     "esco_uri": "http://data.europa.eu/esco/skill/1bba98a7-92b9-450b-9235-e0c905f8f3c4",
     "week": "2026-04-20",
@@ -29030,7 +29030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9962,
+    "id": 12570,
     "skill_label": "Data Augmentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29040,7 +29040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9963,
+    "id": 12571,
     "skill_label": "Data Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29050,7 +29050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9964,
+    "id": 12572,
     "skill_label": "Data Center Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29060,7 +29060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9965,
+    "id": 12573,
     "skill_label": "Data Center Facilities Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29070,7 +29070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9966,
+    "id": 12574,
     "skill_label": "Data Center Infrastructure",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29080,7 +29080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9967,
+    "id": 12575,
     "skill_label": "Data Center Network Infrastructure",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29090,7 +29090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9968,
+    "id": 12576,
     "skill_label": "Data Center Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29100,7 +29100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9969,
+    "id": 12577,
     "skill_label": "Data Classification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29110,7 +29110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9970,
+    "id": 12578,
     "skill_label": "Data Cleaning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29120,7 +29120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9971,
+    "id": 12579,
     "skill_label": "Data Cloud Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29130,7 +29130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9972,
+    "id": 12580,
     "skill_label": "Data Collection",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29140,7 +29140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9973,
+    "id": 12581,
     "skill_label": "Data Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29150,7 +29150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9974,
+    "id": 12582,
     "skill_label": "Data Conversion",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29160,7 +29160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9975,
+    "id": 12583,
     "skill_label": "Data Curation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29170,7 +29170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9976,
+    "id": 12584,
     "skill_label": "Data Engineering",
     "esco_uri": "http://data.europa.eu/esco/skill/48db96bf-3314-45c6-bad8-fdb6e20e5639",
     "week": "2026-04-20",
@@ -29180,7 +29180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9977,
+    "id": 12585,
     "skill_label": "Data Entry",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29190,7 +29190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9978,
+    "id": 12586,
     "skill_label": "Data Extraction",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29200,7 +29200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9979,
+    "id": 12587,
     "skill_label": "Data Governance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29210,7 +29210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9980,
+    "id": 12588,
     "skill_label": "Data Guard",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29220,7 +29220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9981,
+    "id": 12589,
     "skill_label": "Data Handling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29230,7 +29230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9982,
+    "id": 12590,
     "skill_label": "Data Ingestion",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29240,7 +29240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9983,
+    "id": 12591,
     "skill_label": "Data Insight Generation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29250,7 +29250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9984,
+    "id": 12592,
     "skill_label": "Data Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29260,7 +29260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9985,
+    "id": 12593,
     "skill_label": "Data Integrity",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29270,7 +29270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9986,
+    "id": 12594,
     "skill_label": "Data Interpretation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29280,7 +29280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9987,
+    "id": 12595,
     "skill_label": "Data Lakes",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29290,7 +29290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9988,
+    "id": 12596,
     "skill_label": "Data Loss Prevention (DLP)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29300,7 +29300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9989,
+    "id": 12597,
     "skill_label": "Data Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29310,7 +29310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9990,
+    "id": 12598,
     "skill_label": "Data Mapping",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29320,7 +29320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9991,
+    "id": 12599,
     "skill_label": "Data Migration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29330,7 +29330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9992,
+    "id": 12600,
     "skill_label": "Data Mining",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29340,7 +29340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9993,
+    "id": 12601,
     "skill_label": "Data Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29350,7 +29350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9994,
+    "id": 12602,
     "skill_label": "Data Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29360,7 +29360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9995,
+    "id": 12603,
     "skill_label": "Data Orchestration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29370,7 +29370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9996,
+    "id": 12604,
     "skill_label": "Data Persistence",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29380,7 +29380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9997,
+    "id": 12605,
     "skill_label": "Data Pipeline",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29390,7 +29390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9998,
+    "id": 12606,
     "skill_label": "Data Pipeline Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29400,7 +29400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 9999,
+    "id": 12607,
     "skill_label": "Data Pipeline Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29410,7 +29410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10000,
+    "id": 12608,
     "skill_label": "Data Pipeline Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29420,7 +29420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10001,
+    "id": 12609,
     "skill_label": "Data Pipeline Orchestration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29430,7 +29430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10002,
+    "id": 12610,
     "skill_label": "Data Pipelines",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29440,7 +29440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10003,
+    "id": 12611,
     "skill_label": "Data Preprocessing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29450,7 +29450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10004,
+    "id": 12612,
     "skill_label": "Data Presentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29460,7 +29460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10005,
+    "id": 12613,
     "skill_label": "Data Privacy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29470,7 +29470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10006,
+    "id": 12614,
     "skill_label": "Data Processing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29480,7 +29480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10007,
+    "id": 12615,
     "skill_label": "Data Processing Pipelines",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29490,7 +29490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10008,
+    "id": 12616,
     "skill_label": "Data Product Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29500,7 +29500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10009,
+    "id": 12617,
     "skill_label": "Data Project Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29510,7 +29510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10010,
+    "id": 12618,
     "skill_label": "Data Quality Assurance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29520,7 +29520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10011,
+    "id": 12619,
     "skill_label": "Data Quality Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29530,7 +29530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10012,
+    "id": 12620,
     "skill_label": "Data Querying",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29540,7 +29540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10013,
+    "id": 12621,
     "skill_label": "Data Reconciliation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29550,7 +29550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10014,
+    "id": 12622,
     "skill_label": "Data Reporting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29560,7 +29560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10015,
+    "id": 12623,
     "skill_label": "Data Science",
     "esco_uri": "http://data.europa.eu/esco/skill/edebd83d-35f6-4ed5-a940-6c203d178c01",
     "week": "2026-04-20",
@@ -29570,7 +29570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10016,
+    "id": 12624,
     "skill_label": "Data Science Fundamentals",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29580,7 +29580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10017,
+    "id": 12625,
     "skill_label": "Data Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29590,7 +29590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10018,
+    "id": 12626,
     "skill_label": "Data Storytelling & Narrative Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29600,7 +29600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10019,
+    "id": 12627,
     "skill_label": "Data Structures",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29610,7 +29610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10020,
+    "id": 12628,
     "skill_label": "Data Transformation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29620,7 +29620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10021,
+    "id": 12629,
     "skill_label": "Data Uploading",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29630,7 +29630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10022,
+    "id": 12630,
     "skill_label": "Data Validation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29640,7 +29640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10023,
+    "id": 12631,
     "skill_label": "Data Visualization",
     "esco_uri": "Data visualization",
     "week": "2026-04-20",
@@ -29650,7 +29650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10024,
+    "id": 12632,
     "skill_label": "Data Warehousing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29660,7 +29660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10025,
+    "id": 12633,
     "skill_label": "Data-Driven Decision Making",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29670,7 +29670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10026,
+    "id": 12634,
     "skill_label": "Data-Driven Problem Solving",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29680,7 +29680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10027,
+    "id": 12635,
     "skill_label": "Data-driven Applications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29690,7 +29690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10028,
+    "id": 12636,
     "skill_label": "Data-driven Decision Making",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29700,7 +29700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10029,
+    "id": 12637,
     "skill_label": "Data-driven Insights",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29710,7 +29710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10030,
+    "id": 12638,
     "skill_label": "Data-driven Research",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29720,7 +29720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10031,
+    "id": 12639,
     "skill_label": "Data-intensive Applications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29730,7 +29730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10032,
+    "id": 12640,
     "skill_label": "DataOps",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29740,7 +29740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10033,
+    "id": 12641,
     "skill_label": "Database Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29750,7 +29750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10034,
+    "id": 12642,
     "skill_label": "Database Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29760,7 +29760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10035,
+    "id": 12643,
     "skill_label": "Database Backup and Recovery",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29770,7 +29770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10036,
+    "id": 12644,
     "skill_label": "Database Deployment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29780,7 +29780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10037,
+    "id": 12645,
     "skill_label": "Database Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29790,7 +29790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10038,
+    "id": 12646,
     "skill_label": "Database Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29800,7 +29800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10039,
+    "id": 12647,
     "skill_label": "Database Governance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29810,7 +29810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10040,
+    "id": 12648,
     "skill_label": "Database Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29820,7 +29820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10041,
+    "id": 12649,
     "skill_label": "Database Interactions",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29830,7 +29830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10042,
+    "id": 12650,
     "skill_label": "Database Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29840,7 +29840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10043,
+    "id": 12651,
     "skill_label": "Database Management Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29850,7 +29850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10044,
+    "id": 12652,
     "skill_label": "Database Migration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29860,7 +29860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10045,
+    "id": 12653,
     "skill_label": "Database Performance Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29870,7 +29870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10046,
+    "id": 12654,
     "skill_label": "Database Performance Tuning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29880,7 +29880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10047,
+    "id": 12655,
     "skill_label": "Database Querying",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29890,7 +29890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10048,
+    "id": 12656,
     "skill_label": "Database Schema Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29900,7 +29900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10049,
+    "id": 12657,
     "skill_label": "Database Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29910,7 +29910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10050,
+    "id": 12658,
     "skill_label": "Database Sharding",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29920,7 +29920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10051,
+    "id": 12659,
     "skill_label": "Databricks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29930,7 +29930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10052,
+    "id": 12660,
     "skill_label": "DeFi Protocols",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29940,7 +29940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10053,
+    "id": 12661,
     "skill_label": "Debugging",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29950,7 +29950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10054,
+    "id": 12662,
     "skill_label": "Decentralized Applications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29960,7 +29960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10055,
+    "id": 12663,
     "skill_label": "Decentralized Governance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29970,7 +29970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10056,
+    "id": 12664,
     "skill_label": "Decentralized Identity",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29980,7 +29980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10057,
+    "id": 12665,
     "skill_label": "Decentralized Storage",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -29990,7 +29990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10058,
+    "id": 12666,
     "skill_label": "Decision Making",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30000,7 +30000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10059,
+    "id": 12667,
     "skill_label": "Deep Learning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30010,7 +30010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10060,
+    "id": 12668,
     "skill_label": "Deep Learning Frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30020,7 +30020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10061,
+    "id": 12669,
     "skill_label": "Defect Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30030,7 +30030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10062,
+    "id": 12670,
     "skill_label": "Defect Tracking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30040,7 +30040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10063,
+    "id": 12671,
     "skill_label": "Degree in Computer Science",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30050,7 +30050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10064,
+    "id": 12672,
     "skill_label": "Delivery Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30060,7 +30060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10065,
+    "id": 12673,
     "skill_label": "Denodo",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30070,7 +30070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10066,
+    "id": 12674,
     "skill_label": "Department of Defense",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30080,7 +30080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10067,
+    "id": 12675,
     "skill_label": "Deployment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30090,7 +30090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10068,
+    "id": 12676,
     "skill_label": "Deployment Decision Gates",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30100,7 +30100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10069,
+    "id": 12677,
     "skill_label": "Deployment Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30110,7 +30110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10070,
+    "id": 12678,
     "skill_label": "Design Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30120,7 +30120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10071,
+    "id": 12679,
     "skill_label": "Design Calculations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30130,7 +30130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10072,
+    "id": 12680,
     "skill_label": "Design Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30140,7 +30140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10073,
+    "id": 12681,
     "skill_label": "Design Patterns",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30150,7 +30150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10074,
+    "id": 12682,
     "skill_label": "Design Reviews",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30160,7 +30160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10075,
+    "id": 12683,
     "skill_label": "Design Verification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30170,7 +30170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10076,
+    "id": 12684,
     "skill_label": "Design of Experiments",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30180,7 +30180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10077,
+    "id": 12685,
     "skill_label": "Design of Experiments (DOE)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30190,7 +30190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10078,
+    "id": 12686,
     "skill_label": "Detection Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30200,7 +30200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10079,
+    "id": 12687,
     "skill_label": "DevOps",
     "esco_uri": "http://data.europa.eu/esco/skill/f0de4973-0a70-4644-8fd4-3a97080476f4",
     "week": "2026-04-20",
@@ -30210,7 +30210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10080,
+    "id": 12688,
     "skill_label": "DevOps Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30220,7 +30220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10081,
+    "id": 12689,
     "skill_label": "DevSecOps",
     "esco_uri": "DevSecOps",
     "week": "2026-04-20",
@@ -30230,7 +30230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10082,
+    "id": 12690,
     "skill_label": "Developer Community Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30240,7 +30240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10083,
+    "id": 12691,
     "skill_label": "Developer Experience",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30250,7 +30250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10084,
+    "id": 12692,
     "skill_label": "Device Coordination",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30260,7 +30260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10085,
+    "id": 12693,
     "skill_label": "Device Driver Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30270,7 +30270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10086,
+    "id": 12694,
     "skill_label": "Device Drivers",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30280,7 +30280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10087,
+    "id": 12695,
     "skill_label": "Device Tree Configuration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30290,7 +30290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10088,
+    "id": 12696,
     "skill_label": "Diagnostic Execution",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30300,7 +30300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10089,
+    "id": 12697,
     "skill_label": "Diagnostic Imaging",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30310,7 +30310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10090,
+    "id": 12698,
     "skill_label": "Diffusion Models",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30320,7 +30320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10091,
+    "id": 12699,
     "skill_label": "Digital Accessibility",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30330,7 +30330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10092,
+    "id": 12700,
     "skill_label": "Digital Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30340,7 +30340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10093,
+    "id": 12701,
     "skill_label": "Digital Display Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30350,7 +30350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10094,
+    "id": 12702,
     "skill_label": "Digital Electronics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30360,7 +30360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10095,
+    "id": 12703,
     "skill_label": "Digital Forensics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30370,7 +30370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10096,
+    "id": 12704,
     "skill_label": "Digital Forensics and Incident Response",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30380,7 +30380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10097,
+    "id": 12705,
     "skill_label": "Digital Marketing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30390,7 +30390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10098,
+    "id": 12706,
     "skill_label": "Digital Signatures",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30400,7 +30400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10099,
+    "id": 12707,
     "skill_label": "Digital Traceability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30410,7 +30410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10100,
+    "id": 12708,
     "skill_label": "Digital Transformation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30420,7 +30420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10101,
+    "id": 12709,
     "skill_label": "Digital Work Instructions",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30430,7 +30430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10102,
+    "id": 12710,
     "skill_label": "Dimensional Inspection",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30440,7 +30440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10103,
+    "id": 12711,
     "skill_label": "Direct Digital Control (DDC)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30450,7 +30450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10104,
+    "id": 12712,
     "skill_label": "Direct-to-Consumer (DTC) E-commerce",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30460,7 +30460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10105,
+    "id": 12713,
     "skill_label": "Disaster Recovery",
     "esco_uri": "http://data.europa.eu/esco/skill/fc2f1d4f-a46f-471e-a618-cbd4d0496a53",
     "week": "2026-04-20",
@@ -30470,7 +30470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10106,
+    "id": 12714,
     "skill_label": "Discrete Mathematics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30480,7 +30480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10107,
+    "id": 12715,
     "skill_label": "Dispatch",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30490,7 +30490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10108,
+    "id": 12716,
     "skill_label": "Distributed Computing",
     "esco_uri": "http://data.europa.eu/esco/skill/897b393f-e7e0-4248-a40d-d77119694e83",
     "week": "2026-04-20",
@@ -30500,7 +30500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10109,
+    "id": 12717,
     "skill_label": "Distributed Control Systems (DCS)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30510,7 +30510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10110,
+    "id": 12718,
     "skill_label": "Distributed Data Processing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30520,7 +30520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10111,
+    "id": 12719,
     "skill_label": "Distributed Ledger Technology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30530,7 +30530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10112,
+    "id": 12720,
     "skill_label": "Distributed Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30540,7 +30540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10113,
+    "id": 12721,
     "skill_label": "Distributed Training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30550,7 +30550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10114,
+    "id": 12722,
     "skill_label": "Distributive Control Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30560,7 +30560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10115,
+    "id": 12723,
     "skill_label": "Django",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30570,7 +30570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10116,
+    "id": 12724,
     "skill_label": "DoD 8140 Information Assurance Technical Level 2",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30580,7 +30580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10117,
+    "id": 12725,
     "skill_label": "DoD Directives Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30590,7 +30590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10118,
+    "id": 12726,
     "skill_label": "DoD Policies and Best Practices",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30600,7 +30600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10119,
+    "id": 12727,
     "skill_label": "DoD Security Clearance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30610,7 +30610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10120,
+    "id": 12728,
     "skill_label": "DoD Security and Compliance Frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30620,7 +30620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10121,
+    "id": 12729,
     "skill_label": "DoD Top Secret Clearance with SCI Eligibility",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30630,7 +30630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10122,
+    "id": 12730,
     "skill_label": "Docker",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30640,7 +30640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10123,
+    "id": 12731,
     "skill_label": "Document Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30650,7 +30650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10124,
+    "id": 12732,
     "skill_label": "Document Preparation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30660,7 +30660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10125,
+    "id": 12733,
     "skill_label": "Document Understanding",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30670,7 +30670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10126,
+    "id": 12734,
     "skill_label": "Documentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30680,7 +30680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10127,
+    "id": 12735,
     "skill_label": "Documentation Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30690,7 +30690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10128,
+    "id": 12736,
     "skill_label": "Documentation Reading",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30700,7 +30700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10129,
+    "id": 12737,
     "skill_label": "Documentation Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30710,7 +30710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10130,
+    "id": 12738,
     "skill_label": "Drainage Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30720,7 +30720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10131,
+    "id": 12739,
     "skill_label": "Driver's License",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30730,7 +30730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10132,
+    "id": 12740,
     "skill_label": "Due Diligence Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30740,7 +30740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10133,
+    "id": 12741,
     "skill_label": "Dynamic Application Security Testing (DAST)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30750,7 +30750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10134,
+    "id": 12742,
     "skill_label": "Dynatrace",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30760,7 +30760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10135,
+    "id": 12743,
     "skill_label": "E-Discovery",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30770,7 +30770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10136,
+    "id": 12744,
     "skill_label": "E-commerce",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30780,7 +30780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10137,
+    "id": 12745,
     "skill_label": "E-commerce Platforms",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30790,7 +30790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10138,
+    "id": 12746,
     "skill_label": "ELT",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30800,7 +30800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10139,
+    "id": 12747,
     "skill_label": "EM 385-1-1",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30810,7 +30810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10140,
+    "id": 12748,
     "skill_label": "ES6",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30820,7 +30820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10141,
+    "id": 12749,
     "skill_label": "ETL",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30830,7 +30830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10142,
+    "id": 12750,
     "skill_label": "ETL Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30840,7 +30840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10143,
+    "id": 12751,
     "skill_label": "ETL Processes",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30850,7 +30850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10144,
+    "id": 12752,
     "skill_label": "ETO Products",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30860,7 +30860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10145,
+    "id": 12753,
     "skill_label": "EVM-compatible Chains",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30870,7 +30870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10146,
+    "id": 12754,
     "skill_label": "Earned Value Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30880,7 +30880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10147,
+    "id": 12755,
     "skill_label": "Earthquake Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30890,7 +30890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10148,
+    "id": 12756,
     "skill_label": "Economic Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30900,7 +30900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10149,
+    "id": 12757,
     "skill_label": "Economics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30910,7 +30910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10150,
+    "id": 12758,
     "skill_label": "Education",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30920,7 +30920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10151,
+    "id": 12759,
     "skill_label": "Effective Communication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30930,7 +30930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10152,
+    "id": 12760,
     "skill_label": "Electrical Concepts",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30940,7 +30940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10153,
+    "id": 12761,
     "skill_label": "Electrical Drawing Interpretation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30950,7 +30950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10154,
+    "id": 12762,
     "skill_label": "Electrical Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30960,7 +30960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10155,
+    "id": 12763,
     "skill_label": "Electrical Safety",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30970,7 +30970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10156,
+    "id": 12764,
     "skill_label": "Electrical Schematics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30980,7 +30980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10157,
+    "id": 12765,
     "skill_label": "Electrical System Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -30990,7 +30990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10158,
+    "id": 12766,
     "skill_label": "Electrical Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31000,7 +31000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10159,
+    "id": 12767,
     "skill_label": "Electrical Troubleshooting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31010,7 +31010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10160,
+    "id": 12768,
     "skill_label": "Electronic Clinical Quality Measures",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31020,7 +31020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10161,
+    "id": 12769,
     "skill_label": "Electronic Data Interchange (EDI)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31030,7 +31030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10162,
+    "id": 12770,
     "skill_label": "Electronic Data Processing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31040,7 +31040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10163,
+    "id": 12771,
     "skill_label": "Electronic Health Records",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31050,7 +31050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10164,
+    "id": 12772,
     "skill_label": "Electronic Medical Records",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31060,7 +31060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10165,
+    "id": 12773,
     "skill_label": "Electronic Medical Records (EMR)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31070,7 +31070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10166,
+    "id": 12774,
     "skill_label": "Electronic Test Equipment Operation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31080,7 +31080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10167,
+    "id": 12775,
     "skill_label": "Electronics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31090,7 +31090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10168,
+    "id": 12776,
     "skill_label": "Electrostatic Discharge Handling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31100,7 +31100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10169,
+    "id": 12777,
     "skill_label": "Email Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31110,7 +31110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10170,
+    "id": 12778,
     "skill_label": "Embedded Software Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31120,7 +31120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10171,
+    "id": 12779,
     "skill_label": "Embedded System Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31130,7 +31130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10172,
+    "id": 12780,
     "skill_label": "Embedded Systems",
     "esco_uri": "http://data.europa.eu/esco/skill/2180bd8c-86de-4889-8165-adac902eee9d",
     "week": "2026-04-20",
@@ -31140,7 +31140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10173,
+    "id": 12781,
     "skill_label": "Embedded Systems Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31150,7 +31150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10174,
+    "id": 12782,
     "skill_label": "Ember.js",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31160,7 +31160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10175,
+    "id": 12783,
     "skill_label": "Emergency Operating Procedures",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31170,7 +31170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10176,
+    "id": 12784,
     "skill_label": "Emotional Intelligence",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31180,7 +31180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10177,
+    "id": 12785,
     "skill_label": "Employee Relations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31190,7 +31190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10178,
+    "id": 12786,
     "skill_label": "Employee Training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31200,7 +31200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10179,
+    "id": 12787,
     "skill_label": "Encryption",
     "esco_uri": "Encryption",
     "week": "2026-04-20",
@@ -31210,7 +31210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10180,
+    "id": 12788,
     "skill_label": "End User Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31220,7 +31220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10181,
+    "id": 12789,
     "skill_label": "End-to-End Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31230,7 +31230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10182,
+    "id": 12790,
     "skill_label": "Endpoint Data Protection",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31240,7 +31240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10183,
+    "id": 12791,
     "skill_label": "Endpoint Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31250,7 +31250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10184,
+    "id": 12792,
     "skill_label": "Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31260,7 +31260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10185,
+    "id": 12793,
     "skill_label": "Engineering Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31270,7 +31270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10186,
+    "id": 12794,
     "skill_label": "Engineering Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31280,7 +31280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10187,
+    "id": 12795,
     "skill_label": "Engineering Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31290,7 +31290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10188,
+    "id": 12796,
     "skill_label": "Engineering Design Process",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31300,7 +31300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10189,
+    "id": 12797,
     "skill_label": "Engineering Design Review",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31310,7 +31310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10190,
+    "id": 12798,
     "skill_label": "Engineering Documentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31320,7 +31320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10191,
+    "id": 12799,
     "skill_label": "Engineering Drawing Interpretation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31330,7 +31330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10192,
+    "id": 12800,
     "skill_label": "Engineering Plans and Specifications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31340,7 +31340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10193,
+    "id": 12801,
     "skill_label": "Engineering Principles",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31350,7 +31350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10194,
+    "id": 12802,
     "skill_label": "Engineering Project Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31360,7 +31360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10195,
+    "id": 12803,
     "skill_label": "Engineering Review Processes",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31370,7 +31370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10196,
+    "id": 12804,
     "skill_label": "English",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31380,7 +31380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10197,
+    "id": 12805,
     "skill_label": "English Language",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31390,7 +31390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10198,
+    "id": 12806,
     "skill_label": "English Language Proficiency",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31400,7 +31400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10199,
+    "id": 12807,
     "skill_label": "Enterprise AI Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31410,7 +31410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10200,
+    "id": 12808,
     "skill_label": "Enterprise Agreement",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31420,7 +31420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10201,
+    "id": 12809,
     "skill_label": "Enterprise Application Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31430,7 +31430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10202,
+    "id": 12810,
     "skill_label": "Enterprise Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31440,7 +31440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10203,
+    "id": 12811,
     "skill_label": "Enterprise Asset Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31450,7 +31450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10204,
+    "id": 12812,
     "skill_label": "Enterprise Cloud Solutions",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31460,7 +31460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10205,
+    "id": 12813,
     "skill_label": "Enterprise IT Ecosystem Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31470,7 +31470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10206,
+    "id": 12814,
     "skill_label": "Enterprise Infrastructure Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31480,7 +31480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10207,
+    "id": 12815,
     "skill_label": "Enterprise Network Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31490,7 +31490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10208,
+    "id": 12816,
     "skill_label": "Enterprise Network Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31500,7 +31500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10209,
+    "id": 12817,
     "skill_label": "Enterprise Networking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31510,7 +31510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10210,
+    "id": 12818,
     "skill_label": "Enterprise Reporting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31520,7 +31520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10211,
+    "id": 12819,
     "skill_label": "Enterprise Resource Planning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31530,7 +31530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10212,
+    "id": 12820,
     "skill_label": "Enterprise Resource Planning (ERP)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31540,7 +31540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10213,
+    "id": 12821,
     "skill_label": "Enterprise Security Platforms",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31550,7 +31550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10214,
+    "id": 12822,
     "skill_label": "Enterprise Systems Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31560,7 +31560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10215,
+    "id": 12823,
     "skill_label": "Entrepreneurial Marketing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31570,7 +31570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10216,
+    "id": 12824,
     "skill_label": "Entrepreneurial Mindset",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31580,7 +31580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10217,
+    "id": 12825,
     "skill_label": "Environmental Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31590,7 +31590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10218,
+    "id": 12826,
     "skill_label": "Epic Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31600,7 +31600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10219,
+    "id": 12827,
     "skill_label": "Epic Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31610,7 +31610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10220,
+    "id": 12828,
     "skill_label": "Epidemiology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31620,7 +31620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10221,
+    "id": 12829,
     "skill_label": "Equipment Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31630,7 +31630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10222,
+    "id": 12830,
     "skill_label": "Equipment Life Cycle Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31640,7 +31640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10223,
+    "id": 12831,
     "skill_label": "Equipment Maintenance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31650,7 +31650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10224,
+    "id": 12832,
     "skill_label": "Equipment Sizing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31660,7 +31660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10225,
+    "id": 12833,
     "skill_label": "Ergonomics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31670,7 +31670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10226,
+    "id": 12834,
     "skill_label": "Error Handling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31680,7 +31680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10227,
+    "id": 12835,
     "skill_label": "Esri GIS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31690,7 +31690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10228,
+    "id": 12836,
     "skill_label": "Ethereum",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31700,7 +31700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10229,
+    "id": 12837,
     "skill_label": "Ethereum Virtual Machine (EVM)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31710,7 +31710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10230,
+    "id": 12838,
     "skill_label": "Ethernet",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31720,7 +31720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10231,
+    "id": 12839,
     "skill_label": "Ethers.js",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31730,7 +31730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10232,
+    "id": 12840,
     "skill_label": "Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31740,7 +31740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10233,
+    "id": 12841,
     "skill_label": "Evaluation Methodology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31750,7 +31750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10234,
+    "id": 12842,
     "skill_label": "Event Driven Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31760,7 +31760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10235,
+    "id": 12843,
     "skill_label": "Evidence Collection",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31770,7 +31770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10236,
+    "id": 12844,
     "skill_label": "Evidence-Based Practice",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31780,7 +31780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10237,
+    "id": 12845,
     "skill_label": "Exadata",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31790,7 +31790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10238,
+    "id": 12846,
     "skill_label": "Exadata Cloud Service",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31800,7 +31800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10239,
+    "id": 12847,
     "skill_label": "Excel",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31810,7 +31810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10240,
+    "id": 12848,
     "skill_label": "Excel Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31820,7 +31820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10241,
+    "id": 12849,
     "skill_label": "Execution Plan Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31830,7 +31830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10242,
+    "id": 12850,
     "skill_label": "Executive Communication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31840,7 +31840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10243,
+    "id": 12851,
     "skill_label": "Executive-level Sales",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31850,7 +31850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10244,
+    "id": 12852,
     "skill_label": "Exit Strategy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31860,7 +31860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10245,
+    "id": 12853,
     "skill_label": "Experiment Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31870,7 +31870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10246,
+    "id": 12854,
     "skill_label": "Experiment Tracking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31880,7 +31880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10247,
+    "id": 12855,
     "skill_label": "Experimental Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31890,7 +31890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10248,
+    "id": 12856,
     "skill_label": "Experimentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31900,7 +31900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10249,
+    "id": 12857,
     "skill_label": "Experimentation Frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31910,7 +31910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10250,
+    "id": 12858,
     "skill_label": "Exploit Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31920,7 +31920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10251,
+    "id": 12859,
     "skill_label": "Exploitation Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31930,7 +31930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10252,
+    "id": 12860,
     "skill_label": "Exploratory Data Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31940,7 +31940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10253,
+    "id": 12861,
     "skill_label": "Exploratory Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31950,7 +31950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10254,
+    "id": 12862,
     "skill_label": "Express.js",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31960,7 +31960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10255,
+    "id": 12863,
     "skill_label": "Exterior Trim Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31970,7 +31970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10256,
+    "id": 12864,
     "skill_label": "Extract, Transform, Load (ETL)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31980,7 +31980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10257,
+    "id": 12865,
     "skill_label": "Extrusion",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -31990,7 +31990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10258,
+    "id": 12866,
     "skill_label": "FAA Regulations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32000,7 +32000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10259,
+    "id": 12867,
     "skill_label": "FDA Regulatory Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32010,7 +32010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10260,
+    "id": 12868,
     "skill_label": "FIPS 199",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32020,7 +32020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10261,
+    "id": 12869,
     "skill_label": "FPGA Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32030,7 +32030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10262,
+    "id": 12870,
     "skill_label": "Facets Components",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32040,7 +32040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10263,
+    "id": 12871,
     "skill_label": "Facets G6 Transition",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32050,7 +32050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10264,
+    "id": 12872,
     "skill_label": "Facility Layout Planning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32060,7 +32060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10265,
+    "id": 12873,
     "skill_label": "Failure Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32070,7 +32070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10266,
+    "id": 12874,
     "skill_label": "Failure Mode and Effects Analysis (FMEA)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32080,7 +32080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10267,
+    "id": 12875,
     "skill_label": "Fairness",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32090,7 +32090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10268,
+    "id": 12876,
     "skill_label": "Fairness in AI",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32100,7 +32100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10269,
+    "id": 12877,
     "skill_label": "False Positive Reduction",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32110,7 +32110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10270,
+    "id": 12878,
     "skill_label": "Fast-paced Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32120,7 +32120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10271,
+    "id": 12879,
     "skill_label": "Feature Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32130,7 +32130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10272,
+    "id": 12880,
     "skill_label": "Feature Ownership",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32140,7 +32140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10273,
+    "id": 12881,
     "skill_label": "Feature Store",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32150,7 +32150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10274,
+    "id": 12882,
     "skill_label": "Feature Stores",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32160,7 +32160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10275,
+    "id": 12883,
     "skill_label": "Federal Contracting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32170,7 +32170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10276,
+    "id": 12884,
     "skill_label": "Federal Procurement",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32180,7 +32180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10277,
+    "id": 12885,
     "skill_label": "Federal Regulations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32190,7 +32190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10278,
+    "id": 12886,
     "skill_label": "Fiber Optic Infrastructure",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32200,7 +32200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10279,
+    "id": 12887,
     "skill_label": "Fiber Optics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32210,7 +32210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10280,
+    "id": 12888,
     "skill_label": "Field Device Configuration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32220,7 +32220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10281,
+    "id": 12889,
     "skill_label": "Field Maintenance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32230,7 +32230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10282,
+    "id": 12890,
     "skill_label": "Field Service",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32240,7 +32240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10283,
+    "id": 12891,
     "skill_label": "Field Service Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32250,7 +32250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10284,
+    "id": 12892,
     "skill_label": "Finance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32260,7 +32260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10285,
+    "id": 12893,
     "skill_label": "Financial Accounting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32270,7 +32270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10286,
+    "id": 12894,
     "skill_label": "Financial Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32280,7 +32280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10287,
+    "id": 12895,
     "skill_label": "Financial Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32290,7 +32290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10288,
+    "id": 12896,
     "skill_label": "Financial Auditing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32300,7 +32300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10289,
+    "id": 12897,
     "skill_label": "Financial Concepts",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32310,7 +32310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10290,
+    "id": 12898,
     "skill_label": "Financial Cost Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32320,7 +32320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10291,
+    "id": 12899,
     "skill_label": "Financial Markets",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32330,7 +32330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10292,
+    "id": 12900,
     "skill_label": "Financial Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32340,7 +32340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10293,
+    "id": 12901,
     "skill_label": "Financial Performance Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32350,7 +32350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10294,
+    "id": 12902,
     "skill_label": "Financial Procedures",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32360,7 +32360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10295,
+    "id": 12903,
     "skill_label": "Financial Products Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32370,7 +32370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10296,
+    "id": 12904,
     "skill_label": "Financial Reasoning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32380,7 +32380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10297,
+    "id": 12905,
     "skill_label": "Financial Reporting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32390,7 +32390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10298,
+    "id": 12906,
     "skill_label": "Financial Services",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32400,7 +32400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10299,
+    "id": 12907,
     "skill_label": "Financial Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32410,7 +32410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10300,
+    "id": 12908,
     "skill_label": "Fine-tuning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32420,7 +32420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10301,
+    "id": 12909,
     "skill_label": "Fire Alarm Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32430,7 +32430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10302,
+    "id": 12910,
     "skill_label": "Fires Tactical Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32440,7 +32440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10303,
+    "id": 12911,
     "skill_label": "Firewall",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32450,7 +32450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10304,
+    "id": 12912,
     "skill_label": "Firewall Configuration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32460,7 +32460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10305,
+    "id": 12913,
     "skill_label": "Firewall Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32470,7 +32470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10306,
+    "id": 12914,
     "skill_label": "Firewall Rule Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32480,7 +32480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10307,
+    "id": 12915,
     "skill_label": "Firmware Debugging",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32490,7 +32490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10308,
+    "id": 12916,
     "skill_label": "Firmware Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32500,7 +32500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10309,
+    "id": 12917,
     "skill_label": "Firmware Updates",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32510,7 +32510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10310,
+    "id": 12918,
     "skill_label": "Firmware Upgrades",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32520,7 +32520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10311,
+    "id": 12919,
     "skill_label": "Force Protection",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32530,7 +32530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10312,
+    "id": 12920,
     "skill_label": "Forcepoint",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32540,7 +32540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10313,
+    "id": 12921,
     "skill_label": "Forecasting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32550,7 +32550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10314,
+    "id": 12922,
     "skill_label": "Formal Methods",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32560,7 +32560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10315,
+    "id": 12923,
     "skill_label": "Founder Journey Experience",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32570,7 +32570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10316,
+    "id": 12924,
     "skill_label": "Foundry",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32580,7 +32580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10317,
+    "id": 12925,
     "skill_label": "Front-End Web Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32590,7 +32590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10318,
+    "id": 12926,
     "skill_label": "Frontend Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32600,7 +32600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10319,
+    "id": 12927,
     "skill_label": "Full Stack Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32610,7 +32610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10320,
+    "id": 12928,
     "skill_label": "Full-Stack Web Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32620,7 +32620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10321,
+    "id": 12929,
     "skill_label": "Functional & Technical Documentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32630,7 +32630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10322,
+    "id": 12930,
     "skill_label": "Functional Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32640,7 +32640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10323,
+    "id": 12931,
     "skill_label": "Functional Documentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32650,7 +32650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10324,
+    "id": 12932,
     "skill_label": "Functional Specification Writing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32660,7 +32660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10325,
+    "id": 12933,
     "skill_label": "Functional Specifications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32670,7 +32670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10326,
+    "id": 12934,
     "skill_label": "Functional Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32680,7 +32680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10327,
+    "id": 12935,
     "skill_label": "Fundraising",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32690,7 +32690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10328,
+    "id": 12936,
     "skill_label": "Fundraising Process",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32700,7 +32700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10329,
+    "id": 12937,
     "skill_label": "Fuzz Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32710,7 +32710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10330,
+    "id": 12938,
     "skill_label": "GCFA",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32720,7 +32720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10331,
+    "id": 12939,
     "skill_label": "GDB",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32730,7 +32730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10332,
+    "id": 12940,
     "skill_label": "GMP",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32740,7 +32740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10333,
+    "id": 12941,
     "skill_label": "GPU Computing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32750,7 +32750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10334,
+    "id": 12942,
     "skill_label": "GREM",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32760,7 +32760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10335,
+    "id": 12943,
     "skill_label": "Gage Repeatability and Reproducibility (Gage R&R)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32770,7 +32770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10336,
+    "id": 12944,
     "skill_label": "Game Technology Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32780,7 +32780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10337,
+    "id": 12945,
     "skill_label": "Gap Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32790,7 +32790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10338,
+    "id": 12946,
     "skill_label": "Gas Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32800,7 +32800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10339,
+    "id": 12947,
     "skill_label": "GenAI Technologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32810,7 +32810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10340,
+    "id": 12948,
     "skill_label": "General Electric (GE) PLCs",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32820,7 +32820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10341,
+    "id": 12949,
     "skill_label": "Generative AI",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32830,7 +32830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10342,
+    "id": 12950,
     "skill_label": "Generative Artificial Intelligence",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32840,7 +32840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10343,
+    "id": 12951,
     "skill_label": "Genesys",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32850,7 +32850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10344,
+    "id": 12952,
     "skill_label": "Genesys Cloud",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32860,7 +32860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10345,
+    "id": 12953,
     "skill_label": "Genesys Cloud CX",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32870,7 +32870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10346,
+    "id": 12954,
     "skill_label": "Geolocation Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32880,7 +32880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10347,
+    "id": 12955,
     "skill_label": "Geomatics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32890,7 +32890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10348,
+    "id": 12956,
     "skill_label": "Geospatial Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32900,7 +32900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10349,
+    "id": 12957,
     "skill_label": "Geotechnical Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32910,7 +32910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10350,
+    "id": 12958,
     "skill_label": "Ghidra",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32920,7 +32920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10351,
+    "id": 12959,
     "skill_label": "Git",
     "esco_uri": "http://data.europa.eu/esco/skill/9d2e926f-53d9-41f5-98f3-19dfaa687f3f",
     "week": "2026-04-20",
@@ -32930,7 +32930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10352,
+    "id": 12960,
     "skill_label": "GitOps",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32940,7 +32940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10353,
+    "id": 12961,
     "skill_label": "Glucose Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32950,7 +32950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10354,
+    "id": 12962,
     "skill_label": "Go",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32960,7 +32960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10355,
+    "id": 12963,
     "skill_label": "Go-to-Market Strategy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32970,7 +32970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10356,
+    "id": 12964,
     "skill_label": "Go-to-market Strategy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32980,7 +32980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10357,
+    "id": 12965,
     "skill_label": "Google Analytics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -32990,7 +32990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10358,
+    "id": 12966,
     "skill_label": "Google Cloud Architect",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33000,7 +33000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10359,
+    "id": 12967,
     "skill_label": "Google Cloud Platform",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33010,7 +33010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10360,
+    "id": 12968,
     "skill_label": "Governance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33020,7 +33020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10361,
+    "id": 12969,
     "skill_label": "Government Audits",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33030,7 +33030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10362,
+    "id": 12970,
     "skill_label": "Grafana",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33040,7 +33040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10363,
+    "id": 12971,
     "skill_label": "Graph Algorithms",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33050,7 +33050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10364,
+    "id": 12972,
     "skill_label": "Graph Databases",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33060,7 +33060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10365,
+    "id": 12973,
     "skill_label": "Graph Neural Networks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33070,7 +33070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10366,
+    "id": 12974,
     "skill_label": "Graph Representation Learning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33080,7 +33080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10367,
+    "id": 12975,
     "skill_label": "Graph-based Data Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33090,7 +33090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10368,
+    "id": 12976,
     "skill_label": "GraphQL",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33100,7 +33100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10369,
+    "id": 12977,
     "skill_label": "Graphic Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33110,7 +33110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10370,
+    "id": 12978,
     "skill_label": "Green Belt Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33120,7 +33120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10371,
+    "id": 12979,
     "skill_label": "Groovy",
     "esco_uri": "http://data.europa.eu/esco/skill/52cf3037-ab53-4806-85ed-7fd21ea7f6a1",
     "week": "2026-04-20",
@@ -33130,7 +33130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10372,
+    "id": 12980,
     "skill_label": "Group Policy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33140,7 +33140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10373,
+    "id": 12981,
     "skill_label": "Growth Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33150,7 +33150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10374,
+    "id": 12982,
     "skill_label": "Growth Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33160,7 +33160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10375,
+    "id": 12983,
     "skill_label": "Gulp",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33170,7 +33170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10376,
+    "id": 12984,
     "skill_label": "HEDIS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33180,7 +33180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10377,
+    "id": 12985,
     "skill_label": "HIPAA Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33190,7 +33190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10378,
+    "id": 12986,
     "skill_label": "HMI",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33200,7 +33200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10379,
+    "id": 12987,
     "skill_label": "HRIS Platforms",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33210,7 +33210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10380,
+    "id": 12988,
     "skill_label": "HS System",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33220,7 +33220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10381,
+    "id": 12989,
     "skill_label": "HTML",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33230,7 +33230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10382,
+    "id": 12990,
     "skill_label": "HTML5",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33240,7 +33240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10383,
+    "id": 12991,
     "skill_label": "HTTP",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33250,7 +33250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10384,
+    "id": 12992,
     "skill_label": "HVAC",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33260,7 +33260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10385,
+    "id": 12993,
     "skill_label": "HVAC Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33270,7 +33270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10386,
+    "id": 12994,
     "skill_label": "Hadoop",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33280,7 +33280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10387,
+    "id": 12995,
     "skill_label": "Harbor Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33290,7 +33290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10388,
+    "id": 12996,
     "skill_label": "Hardhat",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33300,7 +33300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10389,
+    "id": 12997,
     "skill_label": "Hardware Abstraction Layer",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33310,7 +33310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10390,
+    "id": 12998,
     "skill_label": "Hardware Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33320,7 +33320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10391,
+    "id": 12999,
     "skill_label": "Hardware Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33330,7 +33330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10392,
+    "id": 13000,
     "skill_label": "Hardware Debugging Tools",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33340,7 +33340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10393,
+    "id": 13001,
     "skill_label": "Hardware Diagnostics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33350,7 +33350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10394,
+    "id": 13002,
     "skill_label": "Hardware Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33360,7 +33360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10395,
+    "id": 13003,
     "skill_label": "Hardware Installation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33370,7 +33370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10396,
+    "id": 13004,
     "skill_label": "Hardware Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33380,7 +33380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10397,
+    "id": 13005,
     "skill_label": "Hardware Lifecycle Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33390,7 +33390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10398,
+    "id": 13006,
     "skill_label": "Hardware Specifications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33400,7 +33400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10399,
+    "id": 13007,
     "skill_label": "Hardware Troubleshooting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33410,7 +33410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10400,
+    "id": 13008,
     "skill_label": "Hardware and Software Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33420,7 +33420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10401,
+    "id": 13009,
     "skill_label": "Haskell",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33430,7 +33430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10402,
+    "id": 13010,
     "skill_label": "Health Informatics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33440,7 +33440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10403,
+    "id": 13011,
     "skill_label": "Health Information Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33450,7 +33450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10404,
+    "id": 13012,
     "skill_label": "Health Safety and Environment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33460,7 +33460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10405,
+    "id": 13013,
     "skill_label": "Healthcare",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33470,7 +33470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10406,
+    "id": 13014,
     "skill_label": "Healthcare Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33480,7 +33480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10407,
+    "id": 13015,
     "skill_label": "Healthcare Analytics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33490,7 +33490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10408,
+    "id": 13016,
     "skill_label": "Healthcare Data Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33500,7 +33500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10409,
+    "id": 13017,
     "skill_label": "Healthcare Data Formats",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33510,7 +33510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10410,
+    "id": 13018,
     "skill_label": "Healthcare Data Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33520,7 +33520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10411,
+    "id": 13019,
     "skill_label": "Healthcare Expertise",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33530,7 +33530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10412,
+    "id": 13020,
     "skill_label": "Healthcare IT",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33540,7 +33540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10413,
+    "id": 13021,
     "skill_label": "Healthcare Industry Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33550,7 +33550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10414,
+    "id": 13022,
     "skill_label": "Healthcare Informatics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33560,7 +33560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10415,
+    "id": 13023,
     "skill_label": "Healthcare Information Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33570,7 +33570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10416,
+    "id": 13024,
     "skill_label": "Healthcare Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33580,7 +33580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10417,
+    "id": 13025,
     "skill_label": "Healthcare Payer Domain",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33590,7 +33590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10418,
+    "id": 13026,
     "skill_label": "Healthcare Payer Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33600,7 +33600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10419,
+    "id": 13027,
     "skill_label": "Healthcare Technology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33610,7 +33610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10420,
+    "id": 13028,
     "skill_label": "Hematology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33620,7 +33620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10421,
+    "id": 13029,
     "skill_label": "High Availability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33630,7 +33630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10422,
+    "id": 13030,
     "skill_label": "High Availability Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33640,7 +33640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10423,
+    "id": 13031,
     "skill_label": "High Availability and Disaster Recovery",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33650,7 +33650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10424,
+    "id": 13032,
     "skill_label": "High Performance Computing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33660,7 +33660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10425,
+    "id": 13033,
     "skill_label": "High-dimensional Data Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33670,7 +33670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10426,
+    "id": 13034,
     "skill_label": "Higher Education Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33680,7 +33680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10427,
+    "id": 13035,
     "skill_label": "Hospital Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33690,7 +33690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10428,
+    "id": 13036,
     "skill_label": "Human Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33700,7 +33700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10429,
+    "id": 13037,
     "skill_label": "Human Intelligence (HUMINT)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33710,7 +33710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10430,
+    "id": 13038,
     "skill_label": "Human Machine Interface",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33720,7 +33720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10431,
+    "id": 13039,
     "skill_label": "Human Machine Interface (HMI)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33730,7 +33730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10432,
+    "id": 13040,
     "skill_label": "Human Machine Interface (HMI) Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33740,7 +33740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10433,
+    "id": 13041,
     "skill_label": "Human Machine Interface (HMI) Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33750,7 +33750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10434,
+    "id": 13042,
     "skill_label": "Human-AI Interaction",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33760,7 +33760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10435,
+    "id": 13043,
     "skill_label": "Human-Computer Interaction",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33770,7 +33770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10436,
+    "id": 13044,
     "skill_label": "Human-in-the-loop",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33780,7 +33780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10437,
+    "id": 13045,
     "skill_label": "Hybrid Cloud",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33790,7 +33790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10438,
+    "id": 13046,
     "skill_label": "Hybrid Cloud Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33800,7 +33800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10439,
+    "id": 13047,
     "skill_label": "Hybrid Cloud Computing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33810,7 +33810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10440,
+    "id": 13048,
     "skill_label": "Hydraulic Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33820,7 +33820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10441,
+    "id": 13049,
     "skill_label": "Hydraulic Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33830,7 +33830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10442,
+    "id": 13050,
     "skill_label": "Hydraulics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33840,7 +33840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10443,
+    "id": 13051,
     "skill_label": "Hyperparameter Tuning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33850,7 +33850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10444,
+    "id": 13052,
     "skill_label": "Hypothesis Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33860,7 +33860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10445,
+    "id": 13053,
     "skill_label": "I2C",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33870,7 +33870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10446,
+    "id": 13054,
     "skill_label": "IBM Cognos Analytics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33880,7 +33880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10447,
+    "id": 13055,
     "skill_label": "IBM Informix",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33890,7 +33890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10448,
+    "id": 13056,
     "skill_label": "IDA Pro",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33900,7 +33900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10449,
+    "id": 13057,
     "skill_label": "IP Address Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33910,7 +33910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10450,
+    "id": 13058,
     "skill_label": "IP Addressing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33920,7 +33920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10451,
+    "id": 13059,
     "skill_label": "IP Cameras",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33930,7 +33930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10452,
+    "id": 13060,
     "skill_label": "IPFS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33940,7 +33940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10453,
+    "id": 13061,
     "skill_label": "IQ/OQ/PQ",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33950,7 +33950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10454,
+    "id": 13062,
     "skill_label": "ISO Standards",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33960,7 +33960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10455,
+    "id": 13063,
     "skill_label": "ISTQB",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33970,7 +33970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10456,
+    "id": 13064,
     "skill_label": "IT Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33980,7 +33980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10457,
+    "id": 13065,
     "skill_label": "IT Infrastructure Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -33990,7 +33990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10458,
+    "id": 13066,
     "skill_label": "IT Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34000,7 +34000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10459,
+    "id": 13067,
     "skill_label": "IT Service Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34010,7 +34010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10460,
+    "id": 13068,
     "skill_label": "IT Service Management (ITSM)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34020,7 +34020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10461,
+    "id": 13069,
     "skill_label": "IT Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34030,7 +34030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10462,
+    "id": 13070,
     "skill_label": "IT Systems Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34040,7 +34040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10463,
+    "id": 13071,
     "skill_label": "Identity and Access Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34050,7 +34050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10464,
+    "id": 13072,
     "skill_label": "Identity and Access Management (IAM)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34060,7 +34060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10465,
+    "id": 13073,
     "skill_label": "Image Classification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34070,7 +34070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10466,
+    "id": 13074,
     "skill_label": "Image Processing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34080,7 +34080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10467,
+    "id": 13075,
     "skill_label": "Imagery Intelligence (IMINT)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34090,7 +34090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10468,
+    "id": 13076,
     "skill_label": "Impact Reporting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34100,7 +34100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10469,
+    "id": 13077,
     "skill_label": "Incident Investigation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34110,7 +34110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10470,
+    "id": 13078,
     "skill_label": "Incident Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34120,7 +34120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10471,
+    "id": 13079,
     "skill_label": "Incident Resolution",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34130,7 +34130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10472,
+    "id": 13080,
     "skill_label": "Incident Response",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34140,7 +34140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10473,
+    "id": 13081,
     "skill_label": "Incoming Quality Control",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34150,7 +34150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10474,
+    "id": 13082,
     "skill_label": "Independent Work",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34160,7 +34160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10475,
+    "id": 13083,
     "skill_label": "Independent Working",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34170,7 +34170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10476,
+    "id": 13084,
     "skill_label": "Indexing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34180,7 +34180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10477,
+    "id": 13085,
     "skill_label": "Industrial Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34190,7 +34190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10478,
+    "id": 13086,
     "skill_label": "Industrial Automation Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34200,7 +34200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10479,
+    "id": 13087,
     "skill_label": "Industrial Communication Protocols",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34210,7 +34210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10480,
+    "id": 13088,
     "skill_label": "Industrial Control Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34220,7 +34220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10481,
+    "id": 13089,
     "skill_label": "Industrial Controls",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34230,7 +34230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10482,
+    "id": 13090,
     "skill_label": "Industrial Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34240,7 +34240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10483,
+    "id": 13091,
     "skill_label": "Industrial Engineering Techniques",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34250,7 +34250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10484,
+    "id": 13092,
     "skill_label": "Industrial Networking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34260,7 +34260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10485,
+    "id": 13093,
     "skill_label": "Industrial Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34270,7 +34270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10486,
+    "id": 13094,
     "skill_label": "Industry 4.0",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34280,7 +34280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10487,
+    "id": 13095,
     "skill_label": "Industry Product Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34290,7 +34290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10488,
+    "id": 13096,
     "skill_label": "Inference",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34300,7 +34300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10489,
+    "id": 13097,
     "skill_label": "Inference Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34310,7 +34310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10490,
+    "id": 13098,
     "skill_label": "Information Assurance Technical (IAT) Level 2",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34320,7 +34320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10491,
+    "id": 13099,
     "skill_label": "Information Retrieval",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34330,7 +34330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10492,
+    "id": 13100,
     "skill_label": "Information Security",
     "esco_uri": "http://data.europa.eu/esco/skill/8088750d-8388-4170-a76f-48354c469c44",
     "week": "2026-04-20",
@@ -34340,7 +34340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10493,
+    "id": 13101,
     "skill_label": "Information Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34350,7 +34350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10494,
+    "id": 13102,
     "skill_label": "Information Technology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34360,7 +34360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10495,
+    "id": 13103,
     "skill_label": "Information Technology Consulting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34370,7 +34370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10496,
+    "id": 13104,
     "skill_label": "Infrastructure Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34380,7 +34380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10497,
+    "id": 13105,
     "skill_label": "Infrastructure Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34390,7 +34390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10498,
+    "id": 13106,
     "skill_label": "Infrastructure Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34400,7 +34400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10499,
+    "id": 13107,
     "skill_label": "Infrastructure Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34410,7 +34410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10500,
+    "id": 13108,
     "skill_label": "Infrastructure Troubleshooting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34420,7 +34420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10501,
+    "id": 13109,
     "skill_label": "Infrastructure as Code",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34430,7 +34430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10502,
+    "id": 13110,
     "skill_label": "Input/Output (IO) List Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34440,7 +34440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10503,
+    "id": 13111,
     "skill_label": "Inside Plant Cable Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34450,7 +34450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10504,
+    "id": 13112,
     "skill_label": "Inspection",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34460,7 +34460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10505,
+    "id": 13113,
     "skill_label": "Inspection and Test Plans (ITP)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34470,7 +34470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10506,
+    "id": 13114,
     "skill_label": "Installation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34480,7 +34480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10507,
+    "id": 13115,
     "skill_label": "Instrumentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34490,7 +34490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10508,
+    "id": 13116,
     "skill_label": "Instrumentation Specification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34500,7 +34500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10509,
+    "id": 13117,
     "skill_label": "Instrumentation and Control Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34510,7 +34510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10510,
+    "id": 13118,
     "skill_label": "Instrumentation and Control Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34520,7 +34520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10511,
+    "id": 13119,
     "skill_label": "Insurance Claims Processing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34530,7 +34530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10512,
+    "id": 13120,
     "skill_label": "Insurance Documentation Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34540,7 +34540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10513,
+    "id": 13121,
     "skill_label": "Insurance Planning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34550,7 +34550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10514,
+    "id": 13122,
     "skill_label": "Integer Truncation Vulnerability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34560,7 +34560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10515,
+    "id": 13123,
     "skill_label": "Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34570,7 +34570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10516,
+    "id": 13124,
     "skill_label": "Integration Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34580,7 +34580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10517,
+    "id": 13125,
     "skill_label": "Integration Validation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34590,7 +34590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10518,
+    "id": 13126,
     "skill_label": "Integration and Test",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34600,7 +34600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10519,
+    "id": 13127,
     "skill_label": "Integrator",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34610,7 +34610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10520,
+    "id": 13128,
     "skill_label": "Intelligence Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34620,7 +34620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10521,
+    "id": 13129,
     "skill_label": "Intelligence Fusion",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34630,7 +34630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10522,
+    "id": 13130,
     "skill_label": "Intelligence Product Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34640,7 +34640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10523,
+    "id": 13131,
     "skill_label": "Interaction Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34650,7 +34650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10524,
+    "id": 13132,
     "skill_label": "Interactive Voice Response (IVR)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34660,7 +34660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10525,
+    "id": 13133,
     "skill_label": "Interdisciplinary Collaboration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34670,7 +34670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10526,
+    "id": 13134,
     "skill_label": "Interface Control",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34680,7 +34680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10527,
+    "id": 13135,
     "skill_label": "Interface Definition",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34690,7 +34690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10528,
+    "id": 13136,
     "skill_label": "Internal Auditing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34700,7 +34700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10529,
+    "id": 13137,
     "skill_label": "International Contracting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34710,7 +34710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10530,
+    "id": 13138,
     "skill_label": "International Traffic in Arms Regulations (ITAR) Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34720,7 +34720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10531,
+    "id": 13139,
     "skill_label": "Internet Information Services (IIS)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34730,7 +34730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10532,
+    "id": 13140,
     "skill_label": "Internet Networking Technologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34740,7 +34740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10533,
+    "id": 13141,
     "skill_label": "Internet Protocol (IP) Subnetting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34750,7 +34750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10534,
+    "id": 13142,
     "skill_label": "Interpersonal Skills",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34760,7 +34760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10535,
+    "id": 13143,
     "skill_label": "Interpretability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34770,7 +34770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10536,
+    "id": 13144,
     "skill_label": "Interpreted Programming Languages",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34780,7 +34780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10537,
+    "id": 13145,
     "skill_label": "Interprocess Communication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34790,7 +34790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10538,
+    "id": 13146,
     "skill_label": "Intrusion Detection",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34800,7 +34800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10539,
+    "id": 13147,
     "skill_label": "Intrusion Detection Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34810,7 +34810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10540,
+    "id": 13148,
     "skill_label": "Intrusion Prevention Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34820,7 +34820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10541,
+    "id": 13149,
     "skill_label": "Inventory Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34830,7 +34830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10542,
+    "id": 13150,
     "skill_label": "Inventory Reconciliation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34840,7 +34840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10543,
+    "id": 13151,
     "skill_label": "Investigative Data Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34850,7 +34850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10544,
+    "id": 13152,
     "skill_label": "Investigative Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34860,7 +34860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10545,
+    "id": 13153,
     "skill_label": "Investment Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34870,7 +34870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10546,
+    "id": 13154,
     "skill_label": "Investment Banking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34880,7 +34880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10547,
+    "id": 13155,
     "skill_label": "Investment Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34890,7 +34890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10548,
+    "id": 13156,
     "skill_label": "Item Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34900,7 +34900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10549,
+    "id": 13157,
     "skill_label": "JAX",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34910,7 +34910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10550,
+    "id": 13158,
     "skill_label": "JCL",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34920,7 +34920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10551,
+    "id": 13159,
     "skill_label": "JFrog Artifactory",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34930,7 +34930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10552,
+    "id": 13160,
     "skill_label": "JMeter",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34940,7 +34940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10553,
+    "id": 13161,
     "skill_label": "JNCIA",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34950,7 +34950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10554,
+    "id": 13162,
     "skill_label": "JNCIP",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34960,7 +34960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10555,
+    "id": 13163,
     "skill_label": "JSON",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34970,7 +34970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10556,
+    "id": 13164,
     "skill_label": "JUnit",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34980,7 +34980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10557,
+    "id": 13165,
     "skill_label": "Jaguar",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -34990,7 +34990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10558,
+    "id": 13166,
     "skill_label": "Java",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35000,7 +35000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10559,
+    "id": 13167,
     "skill_label": "Java Platform, Enterprise Edition (J2EE)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35010,7 +35010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10560,
+    "id": 13168,
     "skill_label": "JavaScript",
     "esco_uri": "http://data.europa.eu/esco/skill/3cd569a2-4f88-4c1e-9995-8dce8c5e51a7",
     "week": "2026-04-20",
@@ -35020,7 +35020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10561,
+    "id": 13169,
     "skill_label": "Joint Venture Agreements",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35030,7 +35030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10562,
+    "id": 13170,
     "skill_label": "Just-In-Time",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35040,7 +35040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10563,
+    "id": 13171,
     "skill_label": "KPI Definition",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35050,7 +35050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10564,
+    "id": 13172,
     "skill_label": "KPI Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35060,7 +35060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10565,
+    "id": 13173,
     "skill_label": "KPI Frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35070,7 +35070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10566,
+    "id": 13174,
     "skill_label": "Kafka",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35080,7 +35080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10567,
+    "id": 13175,
     "skill_label": "Kaizen",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35090,7 +35090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10568,
+    "id": 13176,
     "skill_label": "Kanban",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35100,7 +35100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10569,
+    "id": 13177,
     "skill_label": "Kerberos",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35110,7 +35110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10570,
+    "id": 13178,
     "skill_label": "Key Performance Indicators (KPIs)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35120,7 +35120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10571,
+    "id": 13179,
     "skill_label": "Keyword Research",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35130,7 +35130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10572,
+    "id": 13180,
     "skill_label": "Knockout",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35140,7 +35140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10573,
+    "id": 13181,
     "skill_label": "Knowledge Distillation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35150,7 +35150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10574,
+    "id": 13182,
     "skill_label": "Knowledge Extraction",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35160,7 +35160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10575,
+    "id": 13183,
     "skill_label": "Knowledge Graphs",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35170,7 +35170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10576,
+    "id": 13184,
     "skill_label": "Kotlin",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35180,7 +35180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10577,
+    "id": 13185,
     "skill_label": "Kubernetes",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35190,7 +35190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10578,
+    "id": 13186,
     "skill_label": "LAN",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35200,7 +35200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10579,
+    "id": 13187,
     "skill_label": "LAN Technologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35210,7 +35210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10580,
+    "id": 13188,
     "skill_label": "LLM Deployment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35220,7 +35220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10581,
+    "id": 13189,
     "skill_label": "LLM Jailbreak Attacks and Defense",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35230,7 +35230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10582,
+    "id": 13190,
     "skill_label": "LLMOps",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35240,7 +35240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10583,
+    "id": 13191,
     "skill_label": "LLMs",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35250,7 +35250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10584,
+    "id": 13192,
     "skill_label": "Labels",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35260,7 +35260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10585,
+    "id": 13193,
     "skill_label": "Labor Market Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35270,7 +35270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10586,
+    "id": 13194,
     "skill_label": "Labor Utilization Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35280,7 +35280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10587,
+    "id": 13195,
     "skill_label": "Laboratory Services",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35290,7 +35290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10588,
+    "id": 13196,
     "skill_label": "Laboratory Specimen Processing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35300,7 +35300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10589,
+    "id": 13197,
     "skill_label": "Ladder Logic",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35310,7 +35310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10590,
+    "id": 13198,
     "skill_label": "Large Language Models",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35320,7 +35320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10591,
+    "id": 13199,
     "skill_label": "Large Scale Data Processing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35330,7 +35330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10592,
+    "id": 13200,
     "skill_label": "Large Scale Machine Learning Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35340,7 +35340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10593,
+    "id": 13201,
     "skill_label": "Large-scale Data Pipeline Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35350,7 +35350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10594,
+    "id": 13202,
     "skill_label": "Large-scale Dataset Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35360,7 +35360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10595,
+    "id": 13203,
     "skill_label": "Large-scale Model Training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35370,7 +35370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10596,
+    "id": 13204,
     "skill_label": "Large-scale Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35380,7 +35380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10597,
+    "id": 13205,
     "skill_label": "Law Enforcement",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35390,7 +35390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10598,
+    "id": 13206,
     "skill_label": "Law Enforcement Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35400,7 +35400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10599,
+    "id": 13207,
     "skill_label": "Lead Generation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35410,7 +35410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10600,
+    "id": 13208,
     "skill_label": "Leadership",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35420,7 +35420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10601,
+    "id": 13209,
     "skill_label": "Lean",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35430,7 +35430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10602,
+    "id": 13210,
     "skill_label": "Lean Manufacturing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35440,7 +35440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10603,
+    "id": 13211,
     "skill_label": "Lean Practices",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35450,7 +35450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10604,
+    "id": 13212,
     "skill_label": "Lean Six Sigma",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35460,7 +35460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10605,
+    "id": 13213,
     "skill_label": "Learning Management Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35470,7 +35470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10606,
+    "id": 13214,
     "skill_label": "Least Privilege",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35480,7 +35480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10607,
+    "id": 13215,
     "skill_label": "Least Privilege Access",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35490,7 +35490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10608,
+    "id": 13216,
     "skill_label": "Legacy Application Modernization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35500,7 +35500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10609,
+    "id": 13217,
     "skill_label": "Legacy Code Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35510,7 +35510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10610,
+    "id": 13218,
     "skill_label": "Licensing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35520,7 +35520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10611,
+    "id": 13219,
     "skill_label": "Life Cycle Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35530,7 +35530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10612,
+    "id": 13220,
     "skill_label": "Life Insurance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35540,7 +35540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10613,
+    "id": 13221,
     "skill_label": "Life Safety Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35550,7 +35550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10614,
+    "id": 13222,
     "skill_label": "Lifecycle Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35560,7 +35560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10615,
+    "id": 13223,
     "skill_label": "Line Balancing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35570,7 +35570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10616,
+    "id": 13224,
     "skill_label": "Link Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35580,7 +35580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10617,
+    "id": 13225,
     "skill_label": "Linux",
     "esco_uri": "http://data.europa.eu/esco/skill/f9a6f35b-01a7-40c9-8b61-b6ee46f97272",
     "week": "2026-04-20",
@@ -35590,7 +35590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10618,
+    "id": 13226,
     "skill_label": "Linux Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35600,7 +35600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10619,
+    "id": 13227,
     "skill_label": "Linux Applications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35610,7 +35610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10620,
+    "id": 13228,
     "skill_label": "Linux Command Line Interface",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35620,7 +35620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10621,
+    "id": 13229,
     "skill_label": "Linux Operating System",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35630,7 +35630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10622,
+    "id": 13230,
     "skill_label": "Linux Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35640,7 +35640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10623,
+    "id": 13231,
     "skill_label": "Linux System Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35650,7 +35650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10624,
+    "id": 13232,
     "skill_label": "Linux Systems Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35660,7 +35660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10625,
+    "id": 13233,
     "skill_label": "Litigation Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35670,7 +35670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10626,
+    "id": 13234,
     "skill_label": "Litigation Technology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35680,7 +35680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10627,
+    "id": 13235,
     "skill_label": "Live Virtual Constructive Simulation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35690,7 +35690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10628,
+    "id": 13236,
     "skill_label": "Local Area Network Communications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35700,7 +35700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10629,
+    "id": 13237,
     "skill_label": "Local Area Networks (LAN)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35710,7 +35710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10630,
+    "id": 13238,
     "skill_label": "Log Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35720,7 +35720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10631,
+    "id": 13239,
     "skill_label": "Logging",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35730,7 +35730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10632,
+    "id": 13240,
     "skill_label": "Logging and Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35740,7 +35740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10633,
+    "id": 13241,
     "skill_label": "Logic Analyzer",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35750,7 +35750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10634,
+    "id": 13242,
     "skill_label": "Logic Analyzer Usage",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35760,7 +35760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10635,
+    "id": 13243,
     "skill_label": "Logic Error Detection",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35770,7 +35770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10636,
+    "id": 13244,
     "skill_label": "Logical Network Bootstrapping",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35780,7 +35780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10637,
+    "id": 13245,
     "skill_label": "Logistics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35790,7 +35790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10638,
+    "id": 13246,
     "skill_label": "Logistics Coordination",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35800,7 +35800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10639,
+    "id": 13247,
     "skill_label": "Logistics Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35810,7 +35810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10640,
+    "id": 13248,
     "skill_label": "Loss Prevention",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35820,7 +35820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10641,
+    "id": 13249,
     "skill_label": "Low Voltage Electrical Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35830,7 +35830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10642,
+    "id": 13250,
     "skill_label": "Low-level Code Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35840,7 +35840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10643,
+    "id": 13251,
     "skill_label": "Low-level Debugging",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35850,7 +35850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10644,
+    "id": 13252,
     "skill_label": "Low-level System Initialization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35860,7 +35860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10645,
+    "id": 13253,
     "skill_label": "MEDITECH Magic",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35870,7 +35870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10646,
+    "id": 13254,
     "skill_label": "MES",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35880,7 +35880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10647,
+    "id": 13255,
     "skill_label": "MIL-STD-464",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35890,7 +35890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10648,
+    "id": 13256,
     "skill_label": "MIL-STD-810",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35900,7 +35900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10649,
+    "id": 13257,
     "skill_label": "MIPS Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35910,7 +35910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10650,
+    "id": 13258,
     "skill_label": "ML Frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35920,7 +35920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10651,
+    "id": 13259,
     "skill_label": "ML Lifecycle Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35930,7 +35930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10652,
+    "id": 13260,
     "skill_label": "ML Ops",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35940,7 +35940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10653,
+    "id": 13261,
     "skill_label": "MLOps",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35950,7 +35950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10654,
+    "id": 13262,
     "skill_label": "MOCA",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35960,7 +35960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10655,
+    "id": 13263,
     "skill_label": "MPLS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35970,7 +35970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10656,
+    "id": 13264,
     "skill_label": "Machine Learning",
     "esco_uri": "http://data.europa.eu/esco/skill/3a2d5b45-56e4-4f5a-a55a-4a4a65afdc43",
     "week": "2026-04-20",
@@ -35980,7 +35980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10657,
+    "id": 13265,
     "skill_label": "Machine Learning Frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -35990,7 +35990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10658,
+    "id": 13266,
     "skill_label": "Machine Learning Fundamentals",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36000,7 +36000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10659,
+    "id": 13267,
     "skill_label": "Machine Learning Infrastructure",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36010,7 +36010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10660,
+    "id": 13268,
     "skill_label": "Machine Learning Lifecycle Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36020,7 +36020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10661,
+    "id": 13269,
     "skill_label": "Machine Learning Model Training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36030,7 +36030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10662,
+    "id": 13270,
     "skill_label": "Machine Learning Pipelines",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36040,7 +36040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10663,
+    "id": 13271,
     "skill_label": "Machine Learning Research",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36050,7 +36050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10664,
+    "id": 13272,
     "skill_label": "Mainframe Operating Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36060,7 +36060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10665,
+    "id": 13273,
     "skill_label": "Maintenance Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36070,7 +36070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10666,
+    "id": 13274,
     "skill_label": "Maintenance Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36080,7 +36080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10667,
+    "id": 13275,
     "skill_label": "Maintenance Planning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36090,7 +36090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10668,
+    "id": 13276,
     "skill_label": "Malware Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36100,7 +36100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10669,
+    "id": 13277,
     "skill_label": "Managed Care",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36110,7 +36110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10670,
+    "id": 13278,
     "skill_label": "Managed Services Provider (MSP) Ecosystem",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36120,7 +36120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10671,
+    "id": 13279,
     "skill_label": "Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36130,7 +36130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10672,
+    "id": 13280,
     "skill_label": "Manual Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36140,7 +36140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10673,
+    "id": 13281,
     "skill_label": "Manufacturing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36150,7 +36150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10674,
+    "id": 13282,
     "skill_label": "Manufacturing Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36160,7 +36160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10675,
+    "id": 13283,
     "skill_label": "Manufacturing Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36170,7 +36170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10676,
+    "id": 13284,
     "skill_label": "Manufacturing Process Improvement",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36180,7 +36180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10677,
+    "id": 13285,
     "skill_label": "Manufacturing Processes",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36190,7 +36190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10678,
+    "id": 13286,
     "skill_label": "Manufacturing Quality",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36200,7 +36200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10679,
+    "id": 13287,
     "skill_label": "Marine Industry Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36210,7 +36210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10680,
+    "id": 13288,
     "skill_label": "Maritime Regulatory Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36220,7 +36220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10681,
+    "id": 13289,
     "skill_label": "Markdown",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36230,7 +36230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10682,
+    "id": 13290,
     "skill_label": "Market Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36240,7 +36240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10683,
+    "id": 13291,
     "skill_label": "Market Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36250,7 +36250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10684,
+    "id": 13292,
     "skill_label": "Market Positioning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36260,7 +36260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10685,
+    "id": 13293,
     "skill_label": "Market Research",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36270,7 +36270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10686,
+    "id": 13294,
     "skill_label": "Marketing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36280,7 +36280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10687,
+    "id": 13295,
     "skill_label": "Marketing Analytics",
     "esco_uri": "http://data.europa.eu/esco/skill/11c56452-fcec-4b00-9695-cca4728e5048",
     "week": "2026-04-20",
@@ -36290,7 +36290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10688,
+    "id": 13296,
     "skill_label": "Marketing Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36300,7 +36300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10689,
+    "id": 13297,
     "skill_label": "Marketing Domain Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36310,7 +36310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10690,
+    "id": 13298,
     "skill_label": "Marketing Leadership",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36320,7 +36320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10691,
+    "id": 13299,
     "skill_label": "Marketing Technology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36330,7 +36330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10692,
+    "id": 13300,
     "skill_label": "Master Data Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36340,7 +36340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10693,
+    "id": 13301,
     "skill_label": "Master's Degree",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36350,7 +36350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10694,
+    "id": 13302,
     "skill_label": "Master's Degree in Computer Science",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36360,7 +36360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10695,
+    "id": 13303,
     "skill_label": "Material Handling Equipment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36370,7 +36370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10696,
+    "id": 13304,
     "skill_label": "Material Handling Equipment Operation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36380,7 +36380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10697,
+    "id": 13305,
     "skill_label": "Materials Selection",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36390,7 +36390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10698,
+    "id": 13306,
     "skill_label": "Mathematics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36400,7 +36400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10699,
+    "id": 13307,
     "skill_label": "Matlab",
     "esco_uri": "http://data.europa.eu/esco/skill/7b0d5000-00da-4864-b776-6de49a87a669",
     "week": "2026-04-20",
@@ -36410,7 +36410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10700,
+    "id": 13308,
     "skill_label": "Maven",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36420,7 +36420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10701,
+    "id": 13309,
     "skill_label": "Maximo",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36430,7 +36430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10702,
+    "id": 13310,
     "skill_label": "Measurement and Signature Intelligence (MASINT)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36440,7 +36440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10703,
+    "id": 13311,
     "skill_label": "Measurement and Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36450,7 +36450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10704,
+    "id": 13312,
     "skill_label": "Mechanical Aptitude",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36460,7 +36460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10705,
+    "id": 13313,
     "skill_label": "Mechanical Assembly",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36470,7 +36470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10706,
+    "id": 13314,
     "skill_label": "Mechanical Drawings",
     "esco_uri": "http://data.europa.eu/esco/skill/59ea80e1-463a-4dba-82c6-d0b6d577d532",
     "week": "2026-04-20",
@@ -36480,7 +36480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10707,
+    "id": 13315,
     "skill_label": "Mechanical Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36490,7 +36490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10708,
+    "id": 13316,
     "skill_label": "Mechanical Fastening Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36500,7 +36500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10709,
+    "id": 13317,
     "skill_label": "Mechanical Maintenance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36510,7 +36510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10710,
+    "id": 13318,
     "skill_label": "Mechanical Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36520,7 +36520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10711,
+    "id": 13319,
     "skill_label": "Mechanical Systems Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36530,7 +36530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10712,
+    "id": 13320,
     "skill_label": "Mechanistic Concept Activation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36540,7 +36540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10713,
+    "id": 13321,
     "skill_label": "Mechatronics",
     "esco_uri": "http://data.europa.eu/esco/skill/e87ec79a-c9ff-46f5-84fa-7a0f394cdf40",
     "week": "2026-04-20",
@@ -36550,7 +36550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10714,
+    "id": 13322,
     "skill_label": "Mechatronics Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36560,7 +36560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10715,
+    "id": 13323,
     "skill_label": "Medicaid",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36570,7 +36570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10716,
+    "id": 13324,
     "skill_label": "Medical Accuracy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36580,7 +36580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10717,
+    "id": 13325,
     "skill_label": "Medical Affairs Domain Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36590,7 +36590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10718,
+    "id": 13326,
     "skill_label": "Medical Assistance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36600,7 +36600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10719,
+    "id": 13327,
     "skill_label": "Medical Billing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36610,7 +36610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10720,
+    "id": 13328,
     "skill_label": "Medical Coding",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36620,7 +36620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10721,
+    "id": 13329,
     "skill_label": "Medical Degree",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36630,7 +36630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10722,
+    "id": 13330,
     "skill_label": "Medical Laboratory Procedures",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36640,7 +36640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10723,
+    "id": 13331,
     "skill_label": "Medical Records Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36650,7 +36650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10724,
+    "id": 13332,
     "skill_label": "Medicare",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36660,7 +36660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10725,
+    "id": 13333,
     "skill_label": "Medium Voltage Electrical Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36670,7 +36670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10726,
+    "id": 13334,
     "skill_label": "Meeting Coordination",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36680,7 +36680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10727,
+    "id": 13335,
     "skill_label": "Memory Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36690,7 +36690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10728,
+    "id": 13336,
     "skill_label": "Memory-efficient Techniques",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36700,7 +36700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10729,
+    "id": 13337,
     "skill_label": "Mentoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36710,7 +36710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10730,
+    "id": 13338,
     "skill_label": "Mentorship",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36720,7 +36720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10731,
+    "id": 13339,
     "skill_label": "Message Brokers",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36730,7 +36730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10732,
+    "id": 13340,
     "skill_label": "Message Queues",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36740,7 +36740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10733,
+    "id": 13341,
     "skill_label": "Message Queuing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36750,7 +36750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10734,
+    "id": 13342,
     "skill_label": "Metadata Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36760,7 +36760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10735,
+    "id": 13343,
     "skill_label": "Methods Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36770,7 +36770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10736,
+    "id": 13344,
     "skill_label": "Metrics Definition",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36780,7 +36780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10737,
+    "id": 13345,
     "skill_label": "Metrics definition",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36790,7 +36790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10738,
+    "id": 13346,
     "skill_label": "MicroVMs",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36800,7 +36800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10739,
+    "id": 13347,
     "skill_label": "Microcontrollers",
     "esco_uri": "http://data.europa.eu/esco/skill/9ef0f3a0-9ce2-4ef1-a987-0366b5cb2dbe",
     "week": "2026-04-20",
@@ -36810,7 +36810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10740,
+    "id": 13348,
     "skill_label": "Microservices",
     "esco_uri": "Microservices",
     "week": "2026-04-20",
@@ -36820,7 +36820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10741,
+    "id": 13349,
     "skill_label": "Microservices Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36830,7 +36830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10742,
+    "id": 13350,
     "skill_label": "Microservices Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36840,7 +36840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10743,
+    "id": 13351,
     "skill_label": "Microsoft 365",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36850,7 +36850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10744,
+    "id": 13352,
     "skill_label": "Microsoft Access",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36860,7 +36860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10745,
+    "id": 13353,
     "skill_label": "Microsoft Active Directory",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36870,7 +36870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10746,
+    "id": 13354,
     "skill_label": "Microsoft Azure",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36880,7 +36880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10747,
+    "id": 13355,
     "skill_label": "Microsoft Azure AI",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36890,7 +36890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10748,
+    "id": 13356,
     "skill_label": "Microsoft Azure Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36900,7 +36900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10749,
+    "id": 13357,
     "skill_label": "Microsoft Azure Network Engineer Associate",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36910,7 +36910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10750,
+    "id": 13358,
     "skill_label": "Microsoft BizTalk Server",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36920,7 +36920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10751,
+    "id": 13359,
     "skill_label": "Microsoft Certified: Azure Solutions Architect",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36930,7 +36930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10752,
+    "id": 13360,
     "skill_label": "Microsoft Defender",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36940,7 +36940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10753,
+    "id": 13361,
     "skill_label": "Microsoft Excel",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36950,7 +36950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10754,
+    "id": 13362,
     "skill_label": "Microsoft Office",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36960,7 +36960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10755,
+    "id": 13363,
     "skill_label": "Microsoft Office Suite",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36970,7 +36970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10756,
+    "id": 13364,
     "skill_label": "Microsoft Power Automate",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36980,7 +36980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10757,
+    "id": 13365,
     "skill_label": "Microsoft Project",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -36990,7 +36990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10758,
+    "id": 13366,
     "skill_label": "Microsoft Purview",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37000,7 +37000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10759,
+    "id": 13367,
     "skill_label": "Microsoft Reporting Services",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37010,7 +37010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10760,
+    "id": 13368,
     "skill_label": "Microsoft SC-400 Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37020,7 +37020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10761,
+    "id": 13369,
     "skill_label": "Microsoft SQL Server",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37030,7 +37030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10762,
+    "id": 13370,
     "skill_label": "Microsoft Teams",
     "esco_uri": "http://data.europa.eu/esco/skill/d7e4a9fa-cfc2-45f9-96eb-13dc6e48c86c",
     "week": "2026-04-20",
@@ -37040,7 +37040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10763,
+    "id": 13371,
     "skill_label": "Microsoft Visual Studio",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37050,7 +37050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10764,
+    "id": 13372,
     "skill_label": "Microsoft Windows",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37060,7 +37060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10765,
+    "id": 13373,
     "skill_label": "Microsoft Windows Operating System",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37070,7 +37070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10766,
+    "id": 13374,
     "skill_label": "Military Electronics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37080,7 +37080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10767,
+    "id": 13375,
     "skill_label": "Military Intelligence Training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37090,7 +37090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10768,
+    "id": 13376,
     "skill_label": "Military Program Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37100,7 +37100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10769,
+    "id": 13377,
     "skill_label": "Military Targeting Processes",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37110,7 +37110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10770,
+    "id": 13378,
     "skill_label": "Military Working Dog Handling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37120,7 +37120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10771,
+    "id": 13379,
     "skill_label": "Minimum Viable Product Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37130,7 +37130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10772,
+    "id": 13380,
     "skill_label": "Missile Defense Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37140,7 +37140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10773,
+    "id": 13381,
     "skill_label": "Missile Maintenance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37150,7 +37150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10774,
+    "id": 13382,
     "skill_label": "Mission Software Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37160,7 +37160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10775,
+    "id": 13383,
     "skill_label": "Mistake Proofing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37170,7 +37170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10776,
+    "id": 13384,
     "skill_label": "Mobile App Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37180,7 +37180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10777,
+    "id": 13385,
     "skill_label": "Mobile Application Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37190,7 +37190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10778,
+    "id": 13386,
     "skill_label": "Mobile Application Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37200,7 +37200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10779,
+    "id": 13387,
     "skill_label": "Mobile Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37210,7 +37210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10780,
+    "id": 13388,
     "skill_label": "Mobile Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37220,7 +37220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10781,
+    "id": 13389,
     "skill_label": "Modbus",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37230,7 +37230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10782,
+    "id": 13390,
     "skill_label": "Model Alignment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37240,7 +37240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10783,
+    "id": 13391,
     "skill_label": "Model Context Protocol",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37250,7 +37250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10784,
+    "id": 13392,
     "skill_label": "Model Context Protocols",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37260,7 +37260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10785,
+    "id": 13393,
     "skill_label": "Model Deployment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37270,7 +37270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10786,
+    "id": 13394,
     "skill_label": "Model Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37280,7 +37280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10787,
+    "id": 13395,
     "skill_label": "Model Distillation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37290,7 +37290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10788,
+    "id": 13396,
     "skill_label": "Model Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37300,7 +37300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10789,
+    "id": 13397,
     "skill_label": "Model Fine-tuning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37310,7 +37310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10790,
+    "id": 13398,
     "skill_label": "Model Implementation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37320,7 +37320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10791,
+    "id": 13399,
     "skill_label": "Model Lifecycle Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37330,7 +37330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10792,
+    "id": 13400,
     "skill_label": "Model Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37340,7 +37340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10793,
+    "id": 13401,
     "skill_label": "Model Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37350,7 +37350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10794,
+    "id": 13402,
     "skill_label": "Model Parameterization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37360,7 +37360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10795,
+    "id": 13403,
     "skill_label": "Model Risk Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37370,7 +37370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10796,
+    "id": 13404,
     "skill_label": "Model Validation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37380,7 +37380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10797,
+    "id": 13405,
     "skill_label": "Model Versioning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37390,7 +37390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10798,
+    "id": 13406,
     "skill_label": "Model-View-Controller (MVC)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37400,7 +37400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10799,
+    "id": 13407,
     "skill_label": "Model-View-Intent (MVI)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37410,7 +37410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10800,
+    "id": 13408,
     "skill_label": "Model-View-ViewModel (MVVM)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37420,7 +37420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10801,
+    "id": 13409,
     "skill_label": "Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37430,7 +37430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10802,
+    "id": 13410,
     "skill_label": "Modeling and Simulation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37440,7 +37440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10803,
+    "id": 13411,
     "skill_label": "Modern Data Platform Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37450,7 +37450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10804,
+    "id": 13412,
     "skill_label": "Modular Software Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37460,7 +37460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10805,
+    "id": 13413,
     "skill_label": "Module Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37470,7 +37470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10806,
+    "id": 13414,
     "skill_label": "Monetization Models",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37480,7 +37480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10807,
+    "id": 13415,
     "skill_label": "Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37490,7 +37490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10808,
+    "id": 13416,
     "skill_label": "Monitoring and Observability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37500,7 +37500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10809,
+    "id": 13417,
     "skill_label": "Monitoring and Performance Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37510,7 +37510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10810,
+    "id": 13418,
     "skill_label": "Monorepo",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37520,7 +37520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10811,
+    "id": 13419,
     "skill_label": "Mortgage Industry Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37530,7 +37530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10812,
+    "id": 13420,
     "skill_label": "Motion Control Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37540,7 +37540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10813,
+    "id": 13421,
     "skill_label": "Multi-Factor Authentication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37550,7 +37550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10814,
+    "id": 13422,
     "skill_label": "Multi-agent Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37560,7 +37560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10815,
+    "id": 13423,
     "skill_label": "Multi-cloud Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37570,7 +37570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10816,
+    "id": 13424,
     "skill_label": "Multi-cloud Environment Experience",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37580,7 +37580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10817,
+    "id": 13425,
     "skill_label": "Multi-functional Team Leadership",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37590,7 +37590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10818,
+    "id": 13426,
     "skill_label": "Multi-modal Models",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37600,7 +37600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10819,
+    "id": 13427,
     "skill_label": "Multi-threaded Programming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37610,7 +37610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10820,
+    "id": 13428,
     "skill_label": "Multi-tier Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37620,7 +37620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10821,
+    "id": 13429,
     "skill_label": "Multi-turn System Interactions",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37630,7 +37630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10822,
+    "id": 13430,
     "skill_label": "Multidisciplinary Production",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37640,7 +37640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10823,
+    "id": 13431,
     "skill_label": "Multimeter Usage",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37650,7 +37650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10824,
+    "id": 13432,
     "skill_label": "Multimodal Machine Learning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37660,7 +37660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10825,
+    "id": 13433,
     "skill_label": "Multimodal Reasoning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37670,7 +37670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10826,
+    "id": 13434,
     "skill_label": "Multimodal Understanding",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37680,7 +37680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10827,
+    "id": 13435,
     "skill_label": "Multithreading",
     "esco_uri": "Multithreading",
     "week": "2026-04-20",
@@ -37690,7 +37690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10828,
+    "id": 13436,
     "skill_label": "MySQL",
     "esco_uri": "http://data.europa.eu/esco/skill/4da171e5-779c-4983-a76f-91c16751e99f",
     "week": "2026-04-20",
@@ -37700,7 +37700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10829,
+    "id": 13437,
     "skill_label": "NCMA Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37710,7 +37710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10830,
+    "id": 13438,
     "skill_label": "NIST",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37720,7 +37720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10831,
+    "id": 13439,
     "skill_label": "NIST 800-171",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37730,7 +37730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10832,
+    "id": 13440,
     "skill_label": "NIST 800-53",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37740,7 +37740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10833,
+    "id": 13441,
     "skill_label": "NIST SP 800-53",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37750,7 +37750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10834,
+    "id": 13442,
     "skill_label": "NLP",
     "esco_uri": "http://data.europa.eu/esco/skill/fff0e2cd-d0bd-4b02-9daf-158b79d9688a",
     "week": "2026-04-20",
@@ -37760,7 +37760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10835,
+    "id": 13443,
     "skill_label": "National Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37770,7 +37770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10836,
+    "id": 13444,
     "skill_label": "Native Android",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37780,7 +37780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10837,
+    "id": 13445,
     "skill_label": "Natural Language Processing",
     "esco_uri": "http://data.europa.eu/esco/skill/fff0e2cd-d0bd-4b02-9daf-158b79d9688a",
     "week": "2026-04-20",
@@ -37790,7 +37790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10838,
+    "id": 13446,
     "skill_label": "Negotiation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37800,7 +37800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10839,
+    "id": 13447,
     "skill_label": "Neonatal Resuscitation Program (NRP)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37810,7 +37810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10840,
+    "id": 13448,
     "skill_label": "NetApp ONTAP",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37820,7 +37820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10841,
+    "id": 13449,
     "skill_label": "Netezza Performance Server",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37830,7 +37830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10842,
+    "id": 13450,
     "skill_label": "Network Access Control",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37840,7 +37840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10843,
+    "id": 13451,
     "skill_label": "Network Address Translation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37850,7 +37850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10844,
+    "id": 13452,
     "skill_label": "Network Address Translation (NAT)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37860,7 +37860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10845,
+    "id": 13453,
     "skill_label": "Network Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37870,7 +37870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10846,
+    "id": 13454,
     "skill_label": "Network Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37880,7 +37880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10847,
+    "id": 13455,
     "skill_label": "Network Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37890,7 +37890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10848,
+    "id": 13456,
     "skill_label": "Network Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37900,7 +37900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10849,
+    "id": 13457,
     "skill_label": "Network Configuration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37910,7 +37910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10850,
+    "id": 13458,
     "skill_label": "Network Deployment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37920,7 +37920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10851,
+    "id": 13459,
     "skill_label": "Network Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37930,7 +37930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10852,
+    "id": 13460,
     "skill_label": "Network Device Configuration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37940,7 +37940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10853,
+    "id": 13461,
     "skill_label": "Network Documentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37950,7 +37950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10854,
+    "id": 13462,
     "skill_label": "Network Engineering",
     "esco_uri": "http://data.europa.eu/esco/skill/02058de6-4b98-449f-8a45-8588b0eb2446",
     "week": "2026-04-20",
@@ -37960,7 +37960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10855,
+    "id": 13463,
     "skill_label": "Network Hardware Platforms",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37970,7 +37970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10856,
+    "id": 13464,
     "skill_label": "Network Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37980,7 +37980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10857,
+    "id": 13465,
     "skill_label": "Network Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -37990,7 +37990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10858,
+    "id": 13466,
     "skill_label": "Network Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38000,7 +38000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10859,
+    "id": 13467,
     "skill_label": "Network Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38010,7 +38010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10860,
+    "id": 13468,
     "skill_label": "Network Performance Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38020,7 +38020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10861,
+    "id": 13469,
     "skill_label": "Network Performance Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38030,7 +38030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10862,
+    "id": 13470,
     "skill_label": "Network Performance Troubleshooting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38040,7 +38040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10863,
+    "id": 13471,
     "skill_label": "Network Performance Tuning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38050,7 +38050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10864,
+    "id": 13472,
     "skill_label": "Network Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38060,7 +38060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10865,
+    "id": 13473,
     "skill_label": "Network Security Groups",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38070,7 +38070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10866,
+    "id": 13474,
     "skill_label": "Network Security Policies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38080,7 +38080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10867,
+    "id": 13475,
     "skill_label": "Network Segmentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38090,7 +38090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10868,
+    "id": 13476,
     "skill_label": "Network Switch Configuration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38100,7 +38100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10869,
+    "id": 13477,
     "skill_label": "Network Traffic Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38110,7 +38110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10870,
+    "id": 13478,
     "skill_label": "Network Troubleshooting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38120,7 +38120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10871,
+    "id": 13479,
     "skill_label": "Network Video Recorder (NVR)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38130,7 +38130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10872,
+    "id": 13480,
     "skill_label": "Networking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38140,7 +38140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10873,
+    "id": 13481,
     "skill_label": "Networking Fundamentals",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38150,7 +38150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10874,
+    "id": 13482,
     "skill_label": "Neural Machine Translation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38160,7 +38160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10875,
+    "id": 13483,
     "skill_label": "Neural Network Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38170,7 +38170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10876,
+    "id": 13484,
     "skill_label": "Neural Networks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38180,7 +38180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10877,
+    "id": 13485,
     "skill_label": "NiFi Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38190,7 +38190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10878,
+    "id": 13486,
     "skill_label": "NiFi Registry",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38200,7 +38200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10879,
+    "id": 13487,
     "skill_label": "NoSQL Databases",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38210,7 +38210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10880,
+    "id": 13488,
     "skill_label": "Node.js",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38220,7 +38220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10881,
+    "id": 13489,
     "skill_label": "Non-lethal Weapons Handling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38230,7 +38230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10882,
+    "id": 13490,
     "skill_label": "Note Taking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38240,7 +38240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10883,
+    "id": 13491,
     "skill_label": "Numerical Simulation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38250,7 +38250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10884,
+    "id": 13492,
     "skill_label": "Numerical Validation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38260,7 +38260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10885,
+    "id": 13493,
     "skill_label": "Nursing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38270,7 +38270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10886,
+    "id": 13494,
     "skill_label": "Nursing Informatics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38280,7 +38280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10887,
+    "id": 13495,
     "skill_label": "OAuth 2.0",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38290,7 +38290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10888,
+    "id": 13496,
     "skill_label": "OSCP",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38300,7 +38300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10889,
+    "id": 13497,
     "skill_label": "OSHA 30 Construction",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38310,7 +38310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10890,
+    "id": 13498,
     "skill_label": "OSHA Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38320,7 +38320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10891,
+    "id": 13499,
     "skill_label": "OSI Model",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38330,7 +38330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10892,
+    "id": 13500,
     "skill_label": "OSPF",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38340,7 +38340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10893,
+    "id": 13501,
     "skill_label": "Objdump",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38350,7 +38350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10894,
+    "id": 13502,
     "skill_label": "Object Detection",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38360,7 +38360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10895,
+    "id": 13503,
     "skill_label": "Object-Oriented Analysis and Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38370,7 +38370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10896,
+    "id": 13504,
     "skill_label": "Object-Oriented Programming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38380,7 +38380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10897,
+    "id": 13505,
     "skill_label": "Object-Relational Mapping (ORM)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38390,7 +38390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10898,
+    "id": 13506,
     "skill_label": "Object-oriented Programming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38400,7 +38400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10899,
+    "id": 13507,
     "skill_label": "Object-relational mapping",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38410,7 +38410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10900,
+    "id": 13508,
     "skill_label": "Observability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38420,7 +38420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10901,
+    "id": 13509,
     "skill_label": "Offensive Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38430,7 +38430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10902,
+    "id": 13510,
     "skill_label": "Office 365",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38440,7 +38440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10903,
+    "id": 13511,
     "skill_label": "Onsite Surveying",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38450,7 +38450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10904,
+    "id": 13512,
     "skill_label": "Open Source Intelligence (OSINT)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38460,7 +38460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10905,
+    "id": 13513,
     "skill_label": "OpenID",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38470,7 +38470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10906,
+    "id": 13514,
     "skill_label": "OpenStack",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38480,7 +38480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10907,
+    "id": 13515,
     "skill_label": "OpenTelemetry",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38490,7 +38490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10908,
+    "id": 13516,
     "skill_label": "Operational AI Safety",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38500,7 +38500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10909,
+    "id": 13517,
     "skill_label": "Operational Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38510,7 +38510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10910,
+    "id": 13518,
     "skill_label": "Operational Cost Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38520,7 +38520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10911,
+    "id": 13519,
     "skill_label": "Operational Efficiency",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38530,7 +38530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10912,
+    "id": 13520,
     "skill_label": "Operational Excellence",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38540,7 +38540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10913,
+    "id": 13521,
     "skill_label": "Operational Leadership",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38550,7 +38550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10914,
+    "id": 13522,
     "skill_label": "Operational Maintenance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38560,7 +38560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10915,
+    "id": 13523,
     "skill_label": "Operational Reporting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38570,7 +38570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10916,
+    "id": 13524,
     "skill_label": "Operational Risk Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38580,7 +38580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10917,
+    "id": 13525,
     "skill_label": "Operational Strategy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38590,7 +38590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10918,
+    "id": 13526,
     "skill_label": "Operational Troubleshooting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38600,7 +38600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10919,
+    "id": 13527,
     "skill_label": "Operationalization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38610,7 +38610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10920,
+    "id": 13528,
     "skill_label": "Operations Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38620,7 +38620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10921,
+    "id": 13529,
     "skill_label": "Operations Research",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38630,7 +38630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10922,
+    "id": 13530,
     "skill_label": "Opportunity Identification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38640,7 +38640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10923,
+    "id": 13531,
     "skill_label": "Optical Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38650,7 +38650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10924,
+    "id": 13532,
     "skill_label": "Optical Transport Technologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38660,7 +38660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10925,
+    "id": 13533,
     "skill_label": "Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38670,7 +38670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10926,
+    "id": 13534,
     "skill_label": "Optimization Techniques",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38680,7 +38680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10927,
+    "id": 13535,
     "skill_label": "Oracle",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38690,7 +38690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10928,
+    "id": 13536,
     "skill_label": "Oracle Agile",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38700,7 +38700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10929,
+    "id": 13537,
     "skill_label": "Oracle Cloud Infrastructure (OCI)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38710,7 +38710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10930,
+    "id": 13538,
     "skill_label": "Oracle Database",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38720,7 +38720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10931,
+    "id": 13539,
     "skill_label": "Oracle EBS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38730,7 +38730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10932,
+    "id": 13540,
     "skill_label": "Oracle ERP",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38740,7 +38740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10933,
+    "id": 13541,
     "skill_label": "Oracle Fusion",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38750,7 +38750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10934,
+    "id": 13542,
     "skill_label": "Oracle Linux",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38760,7 +38760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10935,
+    "id": 13543,
     "skill_label": "Oracle PL/SQL",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38770,7 +38770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10936,
+    "id": 13544,
     "skill_label": "Oracle Real Application Clusters (RAC)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38780,7 +38780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10937,
+    "id": 13545,
     "skill_label": "Oracles",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38790,7 +38790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10938,
+    "id": 13546,
     "skill_label": "Oral Communication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38800,7 +38800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10939,
+    "id": 13547,
     "skill_label": "Orchestration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38810,7 +38810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10940,
+    "id": 13548,
     "skill_label": "Order Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38820,7 +38820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10941,
+    "id": 13549,
     "skill_label": "Order Picking Technologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38830,7 +38830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10942,
+    "id": 13550,
     "skill_label": "Organizational Change Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38840,7 +38840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10943,
+    "id": 13551,
     "skill_label": "Organizational Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38850,7 +38850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10944,
+    "id": 13552,
     "skill_label": "Organizational Skills",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38860,7 +38860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10945,
+    "id": 13553,
     "skill_label": "Oscilloscope",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38870,7 +38870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10946,
+    "id": 13554,
     "skill_label": "Oscilloscope Usage",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38880,7 +38880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10947,
+    "id": 13555,
     "skill_label": "Overall Equipment Effectiveness",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38890,7 +38890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10948,
+    "id": 13556,
     "skill_label": "Ownership Mindset",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38900,7 +38900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10949,
+    "id": 13557,
     "skill_label": "PCI DSS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38910,7 +38910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10950,
+    "id": 13558,
     "skill_label": "PCI Express",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38920,7 +38920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10951,
+    "id": 13559,
     "skill_label": "PGP Encryption",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38930,7 +38930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10952,
+    "id": 13560,
     "skill_label": "PL/SQL",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38940,7 +38940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10953,
+    "id": 13561,
     "skill_label": "PLC Programming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38950,7 +38950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10954,
+    "id": 13562,
     "skill_label": "PLC Programming Languages",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38960,7 +38960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10955,
+    "id": 13563,
     "skill_label": "Packaging, Handling, Storage and Transportation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38970,7 +38970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10956,
+    "id": 13564,
     "skill_label": "Page Builder",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38980,7 +38980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10957,
+    "id": 13565,
     "skill_label": "Paid Advertising",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -38990,7 +38990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10958,
+    "id": 13566,
     "skill_label": "Palo Alto",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39000,7 +39000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10959,
+    "id": 13567,
     "skill_label": "Palo Alto Networks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39010,7 +39010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10960,
+    "id": 13568,
     "skill_label": "Palo Alto Networks Firewalls",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39020,7 +39020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10961,
+    "id": 13569,
     "skill_label": "Partner Enablement",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39030,7 +39030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10962,
+    "id": 13570,
     "skill_label": "Passwordless Authentication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39040,7 +39040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10963,
+    "id": 13571,
     "skill_label": "Patch Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39050,7 +39050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10964,
+    "id": 13572,
     "skill_label": "Patient Education",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39060,7 +39060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10965,
+    "id": 13573,
     "skill_label": "Patient Finance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39070,7 +39070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10966,
+    "id": 13574,
     "skill_label": "Patrol Procedures",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39080,7 +39080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10967,
+    "id": 13575,
     "skill_label": "Pattern Recognition",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39090,7 +39090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10968,
+    "id": 13576,
     "skill_label": "Pay Per Click Advertising",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39100,7 +39100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10969,
+    "id": 13577,
     "skill_label": "Payer Domain Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39110,7 +39110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10970,
+    "id": 13578,
     "skill_label": "Payload Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39120,7 +39120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10971,
+    "id": 13579,
     "skill_label": "Payment Processing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39130,7 +39130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10972,
+    "id": 13580,
     "skill_label": "Payroll Processing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39140,7 +39140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10973,
+    "id": 13581,
     "skill_label": "Payroll Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39150,7 +39150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10974,
+    "id": 13582,
     "skill_label": "Pediatric Advanced Life Support (PALS)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39160,7 +39160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10975,
+    "id": 13583,
     "skill_label": "Pelco Technology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39170,7 +39170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10976,
+    "id": 13584,
     "skill_label": "Penetration Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39180,7 +39180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10977,
+    "id": 13585,
     "skill_label": "People Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39190,7 +39190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10978,
+    "id": 13586,
     "skill_label": "PeopleSoft",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39200,7 +39200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10979,
+    "id": 13587,
     "skill_label": "Perception",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39210,7 +39210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10980,
+    "id": 13588,
     "skill_label": "Performance Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39220,7 +39220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10981,
+    "id": 13589,
     "skill_label": "Performance Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39230,7 +39230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10982,
+    "id": 13590,
     "skill_label": "Performance Improvement",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39240,7 +39240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10983,
+    "id": 13591,
     "skill_label": "Performance Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39250,7 +39250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10984,
+    "id": 13592,
     "skill_label": "Performance Metrics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39260,7 +39260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10985,
+    "id": 13593,
     "skill_label": "Performance Metrics Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39270,7 +39270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10986,
+    "id": 13594,
     "skill_label": "Performance Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39280,7 +39280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10987,
+    "id": 13595,
     "skill_label": "Performance Test Plan Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39290,7 +39290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10988,
+    "id": 13596,
     "skill_label": "Performance Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39300,7 +39300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10989,
+    "id": 13597,
     "skill_label": "Performance Tuning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39310,7 +39310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10990,
+    "id": 13598,
     "skill_label": "Peripheral Communication Protocols",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39320,7 +39320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10991,
+    "id": 13599,
     "skill_label": "Peripheral Driver Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39330,7 +39330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10992,
+    "id": 13600,
     "skill_label": "Peripheral Drivers",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39340,7 +39340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10993,
+    "id": 13601,
     "skill_label": "Personalization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39350,7 +39350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10994,
+    "id": 13602,
     "skill_label": "Personnel Qualification Standards",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39360,7 +39360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10995,
+    "id": 13603,
     "skill_label": "Persuasion",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39370,7 +39370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10996,
+    "id": 13604,
     "skill_label": "PhD",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39380,7 +39380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10997,
+    "id": 13605,
     "skill_label": "PhD Degree",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39390,7 +39390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10998,
+    "id": 13606,
     "skill_label": "PhD in Computer Science or related field",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39400,7 +39400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 10999,
+    "id": 13607,
     "skill_label": "PhD in Computer Science or related fields",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39410,7 +39410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11000,
+    "id": 13608,
     "skill_label": "Pharmacy Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39420,7 +39420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11001,
+    "id": 13609,
     "skill_label": "Physical Dexterity",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39430,7 +39430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11002,
+    "id": 13610,
     "skill_label": "Physical Fitness",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39440,7 +39440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11003,
+    "id": 13611,
     "skill_label": "Physical Inventory",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39450,7 +39450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11004,
+    "id": 13612,
     "skill_label": "Physical Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39460,7 +39460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11005,
+    "id": 13613,
     "skill_label": "Physical Stamina",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39470,7 +39470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11006,
+    "id": 13614,
     "skill_label": "Physical Strength",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39480,7 +39480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11007,
+    "id": 13615,
     "skill_label": "Physics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39490,7 +39490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11008,
+    "id": 13616,
     "skill_label": "Physics Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39500,7 +39500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11009,
+    "id": 13617,
     "skill_label": "Pilot Deployment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39510,7 +39510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11010,
+    "id": 13618,
     "skill_label": "Pipeline Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39520,7 +39520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11011,
+    "id": 13619,
     "skill_label": "Pipeline Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39530,7 +39530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11012,
+    "id": 13620,
     "skill_label": "Pipeline Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39540,7 +39540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11013,
+    "id": 13621,
     "skill_label": "Pipeline Orchestration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39550,7 +39550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11014,
+    "id": 13622,
     "skill_label": "Piping and Instrumentation Diagrams (P&ID)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39560,7 +39560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11015,
+    "id": 13623,
     "skill_label": "Piping and Instrumentation Diagrams (P&IDs)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39570,7 +39570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11016,
+    "id": 13624,
     "skill_label": "Platform Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39580,7 +39580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11017,
+    "id": 13625,
     "skill_label": "Playwright",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39590,7 +39590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11018,
+    "id": 13626,
     "skill_label": "Plumbing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39600,7 +39600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11019,
+    "id": 13627,
     "skill_label": "Plumbing Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39610,7 +39610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11020,
+    "id": 13628,
     "skill_label": "Pneumatic Controls",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39620,7 +39620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11021,
+    "id": 13629,
     "skill_label": "Pneumatic Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39630,7 +39630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11022,
+    "id": 13630,
     "skill_label": "Point of Sale (POS) Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39640,7 +39640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11023,
+    "id": 13631,
     "skill_label": "Policy as Code",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39650,7 +39650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11024,
+    "id": 13632,
     "skill_label": "Polygon",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39660,7 +39660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11025,
+    "id": 13633,
     "skill_label": "Pose Estimation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39670,7 +39670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11026,
+    "id": 13634,
     "skill_label": "Positioning and Messaging",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39680,7 +39680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11027,
+    "id": 13635,
     "skill_label": "Post-Project Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39690,7 +39690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11028,
+    "id": 13636,
     "skill_label": "Post-training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39700,7 +39700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11029,
+    "id": 13637,
     "skill_label": "PostgreSQL",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39710,7 +39710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11030,
+    "id": 13638,
     "skill_label": "Power Automate",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39720,7 +39720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11031,
+    "id": 13639,
     "skill_label": "Power BI",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39730,7 +39730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11032,
+    "id": 13640,
     "skill_label": "Power Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39740,7 +39740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11033,
+    "id": 13641,
     "skill_label": "Power Platform",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39750,7 +39750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11034,
+    "id": 13642,
     "skill_label": "Power Quality",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39760,7 +39760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11035,
+    "id": 13643,
     "skill_label": "Power Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39770,7 +39770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11036,
+    "id": 13644,
     "skill_label": "Power over Ethernet (PoE)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39780,7 +39780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11037,
+    "id": 13645,
     "skill_label": "PowerShell",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39790,7 +39790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11038,
+    "id": 13646,
     "skill_label": "Pre-sales",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39800,7 +39800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11039,
+    "id": 13647,
     "skill_label": "Pre-sales Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39810,7 +39810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11040,
+    "id": 13648,
     "skill_label": "Pre-training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39820,7 +39820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11041,
+    "id": 13649,
     "skill_label": "Predictive Analytics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39830,7 +39830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11042,
+    "id": 13650,
     "skill_label": "Predictive Maintenance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39840,7 +39840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11043,
+    "id": 13651,
     "skill_label": "Predictive Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39850,7 +39850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11044,
+    "id": 13652,
     "skill_label": "Preference Learning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39860,7 +39860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11045,
+    "id": 13653,
     "skill_label": "Presentation Skills",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39870,7 +39870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11046,
+    "id": 13654,
     "skill_label": "Preventive Maintenance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39880,7 +39880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11047,
+    "id": 13655,
     "skill_label": "Pricing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39890,7 +39890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11048,
+    "id": 13656,
     "skill_label": "Pricing Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39900,7 +39900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11049,
+    "id": 13657,
     "skill_label": "Pricing Strategy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39910,7 +39910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11050,
+    "id": 13658,
     "skill_label": "Prisma",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39920,7 +39920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11051,
+    "id": 13659,
     "skill_label": "Privacy Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39930,7 +39930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11052,
+    "id": 13660,
     "skill_label": "Privacy-Preserving Learning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39940,7 +39940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11053,
+    "id": 13661,
     "skill_label": "Privileged Access Management (PAM)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39950,7 +39950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11054,
+    "id": 13662,
     "skill_label": "Probabilistic Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39960,7 +39960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11055,
+    "id": 13663,
     "skill_label": "Probability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39970,7 +39970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11056,
+    "id": 13664,
     "skill_label": "Probability Theory",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39980,7 +39980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11057,
+    "id": 13665,
     "skill_label": "Problem Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -39990,7 +39990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11058,
+    "id": 13666,
     "skill_label": "Problem Resolution",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40000,7 +40000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11059,
+    "id": 13667,
     "skill_label": "Problem Solving",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40010,7 +40010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11060,
+    "id": 13668,
     "skill_label": "Process Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40020,7 +40020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11061,
+    "id": 13669,
     "skill_label": "Process Calculus",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40030,7 +40030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11062,
+    "id": 13670,
     "skill_label": "Process Control",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40040,7 +40040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11063,
+    "id": 13671,
     "skill_label": "Process Control Network",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40050,7 +40050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11064,
+    "id": 13672,
     "skill_label": "Process Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40060,7 +40060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11065,
+    "id": 13673,
     "skill_label": "Process Failure Mode and Effects Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40070,7 +40070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11066,
+    "id": 13674,
     "skill_label": "Process Failure Mode and Effects Analysis (PFMEA)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40080,7 +40080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11067,
+    "id": 13675,
     "skill_label": "Process Flow Diagramming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40090,7 +40090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11068,
+    "id": 13676,
     "skill_label": "Process Historian Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40100,7 +40100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11069,
+    "id": 13677,
     "skill_label": "Process Improvement",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40110,7 +40110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11070,
+    "id": 13678,
     "skill_label": "Process Mapping",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40120,7 +40120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11071,
+    "id": 13679,
     "skill_label": "Process Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40130,7 +40130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11072,
+    "id": 13680,
     "skill_label": "Process Redesign",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40140,7 +40140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11073,
+    "id": 13681,
     "skill_label": "Process Simulation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40150,7 +40150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11074,
+    "id": 13682,
     "skill_label": "Process Validation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40160,7 +40160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11075,
+    "id": 13683,
     "skill_label": "Procurement",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40170,7 +40170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11076,
+    "id": 13684,
     "skill_label": "Procurement Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40180,7 +40180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11077,
+    "id": 13685,
     "skill_label": "Product Backlog Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40190,7 +40190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11078,
+    "id": 13686,
     "skill_label": "Product Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40200,7 +40200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11079,
+    "id": 13687,
     "skill_label": "Product Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40210,7 +40210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11080,
+    "id": 13688,
     "skill_label": "Product Discovery",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40220,7 +40220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11081,
+    "id": 13689,
     "skill_label": "Product Engineering Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40230,7 +40230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11082,
+    "id": 13690,
     "skill_label": "Product Expertise",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40240,7 +40240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11083,
+    "id": 13691,
     "skill_label": "Product Information Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40250,7 +40250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11084,
+    "id": 13692,
     "skill_label": "Product Launch",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40260,7 +40260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11085,
+    "id": 13693,
     "skill_label": "Product Life Cycle Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40270,7 +40270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11086,
+    "id": 13694,
     "skill_label": "Product Lifecycle Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40280,7 +40280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11087,
+    "id": 13695,
     "skill_label": "Product Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40290,7 +40290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11088,
+    "id": 13696,
     "skill_label": "Product Marketing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40300,7 +40300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11089,
+    "id": 13697,
     "skill_label": "Product Owner Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40310,7 +40310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11090,
+    "id": 13698,
     "skill_label": "Product Performance Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40320,7 +40320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11091,
+    "id": 13699,
     "skill_label": "Product Planning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40330,7 +40330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11092,
+    "id": 13700,
     "skill_label": "Product Qualification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40340,7 +40340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11093,
+    "id": 13701,
     "skill_label": "Product Requirements Definition",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40350,7 +40350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11094,
+    "id": 13702,
     "skill_label": "Product Roadmap",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40360,7 +40360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11095,
+    "id": 13703,
     "skill_label": "Product Roadmap Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40370,7 +40370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11096,
+    "id": 13704,
     "skill_label": "Product Roadmap Planning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40380,7 +40380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11097,
+    "id": 13705,
     "skill_label": "Product Specification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40390,7 +40390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11098,
+    "id": 13706,
     "skill_label": "Product Strategy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40400,7 +40400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11099,
+    "id": 13707,
     "skill_label": "Product Talent Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40410,7 +40410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11100,
+    "id": 13708,
     "skill_label": "Product Thinking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40420,7 +40420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11101,
+    "id": 13709,
     "skill_label": "Product Validation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40430,7 +40430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11102,
+    "id": 13710,
     "skill_label": "Production Deployment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40440,7 +40440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11103,
+    "id": 13711,
     "skill_label": "Production Implementation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40450,7 +40450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11104,
+    "id": 13712,
     "skill_label": "Production Machine Learning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40460,7 +40460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11105,
+    "id": 13713,
     "skill_label": "Production Part Approval Process (PPAP)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40470,7 +40470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11106,
+    "id": 13714,
     "skill_label": "Production Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40480,7 +40480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11107,
+    "id": 13715,
     "skill_label": "Production Vehicle Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40490,7 +40490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11108,
+    "id": 13716,
     "skill_label": "Professional Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40500,7 +40500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11109,
+    "id": 13717,
     "skill_label": "Professional Engineering License",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40510,7 +40510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11110,
+    "id": 13718,
     "skill_label": "Professionalism",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40520,7 +40520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11111,
+    "id": 13719,
     "skill_label": "Program Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40530,7 +40530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11112,
+    "id": 13720,
     "skill_label": "Program Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40540,7 +40540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11113,
+    "id": 13721,
     "skill_label": "Programmable Logic Controllers",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40550,7 +40550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11114,
+    "id": 13722,
     "skill_label": "Programmable Logic Controllers (PLC)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40560,7 +40560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11115,
+    "id": 13723,
     "skill_label": "Programmable Logic Controllers (PLC) Programming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40570,7 +40570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11116,
+    "id": 13724,
     "skill_label": "Programmable Logic Controllers (PLCs)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40580,7 +40580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11117,
+    "id": 13725,
     "skill_label": "Programming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40590,7 +40590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11118,
+    "id": 13726,
     "skill_label": "Programming Design Methodologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40600,7 +40600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11119,
+    "id": 13727,
     "skill_label": "Programming Languages",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40610,7 +40610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11120,
+    "id": 13728,
     "skill_label": "Progressive Delivery",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40620,7 +40620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11121,
+    "id": 13729,
     "skill_label": "Project Collaboration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40630,7 +40630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11122,
+    "id": 13730,
     "skill_label": "Project Coordination",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40640,7 +40640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11123,
+    "id": 13731,
     "skill_label": "Project Cost Estimation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40650,7 +40650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11124,
+    "id": 13732,
     "skill_label": "Project Delivery",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40660,7 +40660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11125,
+    "id": 13733,
     "skill_label": "Project Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40670,7 +40670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11126,
+    "id": 13734,
     "skill_label": "Project Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40680,7 +40680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11127,
+    "id": 13735,
     "skill_label": "Project Management Methodologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40690,7 +40690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11128,
+    "id": 13736,
     "skill_label": "Project Management Professional (PMP)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40700,7 +40700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11129,
+    "id": 13737,
     "skill_label": "Project Planning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40710,7 +40710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11130,
+    "id": 13738,
     "skill_label": "Project Quality Plan Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40720,7 +40720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11131,
+    "id": 13739,
     "skill_label": "Project Quality Plan Implementation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40730,7 +40730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11132,
+    "id": 13740,
     "skill_label": "Project Quantity Estimation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40740,7 +40740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11133,
+    "id": 13741,
     "skill_label": "Project Scheduling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40750,7 +40750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11134,
+    "id": 13742,
     "skill_label": "Project Work",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40760,7 +40760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11135,
+    "id": 13743,
     "skill_label": "Project-Based Learning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40770,7 +40770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11136,
+    "id": 13744,
     "skill_label": "Prompt Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40780,7 +40780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11137,
+    "id": 13745,
     "skill_label": "Proposal Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40790,7 +40790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11138,
+    "id": 13746,
     "skill_label": "Proposal Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40800,7 +40800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11139,
+    "id": 13747,
     "skill_label": "Protective Services",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40810,7 +40810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11140,
+    "id": 13748,
     "skill_label": "Prototype Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40820,7 +40820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11141,
+    "id": 13749,
     "skill_label": "Proxy Technologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40830,7 +40830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11142,
+    "id": 13750,
     "skill_label": "Public Health Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40840,7 +40840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11143,
+    "id": 13751,
     "skill_label": "Public Key Infrastructure",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40850,7 +40850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11144,
+    "id": 13752,
     "skill_label": "Public Key Infrastructure (PKI)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40860,7 +40860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11145,
+    "id": 13753,
     "skill_label": "Public Policy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40870,7 +40870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11146,
+    "id": 13754,
     "skill_label": "Public Sector Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40880,7 +40880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11147,
+    "id": 13755,
     "skill_label": "Public Trust Clearance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40890,7 +40890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11148,
+    "id": 13756,
     "skill_label": "Purchase Order Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40900,7 +40900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11149,
+    "id": 13757,
     "skill_label": "PySpark",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40910,7 +40910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11150,
+    "id": 13758,
     "skill_label": "Python",
     "esco_uri": "http://data.europa.eu/esco/skill/ccd0a1d9-afda-43d9-b901-96344886e14d",
     "week": "2026-04-20",
@@ -40920,7 +40920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11151,
+    "id": 13759,
     "skill_label": "Python Programming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40930,7 +40930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11152,
+    "id": 13760,
     "skill_label": "QA Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40940,7 +40940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11153,
+    "id": 13761,
     "skill_label": "Qualification Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40950,7 +40950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11154,
+    "id": 13762,
     "skill_label": "Qualitative Data Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40960,7 +40960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11155,
+    "id": 13763,
     "skill_label": "Quality Assurance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40970,7 +40970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11156,
+    "id": 13764,
     "skill_label": "Quality Control",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40980,7 +40980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11157,
+    "id": 13765,
     "skill_label": "Quality Improvement",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -40990,7 +40990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11158,
+    "id": 13766,
     "skill_label": "Quality Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41000,7 +41000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11159,
+    "id": 13767,
     "skill_label": "Quality Management System",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41010,7 +41010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11160,
+    "id": 13768,
     "skill_label": "Quality Payment Programs",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41020,7 +41020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11161,
+    "id": 13769,
     "skill_label": "Qualys",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41030,7 +41030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11162,
+    "id": 13770,
     "skill_label": "Quantitative Analysis",
     "esco_uri": "http://data.europa.eu/esco/skill/6360a934-cc87-4954-9656-b32db20592e3",
     "week": "2026-04-20",
@@ -41040,7 +41040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11163,
+    "id": 13771,
     "skill_label": "Quantitative Data Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41050,7 +41050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11164,
+    "id": 13772,
     "skill_label": "Quantitative Methods",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41060,7 +41060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11165,
+    "id": 13773,
     "skill_label": "Quantitative Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41070,7 +41070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11166,
+    "id": 13774,
     "skill_label": "Quantitative Research",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41080,7 +41080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11167,
+    "id": 13775,
     "skill_label": "Quantity Takeoff",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41090,7 +41090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11168,
+    "id": 13776,
     "skill_label": "Query Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41100,7 +41100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11169,
+    "id": 13777,
     "skill_label": "RAFT",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41110,7 +41110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11170,
+    "id": 13778,
     "skill_label": "REST API",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41120,7 +41120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11171,
+    "id": 13779,
     "skill_label": "REST APIs",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41130,7 +41130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11172,
+    "id": 13780,
     "skill_label": "RF Circuit Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41140,7 +41140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11173,
+    "id": 13781,
     "skill_label": "RFP Responses",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41150,7 +41150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11174,
+    "id": 13782,
     "skill_label": "RS-485",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41160,7 +41160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11175,
+    "id": 13783,
     "skill_label": "Radar Systems Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41170,7 +41170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11176,
+    "id": 13784,
     "skill_label": "Radio Frequency (RF) Fundamentals",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41180,7 +41180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11177,
+    "id": 13785,
     "skill_label": "Radio Frequency Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41190,7 +41190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11178,
+    "id": 13786,
     "skill_label": "Radiologic Technology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41200,7 +41200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11179,
+    "id": 13787,
     "skill_label": "Radiologic Technology Education",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41210,7 +41210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11180,
+    "id": 13788,
     "skill_label": "Ranking Algorithms",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41220,7 +41220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11181,
+    "id": 13789,
     "skill_label": "Rapid Experimentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41230,7 +41230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11182,
+    "id": 13790,
     "skill_label": "React",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41240,7 +41240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11183,
+    "id": 13791,
     "skill_label": "Reading Technical Documentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41250,7 +41250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11184,
+    "id": 13792,
     "skill_label": "Reading and Interpreting Technical Diagrams",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41260,7 +41260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11185,
+    "id": 13793,
     "skill_label": "Real Estate Domain Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41270,7 +41270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11186,
+    "id": 13794,
     "skill_label": "Real Estate License",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41280,7 +41280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11187,
+    "id": 13795,
     "skill_label": "Real Estate Transactions",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41290,7 +41290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11188,
+    "id": 13796,
     "skill_label": "Real-Time Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41300,7 +41300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11189,
+    "id": 13797,
     "skill_label": "Real-Time Operating Systems (RTOS)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41310,7 +41310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11190,
+    "id": 13798,
     "skill_label": "Real-Time Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41320,7 +41320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11191,
+    "id": 13799,
     "skill_label": "Real-time Analytics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41330,7 +41330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11192,
+    "id": 13800,
     "skill_label": "Real-time Data Streaming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41340,7 +41340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11193,
+    "id": 13801,
     "skill_label": "Real-time Embedded Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41350,7 +41350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11194,
+    "id": 13802,
     "skill_label": "Reasoning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41360,7 +41360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11195,
+    "id": 13803,
     "skill_label": "Recommendation Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41370,7 +41370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11196,
+    "id": 13804,
     "skill_label": "Recommender Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41380,7 +41380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11197,
+    "id": 13805,
     "skill_label": "Record Keeping",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41390,7 +41390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11198,
+    "id": 13806,
     "skill_label": "Recurrent Neural Networks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41400,7 +41400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11199,
+    "id": 13807,
     "skill_label": "Red Hat Enterprise Linux",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41410,7 +41410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11200,
+    "id": 13808,
     "skill_label": "Red Teaming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41420,7 +41420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11201,
+    "id": 13809,
     "skill_label": "Redux",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41430,7 +41430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11202,
+    "id": 13810,
     "skill_label": "Regional Market Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41440,7 +41440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11203,
+    "id": 13811,
     "skill_label": "Registered Nurse",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41450,7 +41450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11204,
+    "id": 13812,
     "skill_label": "Regression Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41460,7 +41460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11205,
+    "id": 13813,
     "skill_label": "Regression Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41470,7 +41470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11206,
+    "id": 13814,
     "skill_label": "Regulated Environment Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41480,7 +41480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11207,
+    "id": 13815,
     "skill_label": "Regulated Environment Experience",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41490,7 +41490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11208,
+    "id": 13816,
     "skill_label": "Regulatory Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41500,7 +41500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11209,
+    "id": 13817,
     "skill_label": "Regulatory Control Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41510,7 +41510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11210,
+    "id": 13818,
     "skill_label": "Regulatory compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41520,7 +41520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11211,
+    "id": 13819,
     "skill_label": "Reinforcement Learning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41530,7 +41530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11212,
+    "id": 13820,
     "skill_label": "Relational Data Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41540,7 +41540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11213,
+    "id": 13821,
     "skill_label": "Relational Data Modelling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41550,7 +41550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11214,
+    "id": 13822,
     "skill_label": "Relational Database",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41560,7 +41560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11215,
+    "id": 13823,
     "skill_label": "Relational Database Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41570,7 +41570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11216,
+    "id": 13824,
     "skill_label": "Relational Database Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41580,7 +41580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11217,
+    "id": 13825,
     "skill_label": "Relational Database Management Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41590,7 +41590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11218,
+    "id": 13826,
     "skill_label": "Relational Databases",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41600,7 +41600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11219,
+    "id": 13827,
     "skill_label": "Relay Control",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41610,7 +41610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11220,
+    "id": 13828,
     "skill_label": "Relay Logic",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41620,7 +41620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11221,
+    "id": 13829,
     "skill_label": "Release Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41630,7 +41630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11222,
+    "id": 13830,
     "skill_label": "Reliability Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41640,7 +41640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11223,
+    "id": 13831,
     "skill_label": "Reliable Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41650,7 +41650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11224,
+    "id": 13832,
     "skill_label": "Remote Access",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41660,7 +41660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11225,
+    "id": 13833,
     "skill_label": "Remote Work",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41670,7 +41670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11226,
+    "id": 13834,
     "skill_label": "Report Preparation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41680,7 +41680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11227,
+    "id": 13835,
     "skill_label": "Report Writing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41690,7 +41690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11228,
+    "id": 13836,
     "skill_label": "Reporting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41700,7 +41700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11229,
+    "id": 13837,
     "skill_label": "Reports",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41710,7 +41710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11230,
+    "id": 13838,
     "skill_label": "Request for Proposal (RFP)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41720,7 +41720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11231,
+    "id": 13839,
     "skill_label": "Request for Proposal (RFP) Authoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41730,7 +41730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11232,
+    "id": 13840,
     "skill_label": "Requirement Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41740,7 +41740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11233,
+    "id": 13841,
     "skill_label": "Requirements Allocation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41750,7 +41750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11234,
+    "id": 13842,
     "skill_label": "Requirements Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41760,7 +41760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11235,
+    "id": 13843,
     "skill_label": "Requirements Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41770,7 +41770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11236,
+    "id": 13844,
     "skill_label": "Requirements Documentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41780,7 +41780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11237,
+    "id": 13845,
     "skill_label": "Requirements Elicitation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41790,7 +41790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11238,
+    "id": 13846,
     "skill_label": "Requirements Gathering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41800,7 +41800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11239,
+    "id": 13847,
     "skill_label": "Requirements Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41810,7 +41810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11240,
+    "id": 13848,
     "skill_label": "Research",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41820,7 +41820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11241,
+    "id": 13849,
     "skill_label": "Research Autonomy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41830,7 +41830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11242,
+    "id": 13850,
     "skill_label": "Research Environment Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41840,7 +41840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11243,
+    "id": 13851,
     "skill_label": "Research Experience",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41850,7 +41850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11244,
+    "id": 13852,
     "skill_label": "Research Methodology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41860,7 +41860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11245,
+    "id": 13853,
     "skill_label": "Research Prototyping",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41870,7 +41870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11246,
+    "id": 13854,
     "skill_label": "Research Publication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41880,7 +41880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11247,
+    "id": 13855,
     "skill_label": "Research and Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41890,7 +41890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11248,
+    "id": 13856,
     "skill_label": "Research to Production Deployment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41900,7 +41900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11249,
+    "id": 13857,
     "skill_label": "Residential Property Valuation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41910,7 +41910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11250,
+    "id": 13858,
     "skill_label": "Resource Forecasting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41920,7 +41920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11251,
+    "id": 13859,
     "skill_label": "Responsible AI",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41930,7 +41930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11252,
+    "id": 13860,
     "skill_label": "Responsible AI Practices",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41940,7 +41940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11253,
+    "id": 13861,
     "skill_label": "Responsible Disclosure",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41950,7 +41950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11254,
+    "id": 13862,
     "skill_label": "Responsive Web Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41960,7 +41960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11255,
+    "id": 13863,
     "skill_label": "Retail Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41970,7 +41970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11256,
+    "id": 13864,
     "skill_label": "Retail Merchandising",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41980,7 +41980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11257,
+    "id": 13865,
     "skill_label": "Retail Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -41990,7 +41990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11258,
+    "id": 13866,
     "skill_label": "Retail Sales",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42000,7 +42000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11259,
+    "id": 13867,
     "skill_label": "Retail Training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42010,7 +42010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11260,
+    "id": 13868,
     "skill_label": "Retrieval-Augmented Generation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42020,7 +42020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11261,
+    "id": 13869,
     "skill_label": "Revenue Cycle Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42030,7 +42030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11262,
+    "id": 13870,
     "skill_label": "Reverse Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42040,7 +42040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11263,
+    "id": 13871,
     "skill_label": "Reward Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42050,7 +42050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11264,
+    "id": 13872,
     "skill_label": "Risk Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42060,7 +42060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11265,
+    "id": 13873,
     "skill_label": "Risk Assessment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42070,7 +42070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11266,
+    "id": 13874,
     "skill_label": "Risk Identification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42080,7 +42080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11267,
+    "id": 13875,
     "skill_label": "Risk Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42090,7 +42090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11268,
+    "id": 13876,
     "skill_label": "Risk Management Framework (RMF)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42100,7 +42100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11269,
+    "id": 13877,
     "skill_label": "Risk Mitigation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42110,7 +42110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11270,
+    "id": 13878,
     "skill_label": "Risk Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42120,7 +42120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11271,
+    "id": 13879,
     "skill_label": "Risk-based Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42130,7 +42130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11272,
+    "id": 13880,
     "skill_label": "Roadway Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42140,7 +42140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11273,
+    "id": 13881,
     "skill_label": "Robot Framework",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42150,7 +42150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11274,
+    "id": 13882,
     "skill_label": "Robotic Process Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42160,7 +42160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11275,
+    "id": 13883,
     "skill_label": "Robotics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42170,7 +42170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11276,
+    "id": 13884,
     "skill_label": "Robustness",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42180,7 +42180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11277,
+    "id": 13885,
     "skill_label": "Robustness Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42190,7 +42190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11278,
+    "id": 13886,
     "skill_label": "Role-Based Access Control",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42200,7 +42200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11279,
+    "id": 13887,
     "skill_label": "Root Cause Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42210,7 +42210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11280,
+    "id": 13888,
     "skill_label": "Route Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42220,7 +42220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11281,
+    "id": 13889,
     "skill_label": "Routing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42230,7 +42230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11282,
+    "id": 13890,
     "skill_label": "Routing Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42240,7 +42240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11283,
+    "id": 13891,
     "skill_label": "Routing and Switching Technologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42250,7 +42250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11284,
+    "id": 13892,
     "skill_label": "Rubric Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42260,7 +42260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11285,
+    "id": 13893,
     "skill_label": "Ruby",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42270,7 +42270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11286,
+    "id": 13894,
     "skill_label": "Ruby on Rails",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42280,7 +42280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11287,
+    "id": 13895,
     "skill_label": "Ruleset Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42290,7 +42290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11288,
+    "id": 13896,
     "skill_label": "Rust",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42300,7 +42300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11289,
+    "id": 13897,
     "skill_label": "SAFe",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42310,7 +42310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11290,
+    "id": 13898,
     "skill_label": "SAFe Scrum Master (SSM)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42320,7 +42320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11291,
+    "id": 13899,
     "skill_label": "SAML",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42330,7 +42330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11292,
+    "id": 13900,
     "skill_label": "SAP",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42340,7 +42340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11293,
+    "id": 13901,
     "skill_label": "SAS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42350,7 +42350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11294,
+    "id": 13902,
     "skill_label": "SCADA",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42360,7 +42360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11295,
+    "id": 13903,
     "skill_label": "SCADA Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42370,7 +42370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11296,
+    "id": 13904,
     "skill_label": "SDK Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42380,7 +42380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11297,
+    "id": 13905,
     "skill_label": "SFTP",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42390,7 +42390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11298,
+    "id": 13906,
     "skill_label": "SOA",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42400,7 +42400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11299,
+    "id": 13907,
     "skill_label": "SOAP APIs",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42410,7 +42410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11300,
+    "id": 13908,
     "skill_label": "SOC 2",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42420,7 +42420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11301,
+    "id": 13909,
     "skill_label": "SOX",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42430,7 +42430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11302,
+    "id": 13910,
     "skill_label": "SPI",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42440,7 +42440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11303,
+    "id": 13911,
     "skill_label": "SQL",
     "esco_uri": "http://data.europa.eu/esco/skill/ab1e97ed-2319-4293-a8b7-072d2648822f",
     "week": "2026-04-20",
@@ -42450,7 +42450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11304,
+    "id": 13912,
     "skill_label": "SQL Databases",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42460,7 +42460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11305,
+    "id": 13913,
     "skill_label": "SQL Programming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42470,7 +42470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11306,
+    "id": 13914,
     "skill_label": "SQL Queries",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42480,7 +42480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11307,
+    "id": 13915,
     "skill_label": "SQL Query Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42490,7 +42490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11308,
+    "id": 13916,
     "skill_label": "SQL Querying",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42500,7 +42500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11309,
+    "id": 13917,
     "skill_label": "SQL Server",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42510,7 +42510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11310,
+    "id": 13918,
     "skill_label": "SSH",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42520,7 +42520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11311,
+    "id": 13919,
     "skill_label": "SSIS Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42530,7 +42530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11312,
+    "id": 13920,
     "skill_label": "SSL/TLS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42540,7 +42540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11313,
+    "id": 13921,
     "skill_label": "STEM Degree",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42550,7 +42550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11314,
+    "id": 13922,
     "skill_label": "STIGs",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42560,7 +42560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11315,
+    "id": 13923,
     "skill_label": "SaaS Applications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42570,7 +42570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11316,
+    "id": 13924,
     "skill_label": "SaaS Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42580,7 +42580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11317,
+    "id": 13925,
     "skill_label": "Safety Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42590,7 +42590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11318,
+    "id": 13926,
     "skill_label": "Safety Best Practices",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42600,7 +42600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11319,
+    "id": 13927,
     "skill_label": "Safety Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42610,7 +42610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11320,
+    "id": 13928,
     "skill_label": "Safety Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42620,7 +42620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11321,
+    "id": 13929,
     "skill_label": "Safety Equipment Maintenance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42630,7 +42630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11322,
+    "id": 13930,
     "skill_label": "Safety Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42640,7 +42640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11323,
+    "id": 13931,
     "skill_label": "Safety Methods",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42650,7 +42650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11324,
+    "id": 13932,
     "skill_label": "Safety Regulations Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42660,7 +42660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11325,
+    "id": 13933,
     "skill_label": "Safety Standards Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42670,7 +42670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11326,
+    "id": 13934,
     "skill_label": "Sales",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42680,7 +42680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11327,
+    "id": 13935,
     "skill_label": "Sales Domain Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42690,7 +42690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11328,
+    "id": 13936,
     "skill_label": "Sales Enablement",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42700,7 +42700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11329,
+    "id": 13937,
     "skill_label": "Sales Forecasting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42710,7 +42710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11330,
+    "id": 13938,
     "skill_label": "Sales Forecasting and Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42720,7 +42720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11331,
+    "id": 13939,
     "skill_label": "Sales Negotiation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42730,7 +42730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11332,
+    "id": 13940,
     "skill_label": "Sales Presentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42740,7 +42740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11333,
+    "id": 13941,
     "skill_label": "Sales Promotion",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42750,7 +42750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11334,
+    "id": 13942,
     "skill_label": "Sales Strategy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42760,7 +42760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11335,
+    "id": 13943,
     "skill_label": "Salesforce",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42770,7 +42770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11336,
+    "id": 13944,
     "skill_label": "Sandboxing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42780,7 +42780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11337,
+    "id": 13945,
     "skill_label": "Satellite Communications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42790,7 +42790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11338,
+    "id": 13946,
     "skill_label": "Satellite Ground Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42800,7 +42800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11339,
+    "id": 13947,
     "skill_label": "Scala",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42810,7 +42810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11340,
+    "id": 13948,
     "skill_label": "Scalability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42820,7 +42820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11341,
+    "id": 13949,
     "skill_label": "Scalable Cloud Solutions",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42830,7 +42830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11342,
+    "id": 13950,
     "skill_label": "Scalable Model Training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42840,7 +42840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11343,
+    "id": 13951,
     "skill_label": "Scalable Systems Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42850,7 +42850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11344,
+    "id": 13952,
     "skill_label": "Scaled Agile Framework (SAFe)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42860,7 +42860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11345,
+    "id": 13953,
     "skill_label": "Scenario Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42870,7 +42870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11346,
+    "id": 13954,
     "skill_label": "Schedule Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42880,7 +42880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11347,
+    "id": 13955,
     "skill_label": "Scheduling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42890,7 +42890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11348,
+    "id": 13956,
     "skill_label": "Schema Migration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42900,7 +42900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11349,
+    "id": 13957,
     "skill_label": "Schematic Reading",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42910,7 +42910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11350,
+    "id": 13958,
     "skill_label": "SciPy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42920,7 +42920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11351,
+    "id": 13959,
     "skill_label": "Scientific Computing",
     "esco_uri": "http://data.europa.eu/esco/skill/5b26f08b-88bc-45f0-b901-530d7786466b",
     "week": "2026-04-20",
@@ -42930,7 +42930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11352,
+    "id": 13960,
     "skill_label": "Scientific Reasoning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42940,7 +42940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11353,
+    "id": 13961,
     "skill_label": "Scientific Research",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42950,7 +42950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11354,
+    "id": 13962,
     "skill_label": "Scikit-Learn",
     "esco_uri": "http://data.europa.eu/esco/skill/484df271-bb52-49f1-8f50-f19624bf4df2",
     "week": "2026-04-20",
@@ -42960,7 +42960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11355,
+    "id": 13963,
     "skill_label": "Scikit-learn",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42970,7 +42970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11356,
+    "id": 13964,
     "skill_label": "Scope Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42980,7 +42980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11357,
+    "id": 13965,
     "skill_label": "Scripted Programming Languages",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -42990,7 +42990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11358,
+    "id": 13966,
     "skill_label": "Scripting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43000,7 +43000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11359,
+    "id": 13967,
     "skill_label": "Scripting Languages",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43010,7 +43010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11360,
+    "id": 13968,
     "skill_label": "Scrum",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43020,7 +43020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11361,
+    "id": 13969,
     "skill_label": "Search",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43030,7 +43030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11362,
+    "id": 13970,
     "skill_label": "Search Engine Optimization",
     "esco_uri": "http://data.europa.eu/esco/skill/eda4d727-4374-49af-ace4-118c7c906835",
     "week": "2026-04-20",
@@ -43040,7 +43040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11363,
+    "id": 13971,
     "skill_label": "Search Technology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43050,7 +43050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11364,
+    "id": 13972,
     "skill_label": "Secret Security Clearance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43060,7 +43060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11365,
+    "id": 13973,
     "skill_label": "Secrets Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43070,7 +43070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11366,
+    "id": 13974,
     "skill_label": "Section 889 Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43080,7 +43080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11367,
+    "id": 13975,
     "skill_label": "Secure Coding",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43090,7 +43090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11368,
+    "id": 13976,
     "skill_label": "Secure Data Storage",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43100,7 +43100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11369,
+    "id": 13977,
     "skill_label": "Secure Network Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43110,7 +43110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11370,
+    "id": 13978,
     "skill_label": "Secure Software Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43120,7 +43120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11371,
+    "id": 13979,
     "skill_label": "Secure Software Development Lifecycle",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43130,7 +43130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11372,
+    "id": 13980,
     "skill_label": "Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43140,7 +43140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11373,
+    "id": 13981,
     "skill_label": "Security Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43150,7 +43150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11374,
+    "id": 13982,
     "skill_label": "Security Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43160,7 +43160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11375,
+    "id": 13983,
     "skill_label": "Security Assertion Markup Language",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43170,7 +43170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11376,
+    "id": 13984,
     "skill_label": "Security Auditing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43180,7 +43180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11377,
+    "id": 13985,
     "skill_label": "Security Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43190,7 +43190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11378,
+    "id": 13986,
     "skill_label": "Security Awareness Training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43200,7 +43200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11379,
+    "id": 13987,
     "skill_label": "Security Best Practices",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43210,7 +43210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11380,
+    "id": 13988,
     "skill_label": "Security Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43220,7 +43220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11381,
+    "id": 13989,
     "skill_label": "Security Champions Program",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43230,7 +43230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11382,
+    "id": 13990,
     "skill_label": "Security Clearance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43240,7 +43240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11383,
+    "id": 13991,
     "skill_label": "Security Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43250,7 +43250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11384,
+    "id": 13992,
     "skill_label": "Security Controls",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43260,7 +43260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11385,
+    "id": 13993,
     "skill_label": "Security Controls Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43270,7 +43270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11386,
+    "id": 13994,
     "skill_label": "Security Controls Implementation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43280,7 +43280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11387,
+    "id": 13995,
     "skill_label": "Security Controls Tuning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43290,7 +43290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11388,
+    "id": 13996,
     "skill_label": "Security Documentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43300,7 +43300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11389,
+    "id": 13997,
     "skill_label": "Security Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43310,7 +43310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11390,
+    "id": 13998,
     "skill_label": "Security Frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43320,7 +43320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11391,
+    "id": 13999,
     "skill_label": "Security Gap Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43330,7 +43330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11392,
+    "id": 14000,
     "skill_label": "Security Governance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43340,7 +43340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11393,
+    "id": 14001,
     "skill_label": "Security Incident Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43350,7 +43350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11394,
+    "id": 14002,
     "skill_label": "Security Information and Event Management (SIEM)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43360,7 +43360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11395,
+    "id": 14003,
     "skill_label": "Security Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43370,7 +43370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11396,
+    "id": 14004,
     "skill_label": "Security Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43380,7 +43380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11397,
+    "id": 14005,
     "skill_label": "Security Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43390,7 +43390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11398,
+    "id": 14006,
     "skill_label": "Security Operations Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43400,7 +43400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11399,
+    "id": 14007,
     "skill_label": "Security Patrol",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43410,7 +43410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11400,
+    "id": 14008,
     "skill_label": "Security Platform Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43420,7 +43420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11401,
+    "id": 14009,
     "skill_label": "Security Reporting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43430,7 +43430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11402,
+    "id": 14010,
     "skill_label": "Security Risk Assessment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43440,7 +43440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11403,
+    "id": 14011,
     "skill_label": "Security Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43450,7 +43450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11404,
+    "id": 14012,
     "skill_label": "Security Technical Implementation Guide (STIG)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43460,7 +43460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11405,
+    "id": 14013,
     "skill_label": "Security Technologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43470,7 +43470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11406,
+    "id": 14014,
     "skill_label": "Security Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43480,7 +43480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11407,
+    "id": 14015,
     "skill_label": "Security Tools Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43490,7 +43490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11408,
+    "id": 14016,
     "skill_label": "Security Training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43500,7 +43500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11409,
+    "id": 14017,
     "skill_label": "Security Workflow Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43510,7 +43510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11410,
+    "id": 14018,
     "skill_label": "Security+",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43520,7 +43520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11411,
+    "id": 14019,
     "skill_label": "Selenium",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43530,7 +43530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11412,
+    "id": 14020,
     "skill_label": "Self Marketing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43540,7 +43540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11413,
+    "id": 14021,
     "skill_label": "Self-healing Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43550,7 +43550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11414,
+    "id": 14022,
     "skill_label": "Self-service Portals",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43560,7 +43560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11415,
+    "id": 14023,
     "skill_label": "Semantic Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43570,7 +43570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11416,
+    "id": 14024,
     "skill_label": "Semantic Search",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43580,7 +43580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11417,
+    "id": 14025,
     "skill_label": "Semantic Segmentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43590,7 +43590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11418,
+    "id": 14026,
     "skill_label": "Sensitivity Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43600,7 +43600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11419,
+    "id": 14027,
     "skill_label": "Serial Console Access",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43610,7 +43610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11420,
+    "id": 14028,
     "skill_label": "Server Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43620,7 +43620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11421,
+    "id": 14029,
     "skill_label": "Server Components",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43630,7 +43630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11422,
+    "id": 14030,
     "skill_label": "Server Operating Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43640,7 +43640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11423,
+    "id": 14031,
     "skill_label": "Serverless Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43650,7 +43650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11424,
+    "id": 14032,
     "skill_label": "Service Bus",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43660,7 +43660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11425,
+    "id": 14033,
     "skill_label": "Service Level Indicators",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43670,7 +43670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11426,
+    "id": 14034,
     "skill_label": "Service Level Indicators (SLIs)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43680,7 +43680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11427,
+    "id": 14035,
     "skill_label": "Service Level Objectives",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43690,7 +43690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11428,
+    "id": 14036,
     "skill_label": "Service Level Objectives (SLOs)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43700,7 +43700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11429,
+    "id": 14037,
     "skill_label": "Service Principal Names (SPNs)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43710,7 +43710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11430,
+    "id": 14038,
     "skill_label": "Service Provider Sales",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43720,7 +43720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11431,
+    "id": 14039,
     "skill_label": "ServiceNow",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43730,7 +43730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11432,
+    "id": 14040,
     "skill_label": "Shell Scripting",
     "esco_uri": "Shell Script",
     "week": "2026-04-20",
@@ -43740,7 +43740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11433,
+    "id": 14041,
     "skill_label": "Shift Scheduling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43750,7 +43750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11434,
+    "id": 14042,
     "skill_label": "Shift Work",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43760,7 +43760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11435,
+    "id": 14043,
     "skill_label": "Ship Construction",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43770,7 +43770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11436,
+    "id": 14044,
     "skill_label": "Ship Propulsion Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43780,7 +43780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11437,
+    "id": 14045,
     "skill_label": "Shipbuilding",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43790,7 +43790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11438,
+    "id": 14046,
     "skill_label": "Shipping Order Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43800,7 +43800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11439,
+    "id": 14047,
     "skill_label": "Shipping Requirements Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43810,7 +43810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11440,
+    "id": 14048,
     "skill_label": "Short Circuit Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43820,7 +43820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11441,
+    "id": 14049,
     "skill_label": "Siemens PCS7",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43830,7 +43830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11442,
+    "id": 14050,
     "skill_label": "Sign Language Processing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43840,7 +43840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11443,
+    "id": 14051,
     "skill_label": "Signals Intelligence (SIGINT)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43850,7 +43850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11444,
+    "id": 14052,
     "skill_label": "Simulation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43860,7 +43860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11445,
+    "id": 14053,
     "skill_label": "Single Sign-On",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43870,7 +43870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11446,
+    "id": 14054,
     "skill_label": "Site Reliability Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43880,7 +43880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11447,
+    "id": 14055,
     "skill_label": "Site Survey",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43890,7 +43890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11448,
+    "id": 14056,
     "skill_label": "Six Sigma",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43900,7 +43900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11449,
+    "id": 14057,
     "skill_label": "Six Sigma Green Belt",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43910,7 +43910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11450,
+    "id": 14058,
     "skill_label": "Small Arms Handling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43920,7 +43920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11451,
+    "id": 14059,
     "skill_label": "Smart Building Technology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43930,7 +43930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11452,
+    "id": 14060,
     "skill_label": "Smart Contract Auditing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43940,7 +43940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11453,
+    "id": 14061,
     "skill_label": "Smart Contract Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43950,7 +43950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11454,
+    "id": 14062,
     "skill_label": "Smart Contract Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43960,7 +43960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11455,
+    "id": 14063,
     "skill_label": "Smart Contracts",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43970,7 +43970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11456,
+    "id": 14064,
     "skill_label": "Snowflake",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43980,7 +43980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11457,
+    "id": 14065,
     "skill_label": "Snowflake Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -43990,7 +43990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11458,
+    "id": 14066,
     "skill_label": "Snowflake Platform Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44000,7 +44000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11459,
+    "id": 14067,
     "skill_label": "Social Media Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44010,7 +44010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11460,
+    "id": 14068,
     "skill_label": "Social Media Marketing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44020,7 +44020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11461,
+    "id": 14069,
     "skill_label": "Software Applications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44030,7 +44030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11462,
+    "id": 14070,
     "skill_label": "Software Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44040,7 +44040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11463,
+    "id": 14071,
     "skill_label": "Software Assurance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44050,7 +44050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11464,
+    "id": 14072,
     "skill_label": "Software Code Review",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44060,7 +44060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11465,
+    "id": 14073,
     "skill_label": "Software Composition Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44070,7 +44070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11466,
+    "id": 14074,
     "skill_label": "Software Composition Analysis (SCA)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44080,7 +44080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11467,
+    "id": 14075,
     "skill_label": "Software Deployment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44090,7 +44090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11468,
+    "id": 14076,
     "skill_label": "Software Design",
     "esco_uri": "http://data.europa.eu/esco/skill/89f6560b-2194-45c9-9ece-d33049a73eef",
     "week": "2026-04-20",
@@ -44100,7 +44100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11469,
+    "id": 14077,
     "skill_label": "Software Design Patterns",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44110,7 +44110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11470,
+    "id": 14078,
     "skill_label": "Software Design Principles",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44120,7 +44120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11471,
+    "id": 14079,
     "skill_label": "Software Development",
     "esco_uri": "Software Development",
     "week": "2026-04-20",
@@ -44130,7 +44130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11472,
+    "id": 14080,
     "skill_label": "Software Development Best Practices",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44140,7 +44140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11473,
+    "id": 14081,
     "skill_label": "Software Development Life Cycle",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44150,7 +44150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11474,
+    "id": 14082,
     "skill_label": "Software Development Life Cycle (SDLC)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44160,7 +44160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11475,
+    "id": 14083,
     "skill_label": "Software Development Lifecycle",
     "esco_uri": "Software Development Life Cycle",
     "week": "2026-04-20",
@@ -44170,7 +44170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11476,
+    "id": 14084,
     "skill_label": "Software Development Lifecycle (SDLC)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44180,7 +44180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11477,
+    "id": 14085,
     "skill_label": "Software Development Methodologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44190,7 +44190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11478,
+    "id": 14086,
     "skill_label": "Software Development Processes",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44200,7 +44200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11479,
+    "id": 14087,
     "skill_label": "Software Development Project Leadership",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44210,7 +44210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11480,
+    "id": 14088,
     "skill_label": "Software Documentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44220,7 +44220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11481,
+    "id": 14089,
     "skill_label": "Software Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44230,7 +44230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11482,
+    "id": 14090,
     "skill_label": "Software Engineering Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44240,7 +44240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11483,
+    "id": 14091,
     "skill_label": "Software Installation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44250,7 +44250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11484,
+    "id": 14092,
     "skill_label": "Software Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44260,7 +44260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11485,
+    "id": 14093,
     "skill_label": "Software Prototyping",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44270,7 +44270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11486,
+    "id": 14094,
     "skill_label": "Software Quality Assurance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44280,7 +44280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11487,
+    "id": 14095,
     "skill_label": "Software Release Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44290,7 +44290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11488,
+    "id": 14096,
     "skill_label": "Software Testing",
     "esco_uri": "Software Testing",
     "week": "2026-04-20",
@@ -44300,7 +44300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11489,
+    "id": 14097,
     "skill_label": "Software Troubleshooting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44310,7 +44310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11490,
+    "id": 14098,
     "skill_label": "Software Verification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44320,7 +44320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11491,
+    "id": 14099,
     "skill_label": "Software and System Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44330,7 +44330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11492,
+    "id": 14100,
     "skill_label": "Software as a Service (SaaS)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44340,7 +44340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11493,
+    "id": 14101,
     "skill_label": "Solaris",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44350,7 +44350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11494,
+    "id": 14102,
     "skill_label": "Soldering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44360,7 +44360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11495,
+    "id": 14103,
     "skill_label": "Solidity",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44370,7 +44370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11496,
+    "id": 14104,
     "skill_label": "Solution Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44380,7 +44380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11497,
+    "id": 14105,
     "skill_label": "Solution Configuration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44390,7 +44390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11498,
+    "id": 14106,
     "skill_label": "Solution Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44400,7 +44400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11499,
+    "id": 14107,
     "skill_label": "Solution Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44410,7 +44410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11500,
+    "id": 14108,
     "skill_label": "Solution Selling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44420,7 +44420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11501,
+    "id": 14109,
     "skill_label": "Solution Validation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44430,7 +44430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11502,
+    "id": 14110,
     "skill_label": "Solutions Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44440,7 +44440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11503,
+    "id": 14111,
     "skill_label": "Spark",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44450,7 +44450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11504,
+    "id": 14112,
     "skill_label": "Spatial Intelligence",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44460,7 +44460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11505,
+    "id": 14113,
     "skill_label": "Spatiotemporal Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44470,7 +44470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11506,
+    "id": 14114,
     "skill_label": "Special Chemistry",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44480,7 +44480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11507,
+    "id": 14115,
     "skill_label": "Specification Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44490,7 +44490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11508,
+    "id": 14116,
     "skill_label": "Specification Writing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44500,7 +44500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11509,
+    "id": 14117,
     "skill_label": "Sponsored Projects Accounting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44510,7 +44510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11510,
+    "id": 14118,
     "skill_label": "Spring Boot",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44520,7 +44520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11511,
+    "id": 14119,
     "skill_label": "Spring Framework",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44530,7 +44530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11512,
+    "id": 14120,
     "skill_label": "Sprint Planning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44540,7 +44540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11513,
+    "id": 14121,
     "skill_label": "Staff Supervision",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44550,7 +44550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11514,
+    "id": 14122,
     "skill_label": "Staff Training and Mentoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44560,7 +44560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11515,
+    "id": 14123,
     "skill_label": "Staffing Planning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44570,7 +44570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11516,
+    "id": 14124,
     "skill_label": "Stakeholder Communication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44580,7 +44580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11517,
+    "id": 14125,
     "skill_label": "Stakeholder Coordination",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44590,7 +44590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11518,
+    "id": 14126,
     "skill_label": "Stakeholder Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44600,7 +44600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11519,
+    "id": 14127,
     "skill_label": "Standard Operating Procedures",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44610,7 +44610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11520,
+    "id": 14128,
     "skill_label": "Standard Operating Procedures (SOP)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44620,7 +44620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11521,
+    "id": 14129,
     "skill_label": "Standardized Work",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44630,7 +44630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11522,
+    "id": 14130,
     "skill_label": "Startup Experience",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44640,7 +44640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11523,
+    "id": 14131,
     "skill_label": "Startup Mentoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44650,7 +44650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11524,
+    "id": 14132,
     "skill_label": "Static Application Security Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44660,7 +44660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11525,
+    "id": 14133,
     "skill_label": "Static Application Security Testing (SAST)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44670,7 +44670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11526,
+    "id": 14134,
     "skill_label": "Statistical Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44680,7 +44680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11527,
+    "id": 14135,
     "skill_label": "Statistical Inference",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44690,7 +44690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11528,
+    "id": 14136,
     "skill_label": "Statistical Methods",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44700,7 +44700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11529,
+    "id": 14137,
     "skill_label": "Statistical Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44710,7 +44710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11530,
+    "id": 14138,
     "skill_label": "Statistical Process Control (SPC)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44720,7 +44720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11531,
+    "id": 14139,
     "skill_label": "Statistical Reasoning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44730,7 +44730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11532,
+    "id": 14140,
     "skill_label": "Statistics",
     "esco_uri": "Statistics",
     "week": "2026-04-20",
@@ -44740,7 +44740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11533,
+    "id": 14141,
     "skill_label": "Storage Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44750,7 +44750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11534,
+    "id": 14142,
     "skill_label": "Storage Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44760,7 +44760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11535,
+    "id": 14143,
     "skill_label": "Store Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44770,7 +44770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11536,
+    "id": 14144,
     "skill_label": "Stored Procedures",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44780,7 +44780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11537,
+    "id": 14145,
     "skill_label": "Strategic Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44790,7 +44790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11538,
+    "id": 14146,
     "skill_label": "Strategic Decision Making",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44800,7 +44800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11539,
+    "id": 14147,
     "skill_label": "Strategic Decision-Making with Data",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44810,7 +44810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11540,
+    "id": 14148,
     "skill_label": "Strategic Partnership Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44820,7 +44820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11541,
+    "id": 14149,
     "skill_label": "Strategic Planning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44830,7 +44830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11542,
+    "id": 14150,
     "skill_label": "Strategic Sourcing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44840,7 +44840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11543,
+    "id": 14151,
     "skill_label": "Strategic Thinking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44850,7 +44850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11544,
+    "id": 14152,
     "skill_label": "Stream Processing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44860,7 +44860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11545,
+    "id": 14153,
     "skill_label": "Streaming",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44870,7 +44870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11546,
+    "id": 14154,
     "skill_label": "Streaming Data",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44880,7 +44880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11547,
+    "id": 14155,
     "skill_label": "Streaming Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44890,7 +44890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11548,
+    "id": 14156,
     "skill_label": "Stress Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44900,7 +44900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11549,
+    "id": 14157,
     "skill_label": "Structural Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44910,7 +44910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11550,
+    "id": 14158,
     "skill_label": "Structured Cabling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44920,7 +44920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11551,
+    "id": 14159,
     "skill_label": "Structured Query Language",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44930,7 +44930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11552,
+    "id": 14160,
     "skill_label": "Studio 5000",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44940,7 +44940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11553,
+    "id": 14161,
     "skill_label": "Subject Matter Expert",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44950,7 +44950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11554,
+    "id": 14162,
     "skill_label": "Subscription Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44960,7 +44960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11555,
+    "id": 14163,
     "skill_label": "Supervised Learning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44970,7 +44970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11556,
+    "id": 14164,
     "skill_label": "Supervisory Control and Data Acquisition",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44980,7 +44980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11557,
+    "id": 14165,
     "skill_label": "Supervisory Control and Data Acquisition (SCADA)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -44990,7 +44990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11558,
+    "id": 14166,
     "skill_label": "Supervisory Skills",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45000,7 +45000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11559,
+    "id": 14167,
     "skill_label": "Supplier Auditing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45010,7 +45010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11560,
+    "id": 14168,
     "skill_label": "Supplier Corrective Actions",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45020,7 +45020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11561,
+    "id": 14169,
     "skill_label": "Supplier Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45030,7 +45030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11562,
+    "id": 14170,
     "skill_label": "Supplier Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45040,7 +45040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11563,
+    "id": 14171,
     "skill_label": "Supplier Quality Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45050,7 +45050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11564,
+    "id": 14172,
     "skill_label": "Supply Chain Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45060,7 +45060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11565,
+    "id": 14173,
     "skill_label": "Supply Chain Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45070,7 +45070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11566,
+    "id": 14174,
     "skill_label": "Supply Chain Risk Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45080,7 +45080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11567,
+    "id": 14175,
     "skill_label": "Supply Chain Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45090,7 +45090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11568,
+    "id": 14176,
     "skill_label": "Supportability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45100,7 +45100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11569,
+    "id": 14177,
     "skill_label": "Surgical Services",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45110,7 +45110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11570,
+    "id": 14178,
     "skill_label": "Surveying",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45120,7 +45120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11571,
+    "id": 14179,
     "skill_label": "Sustainable Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45130,7 +45130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11572,
+    "id": 14180,
     "skill_label": "Sustainment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45140,7 +45140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11573,
+    "id": 14181,
     "skill_label": "Swift",
     "esco_uri": "http://data.europa.eu/esco/skill/be80acfc-b6f2-4411-9b8d-b19d9cd2556a",
     "week": "2026-04-20",
@@ -45150,7 +45150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11574,
+    "id": 14182,
     "skill_label": "SwiftUI",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45160,7 +45160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11575,
+    "id": 14183,
     "skill_label": "Switching",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45170,7 +45170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11576,
+    "id": 14184,
     "skill_label": "Synthetic Data Generation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45180,7 +45180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11577,
+    "id": 14185,
     "skill_label": "System Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45190,7 +45190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11578,
+    "id": 14186,
     "skill_label": "System Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45200,7 +45200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11579,
+    "id": 14187,
     "skill_label": "System Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45210,7 +45210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11580,
+    "id": 14188,
     "skill_label": "System Availability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45220,7 +45220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11581,
+    "id": 14189,
     "skill_label": "System Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45230,7 +45230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11582,
+    "id": 14190,
     "skill_label": "System Documentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45240,7 +45240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11583,
+    "id": 14191,
     "skill_label": "System Implementation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45250,7 +45250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11584,
+    "id": 14192,
     "skill_label": "System Initialization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45260,7 +45260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11585,
+    "id": 14193,
     "skill_label": "System Integration",
     "esco_uri": "http://data.europa.eu/esco/skill/6fa1c2c0-a012-4ca0-9642-e01569ba322c",
     "week": "2026-04-20",
@@ -45270,7 +45270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11586,
+    "id": 14194,
     "skill_label": "System Maintenance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45280,7 +45280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11587,
+    "id": 14195,
     "skill_label": "System Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45290,7 +45290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11588,
+    "id": 14196,
     "skill_label": "System Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45300,7 +45300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11589,
+    "id": 14197,
     "skill_label": "System Operation and Maintenance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45310,7 +45310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11590,
+    "id": 14198,
     "skill_label": "System Performance Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45320,7 +45320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11591,
+    "id": 14199,
     "skill_label": "System Performance Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45330,7 +45330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11592,
+    "id": 14200,
     "skill_label": "System Performance Tuning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45340,7 +45340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11593,
+    "id": 14201,
     "skill_label": "System Requirements Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45350,7 +45350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11594,
+    "id": 14202,
     "skill_label": "System Safety",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45360,7 +45360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11595,
+    "id": 14203,
     "skill_label": "System Scalability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45370,7 +45370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11596,
+    "id": 14204,
     "skill_label": "System Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45380,7 +45380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11597,
+    "id": 14205,
     "skill_label": "System Software Specifications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45390,7 +45390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11598,
+    "id": 14206,
     "skill_label": "System Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45400,7 +45400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11599,
+    "id": 14207,
     "skill_label": "System-Level Software Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45410,7 +45410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11600,
+    "id": 14208,
     "skill_label": "Systems Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45420,7 +45420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11601,
+    "id": 14209,
     "skill_label": "Systems Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45430,7 +45430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11602,
+    "id": 14210,
     "skill_label": "Systems Configuration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45440,7 +45440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11603,
+    "id": 14211,
     "skill_label": "Systems Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45450,7 +45450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11604,
+    "id": 14212,
     "skill_label": "Systems Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45460,7 +45460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11605,
+    "id": 14213,
     "skill_label": "Systems Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45470,7 +45470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11606,
+    "id": 14214,
     "skill_label": "Systems Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45480,7 +45480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11607,
+    "id": 14215,
     "skill_label": "Systems Requirements Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45490,7 +45490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11608,
+    "id": 14216,
     "skill_label": "Systems Security Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45500,7 +45500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11609,
+    "id": 14217,
     "skill_label": "Systems Software",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45510,7 +45510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11610,
+    "id": 14218,
     "skill_label": "Systems Software Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45520,7 +45520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11611,
+    "id": 14219,
     "skill_label": "Systems Study",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45530,7 +45530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11612,
+    "id": 14220,
     "skill_label": "T-SQL",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45540,7 +45540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11613,
+    "id": 14221,
     "skill_label": "TCP/IP",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45550,7 +45550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11614,
+    "id": 14222,
     "skill_label": "TPU Computing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45560,7 +45560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11615,
+    "id": 14223,
     "skill_label": "TS/SCI Clearance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45570,7 +45570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11616,
+    "id": 14224,
     "skill_label": "TS/SCI Security Clearance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45580,7 +45580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11617,
+    "id": 14225,
     "skill_label": "TSG Execution",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45590,7 +45590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11618,
+    "id": 14226,
     "skill_label": "Tableau",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45600,7 +45600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11619,
+    "id": 14227,
     "skill_label": "Tactical Skills",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45610,7 +45610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11620,
+    "id": 14228,
     "skill_label": "Tailwind CSS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45620,7 +45620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11621,
+    "id": 14229,
     "skill_label": "Task Following",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45630,7 +45630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11622,
+    "id": 14230,
     "skill_label": "Tax Domain Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45640,7 +45640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11623,
+    "id": 14231,
     "skill_label": "Teaching",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45650,7 +45650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11624,
+    "id": 14232,
     "skill_label": "Team Collaboration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45660,7 +45660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11625,
+    "id": 14233,
     "skill_label": "Team Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45670,7 +45670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11626,
+    "id": 14234,
     "skill_label": "Team Leadership",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45680,7 +45680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11627,
+    "id": 14235,
     "skill_label": "Team Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45690,7 +45690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11628,
+    "id": 14236,
     "skill_label": "Team Scaling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45700,7 +45700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11629,
+    "id": 14237,
     "skill_label": "Team Supervision",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45710,7 +45710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11630,
+    "id": 14238,
     "skill_label": "Teamwork",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45720,7 +45720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11631,
+    "id": 14239,
     "skill_label": "Technical Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45730,7 +45730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11632,
+    "id": 14240,
     "skill_label": "Technical Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45740,7 +45740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11633,
+    "id": 14241,
     "skill_label": "Technical Baseline Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45750,7 +45750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11634,
+    "id": 14242,
     "skill_label": "Technical Communication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45760,7 +45760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11635,
+    "id": 14243,
     "skill_label": "Technical Consultation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45770,7 +45770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11636,
+    "id": 14244,
     "skill_label": "Technical Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45780,7 +45780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11637,
+    "id": 14245,
     "skill_label": "Technical Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45790,7 +45790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11638,
+    "id": 14246,
     "skill_label": "Technical Direction",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45800,7 +45800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11639,
+    "id": 14247,
     "skill_label": "Technical Documentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45810,7 +45810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11640,
+    "id": 14248,
     "skill_label": "Technical Documentation Interpretation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45820,7 +45820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11641,
+    "id": 14249,
     "skill_label": "Technical Feedback",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45830,7 +45830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11642,
+    "id": 14250,
     "skill_label": "Technical Interview Preparation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45840,7 +45840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11643,
+    "id": 14251,
     "skill_label": "Technical Leadership",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45850,7 +45850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11644,
+    "id": 14252,
     "skill_label": "Technical Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45860,7 +45860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11645,
+    "id": 14253,
     "skill_label": "Technical Mentoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45870,7 +45870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11646,
+    "id": 14254,
     "skill_label": "Technical Pre-sales Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45880,7 +45880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11647,
+    "id": 14255,
     "skill_label": "Technical Presentations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45890,7 +45890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11648,
+    "id": 14256,
     "skill_label": "Technical Pricing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45900,7 +45900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11649,
+    "id": 14257,
     "skill_label": "Technical Product Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45910,7 +45910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11650,
+    "id": 14258,
     "skill_label": "Technical Product Roadmap Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45920,7 +45920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11651,
+    "id": 14259,
     "skill_label": "Technical Project Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45930,7 +45930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11652,
+    "id": 14260,
     "skill_label": "Technical Readiness",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45940,7 +45940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11653,
+    "id": 14261,
     "skill_label": "Technical Report Writing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45950,7 +45950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11654,
+    "id": 14262,
     "skill_label": "Technical Reviews",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45960,7 +45960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11655,
+    "id": 14263,
     "skill_label": "Technical Sales",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45970,7 +45970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11656,
+    "id": 14264,
     "skill_label": "Technical Specification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45980,7 +45980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11657,
+    "id": 14265,
     "skill_label": "Technical Specification Interpretation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -45990,7 +45990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11658,
+    "id": 14266,
     "skill_label": "Technical Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46000,7 +46000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11659,
+    "id": 14267,
     "skill_label": "Technical Support / Troubleshooting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46010,7 +46010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11660,
+    "id": 14268,
     "skill_label": "Technical Training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46020,7 +46020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11661,
+    "id": 14269,
     "skill_label": "Technical Troubleshooting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46030,7 +46030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11662,
+    "id": 14270,
     "skill_label": "Technical Workshops",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46040,7 +46040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11663,
+    "id": 14271,
     "skill_label": "Technical Writing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46050,7 +46050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11664,
+    "id": 14272,
     "skill_label": "Technology Education",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46060,7 +46060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11665,
+    "id": 14273,
     "skill_label": "Technology Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46070,7 +46070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11666,
+    "id": 14274,
     "skill_label": "Technology Solutions Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46080,7 +46080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11667,
+    "id": 14275,
     "skill_label": "Telecommunications",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46090,7 +46090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11668,
+    "id": 14276,
     "skill_label": "Telecommunications Infrastructure",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46100,7 +46100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11669,
+    "id": 14277,
     "skill_label": "Temporal Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46110,7 +46110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11670,
+    "id": 14278,
     "skill_label": "Terraform",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46120,7 +46120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11671,
+    "id": 14279,
     "skill_label": "Territory Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46130,7 +46130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11672,
+    "id": 14280,
     "skill_label": "Test Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46140,7 +46140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11673,
+    "id": 14281,
     "skill_label": "Test Automation Frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46150,7 +46150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11674,
+    "id": 14282,
     "skill_label": "Test Case Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46160,7 +46160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11675,
+    "id": 14283,
     "skill_label": "Test Case Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46170,7 +46170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11676,
+    "id": 14284,
     "skill_label": "Test Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46180,7 +46180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11677,
+    "id": 14285,
     "skill_label": "Test Driven Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46190,7 +46190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11678,
+    "id": 14286,
     "skill_label": "Test Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46200,7 +46200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11679,
+    "id": 14287,
     "skill_label": "Test Methodology",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46210,7 +46210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11680,
+    "id": 14288,
     "skill_label": "Test Planning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46220,7 +46220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11681,
+    "id": 14289,
     "skill_label": "Test Scenario Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46230,7 +46230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11682,
+    "id": 14290,
     "skill_label": "Test Strategy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46240,7 +46240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11683,
+    "id": 14291,
     "skill_label": "Test Systems Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46250,7 +46250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11684,
+    "id": 14292,
     "skill_label": "Test and Evaluation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46260,7 +46260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11685,
+    "id": 14293,
     "skill_label": "Test-Driven Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46270,7 +46270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11686,
+    "id": 14294,
     "skill_label": "TestNG",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46280,7 +46280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11687,
+    "id": 14295,
     "skill_label": "Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46290,7 +46290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11688,
+    "id": 14296,
     "skill_label": "Testing Frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46300,7 +46300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11689,
+    "id": 14297,
     "skill_label": "Testing Methodologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46310,7 +46310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11690,
+    "id": 14298,
     "skill_label": "Testing Plan Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46320,7 +46320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11691,
+    "id": 14299,
     "skill_label": "Testing Strategy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46330,7 +46330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11692,
+    "id": 14300,
     "skill_label": "Texas Certified Medical Radiological Technologist",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46340,7 +46340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11693,
+    "id": 14301,
     "skill_label": "Text Data Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46350,7 +46350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11694,
+    "id": 14302,
     "skill_label": "Thermal Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46360,7 +46360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11695,
+    "id": 14303,
     "skill_label": "Threat Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46370,7 +46370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11696,
+    "id": 14304,
     "skill_label": "Threat Assessment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46380,7 +46380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11697,
+    "id": 14305,
     "skill_label": "Threat Intelligence",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46390,7 +46390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11698,
+    "id": 14306,
     "skill_label": "Threat Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46400,7 +46400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11699,
+    "id": 14307,
     "skill_label": "Threat Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46410,7 +46410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11700,
+    "id": 14308,
     "skill_label": "Threat Monitoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46420,7 +46420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11701,
+    "id": 14309,
     "skill_label": "Threat Prevention",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46430,7 +46430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11702,
+    "id": 14310,
     "skill_label": "Time Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46440,7 +46440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11703,
+    "id": 14311,
     "skill_label": "Time Series Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46450,7 +46450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11704,
+    "id": 14312,
     "skill_label": "Time Series Forecasting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46460,7 +46460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11705,
+    "id": 14313,
     "skill_label": "Time Studies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46470,7 +46470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11706,
+    "id": 14314,
     "skill_label": "Top Secret Security Clearance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46480,7 +46480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11707,
+    "id": 14315,
     "skill_label": "Torque Tools Usage",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46490,7 +46490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11708,
+    "id": 14316,
     "skill_label": "Total Productive Maintenance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46500,7 +46500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11709,
+    "id": 14317,
     "skill_label": "Trade Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46510,7 +46510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11710,
+    "id": 14318,
     "skill_label": "Trade Studies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46520,7 +46520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11711,
+    "id": 14319,
     "skill_label": "Trainable Classifiers",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46530,7 +46530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11712,
+    "id": 14320,
     "skill_label": "Training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46540,7 +46540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11713,
+    "id": 14321,
     "skill_label": "Training Delivery",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46550,7 +46550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11714,
+    "id": 14322,
     "skill_label": "Training Facilitation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46560,7 +46560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11715,
+    "id": 14323,
     "skill_label": "Training Program Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46570,7 +46570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11716,
+    "id": 14324,
     "skill_label": "Training and Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46580,7 +46580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11717,
+    "id": 14325,
     "skill_label": "Training and Enablement",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46590,7 +46590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11718,
+    "id": 14326,
     "skill_label": "Training and Mentoring",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46600,7 +46600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11719,
+    "id": 14327,
     "skill_label": "Training and Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46610,7 +46610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11720,
+    "id": 14328,
     "skill_label": "Transaction Mechanics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46620,7 +46620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11721,
+    "id": 14329,
     "skill_label": "Transformers",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46630,7 +46630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11722,
+    "id": 14330,
     "skill_label": "Transportation Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46640,7 +46640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11723,
+    "id": 14331,
     "skill_label": "Trauma Registry",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46650,7 +46650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11724,
+    "id": 14332,
     "skill_label": "Trauma-Informed Care Knowledge",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46660,7 +46660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11725,
+    "id": 14333,
     "skill_label": "Travel Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46670,7 +46670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11726,
+    "id": 14334,
     "skill_label": "Trend Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46680,7 +46680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11727,
+    "id": 14335,
     "skill_label": "TriZetto Facets",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46690,7 +46690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11728,
+    "id": 14336,
     "skill_label": "Triggers",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46700,7 +46700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11729,
+    "id": 14337,
     "skill_label": "Troubleshooting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46710,7 +46710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11730,
+    "id": 14338,
     "skill_label": "Trust Frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46720,7 +46720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11731,
+    "id": 14339,
     "skill_label": "Type Confusion Vulnerability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46730,7 +46730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11732,
+    "id": 14340,
     "skill_label": "TypeScript",
     "esco_uri": "http://data.europa.eu/esco/skill/867137fb-ff1b-4ca3-99f3-cb6969aa2c68",
     "week": "2026-04-20",
@@ -46740,7 +46740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11733,
+    "id": 14341,
     "skill_label": "U.S. Army Material Maintenance Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46750,7 +46750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11734,
+    "id": 14342,
     "skill_label": "U.S. Citizenship",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46760,7 +46760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11735,
+    "id": 14343,
     "skill_label": "UART",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46770,7 +46770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11736,
+    "id": 14344,
     "skill_label": "UI Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46780,7 +46780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11737,
+    "id": 14345,
     "skill_label": "UI Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46790,7 +46790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11738,
+    "id": 14346,
     "skill_label": "UI/UX Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46800,7 +46800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11739,
+    "id": 14347,
     "skill_label": "UIKit",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46810,7 +46810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11740,
+    "id": 14348,
     "skill_label": "US Army Air and Missile Defense Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46820,7 +46820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11741,
+    "id": 14349,
     "skill_label": "US Army Supply and Logistics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46830,7 +46830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11742,
+    "id": 14350,
     "skill_label": "US Navy Vessel Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46840,7 +46840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11743,
+    "id": 14351,
     "skill_label": "USB",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46850,7 +46850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11744,
+    "id": 14352,
     "skill_label": "USB Protocol",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46860,7 +46860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11745,
+    "id": 14353,
     "skill_label": "Ubuntu",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46870,7 +46870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11746,
+    "id": 14354,
     "skill_label": "UiPath",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46880,7 +46880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11747,
+    "id": 14355,
     "skill_label": "UiPath Developer Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46890,7 +46890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11748,
+    "id": 14356,
     "skill_label": "UiPath REFramework",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46900,7 +46900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11749,
+    "id": 14357,
     "skill_label": "UiPath RPA Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46910,7 +46910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11750,
+    "id": 14358,
     "skill_label": "UiPath Studio",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46920,7 +46920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11751,
+    "id": 14359,
     "skill_label": "Uninterruptible Power Supply (UPS)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46930,7 +46930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11752,
+    "id": 14360,
     "skill_label": "Unit Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46940,7 +46940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11753,
+    "id": 14361,
     "skill_label": "Universal CFC Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46950,7 +46950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11754,
+    "id": 14362,
     "skill_label": "Universal CFC EPA Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46960,7 +46960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11755,
+    "id": 14363,
     "skill_label": "Unix",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46970,7 +46970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11756,
+    "id": 14364,
     "skill_label": "Unix Shell Scripting",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46980,7 +46980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11757,
+    "id": 14365,
     "skill_label": "Unsupervised Learning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -46990,7 +46990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11758,
+    "id": 14366,
     "skill_label": "Urban and Regional Planning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47000,7 +47000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11759,
+    "id": 14367,
     "skill_label": "Urinalysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47010,7 +47010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11760,
+    "id": 14368,
     "skill_label": "Usability Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47020,7 +47020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11761,
+    "id": 14369,
     "skill_label": "Use Case Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47030,7 +47030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11762,
+    "id": 14370,
     "skill_label": "Use of Force",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47040,7 +47040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11763,
+    "id": 14371,
     "skill_label": "Use of Smartphone Camera",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47050,7 +47050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11764,
+    "id": 14372,
     "skill_label": "Use-After-Free Vulnerability",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47060,7 +47060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11765,
+    "id": 14373,
     "skill_label": "User Acceptance Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47070,7 +47070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11766,
+    "id": 14374,
     "skill_label": "User Authentication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47080,7 +47080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11767,
+    "id": 14375,
     "skill_label": "User Experience",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47090,7 +47090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11768,
+    "id": 14376,
     "skill_label": "User Experience Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47100,7 +47100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11769,
+    "id": 14377,
     "skill_label": "User Flow",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47110,7 +47110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11770,
+    "id": 14378,
     "skill_label": "User Interface Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47120,7 +47120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11771,
+    "id": 14379,
     "skill_label": "User Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47130,7 +47130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11772,
+    "id": 14380,
     "skill_label": "User Research",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47140,7 +47140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11773,
+    "id": 14381,
     "skill_label": "User Roles and Permissions",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47150,7 +47150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11774,
+    "id": 14382,
     "skill_label": "User Segmentation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47160,7 +47160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11775,
+    "id": 14383,
     "skill_label": "User Stories",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47170,7 +47170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11776,
+    "id": 14384,
     "skill_label": "User Story Definition",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47180,7 +47180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11777,
+    "id": 14385,
     "skill_label": "User Story Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47190,7 +47190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11778,
+    "id": 14386,
     "skill_label": "User Story Writing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47200,7 +47200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11779,
+    "id": 14387,
     "skill_label": "User Study Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47210,7 +47210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11780,
+    "id": 14388,
     "skill_label": "User Support",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47220,7 +47220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11781,
+    "id": 14389,
     "skill_label": "User Training",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47230,7 +47230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11782,
+    "id": 14390,
     "skill_label": "User-centric Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47240,7 +47240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11783,
+    "id": 14391,
     "skill_label": "Utility Metering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47250,7 +47250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11784,
+    "id": 14392,
     "skill_label": "VLAN Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47260,7 +47260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11785,
+    "id": 14393,
     "skill_label": "VLANs",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47270,7 +47270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11786,
+    "id": 14394,
     "skill_label": "VMware",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47280,7 +47280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11787,
+    "id": 14395,
     "skill_label": "VMware vSphere",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47290,7 +47290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11788,
+    "id": 14396,
     "skill_label": "VPN",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47300,7 +47300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11789,
+    "id": 14397,
     "skill_label": "VPN Technologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47310,7 +47310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11790,
+    "id": 14398,
     "skill_label": "VSAM",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47320,7 +47320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11791,
+    "id": 14399,
     "skill_label": "Validation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47330,7 +47330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11792,
+    "id": 14400,
     "skill_label": "Validation Protocols",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47340,7 +47340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11793,
+    "id": 14401,
     "skill_label": "Value Selling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47350,7 +47350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11794,
+    "id": 14402,
     "skill_label": "Value Stream Mapping",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47360,7 +47360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11795,
+    "id": 14403,
     "skill_label": "Value-Based Programs",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47370,7 +47370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11796,
+    "id": 14404,
     "skill_label": "Valve Sizing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47380,7 +47380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11797,
+    "id": 14405,
     "skill_label": "Vector Databases",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47390,7 +47390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11798,
+    "id": 14406,
     "skill_label": "Vehicle Functional Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47400,7 +47400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11799,
+    "id": 14407,
     "skill_label": "Vehicle Maintenance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47410,7 +47410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11800,
+    "id": 14408,
     "skill_label": "Vendor Compliance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47420,7 +47420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11801,
+    "id": 14409,
     "skill_label": "Vendor Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47430,7 +47430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11802,
+    "id": 14410,
     "skill_label": "Vendor and Manufacturer Liaison",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47440,7 +47440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11803,
+    "id": 14411,
     "skill_label": "Vendor management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47450,7 +47450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11804,
+    "id": 14412,
     "skill_label": "Verbal Communication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47460,7 +47460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11805,
+    "id": 14413,
     "skill_label": "Verification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47470,7 +47470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11806,
+    "id": 14414,
     "skill_label": "Verification Methods",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47480,7 +47480,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11807,
+    "id": 14415,
     "skill_label": "Verification and Validation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47490,7 +47490,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11808,
+    "id": 14416,
     "skill_label": "Verified Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47500,7 +47500,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11809,
+    "id": 14417,
     "skill_label": "Version Control",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47510,7 +47510,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11810,
+    "id": 14418,
     "skill_label": "Video Management Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47520,7 +47520,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11811,
+    "id": 14419,
     "skill_label": "Video Recording",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47530,7 +47530,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11812,
+    "id": 14420,
     "skill_label": "Video Surveillance",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47540,7 +47540,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11813,
+    "id": 14421,
     "skill_label": "Video Surveillance Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47550,7 +47550,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11814,
+    "id": 14422,
     "skill_label": "Virtual LAN (VLAN)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47560,7 +47560,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11815,
+    "id": 14423,
     "skill_label": "Virtual Machines",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47570,7 +47570,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11816,
+    "id": 14424,
     "skill_label": "Virtual Networks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47580,7 +47580,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11817,
+    "id": 14425,
     "skill_label": "Virtual Private Networks (VPNs)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47590,7 +47590,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11818,
+    "id": 14426,
     "skill_label": "Virtual WAN",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47600,7 +47600,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11819,
+    "id": 14427,
     "skill_label": "Virtualization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47610,7 +47610,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11820,
+    "id": 14428,
     "skill_label": "Vision Transformers",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47620,7 +47620,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11821,
+    "id": 14429,
     "skill_label": "Vision-Language Modeling",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47630,7 +47630,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11822,
+    "id": 14430,
     "skill_label": "Visual Basic",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47640,7 +47640,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11823,
+    "id": 14431,
     "skill_label": "Visual Generation Foundation Models",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47650,7 +47650,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11824,
+    "id": 14432,
     "skill_label": "Visual Hierarchy",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47660,7 +47660,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11825,
+    "id": 14433,
     "skill_label": "Visual Merchandising",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47670,7 +47670,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11826,
+    "id": 14434,
     "skill_label": "Vital Safety Systems",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47680,7 +47680,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11827,
+    "id": 14435,
     "skill_label": "Vulnerability Assessment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47690,7 +47690,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11828,
+    "id": 14436,
     "skill_label": "Vulnerability Discovery",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47700,7 +47700,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11829,
+    "id": 14437,
     "skill_label": "Vulnerability Exploitation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47710,7 +47710,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11830,
+    "id": 14438,
     "skill_label": "Vulnerability Management",
     "esco_uri": "Vulnerability Management",
     "week": "2026-04-20",
@@ -47720,7 +47720,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11831,
+    "id": 14439,
     "skill_label": "Vulnerability Research",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47730,7 +47730,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11832,
+    "id": 14440,
     "skill_label": "Vulnerability Scanning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47740,7 +47740,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11833,
+    "id": 14441,
     "skill_label": "WAN",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47750,7 +47750,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11834,
+    "id": 14442,
     "skill_label": "WAN Technologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47760,7 +47760,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11835,
+    "id": 14443,
     "skill_label": "Warehouse Operations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47770,7 +47770,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11836,
+    "id": 14444,
     "skill_label": "Warehouse Safety",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47780,7 +47780,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11837,
+    "id": 14445,
     "skill_label": "Warehousing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47790,7 +47790,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11838,
+    "id": 14446,
     "skill_label": "Water Resources Engineering",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47800,7 +47800,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11839,
+    "id": 14447,
     "skill_label": "Wealth Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47810,7 +47810,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11840,
+    "id": 14448,
     "skill_label": "Weapons Qualification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47820,7 +47820,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11841,
+    "id": 14449,
     "skill_label": "Web Analytics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47830,7 +47830,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11842,
+    "id": 14450,
     "skill_label": "Web Application Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47840,7 +47840,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11843,
+    "id": 14451,
     "skill_label": "Web Application Security",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47850,7 +47850,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11844,
+    "id": 14452,
     "skill_label": "Web Application Testing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47860,7 +47860,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11845,
+    "id": 14453,
     "skill_label": "Web Content Accessibility Guidelines (WCAG)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47870,7 +47870,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11846,
+    "id": 14454,
     "skill_label": "Web Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47880,7 +47880,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11847,
+    "id": 14455,
     "skill_label": "Web Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47890,7 +47890,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11848,
+    "id": 14456,
     "skill_label": "Web Frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47900,7 +47900,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11849,
+    "id": 14457,
     "skill_label": "Web Server Technologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47910,7 +47910,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11850,
+    "id": 14458,
     "skill_label": "Web Services",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47920,7 +47920,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11851,
+    "id": 14459,
     "skill_label": "Web3",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47930,7 +47930,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11852,
+    "id": 14460,
     "skill_label": "Web3 Integration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47940,7 +47940,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11853,
+    "id": 14461,
     "skill_label": "Web3.js",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47950,7 +47950,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11854,
+    "id": 14462,
     "skill_label": "Webpack",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47960,7 +47960,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11855,
+    "id": 14463,
     "skill_label": "Wide Area Networks (WAN)",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47970,7 +47970,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11856,
+    "id": 14464,
     "skill_label": "Windows Active Directory",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47980,7 +47980,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11857,
+    "id": 14465,
     "skill_label": "Windows Client-Server Environment",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -47990,7 +47990,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11858,
+    "id": 14466,
     "skill_label": "Windows Operating System",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48000,7 +48000,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11859,
+    "id": 14467,
     "skill_label": "Windows Server",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48010,7 +48010,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11860,
+    "id": 14468,
     "skill_label": "Windows Server Administration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48020,7 +48020,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11861,
+    "id": 14469,
     "skill_label": "Windows Server Domain Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48030,7 +48030,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11862,
+    "id": 14470,
     "skill_label": "Wireframing",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48040,7 +48040,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11863,
+    "id": 14471,
     "skill_label": "Wireless Networking",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48050,7 +48050,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11864,
+    "id": 14472,
     "skill_label": "Wireless Technologies",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48060,7 +48060,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11865,
+    "id": 14473,
     "skill_label": "Work Measurement",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48070,7 +48070,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11866,
+    "id": 14474,
     "skill_label": "Work Order Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48080,7 +48080,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11867,
+    "id": 14475,
     "skill_label": "Work Prioritization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48090,7 +48090,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11868,
+    "id": 14476,
     "skill_label": "Workday Certification",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48100,7 +48100,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11869,
+    "id": 14477,
     "skill_label": "Workday Core Connectors",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48110,7 +48110,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11870,
+    "id": 14478,
     "skill_label": "Workday EIB",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48120,7 +48120,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11871,
+    "id": 14479,
     "skill_label": "Workday Integrations",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48130,7 +48130,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11872,
+    "id": 14480,
     "skill_label": "Workday Studio",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48140,7 +48140,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11873,
+    "id": 14481,
     "skill_label": "Workflow Analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48150,7 +48150,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11874,
+    "id": 14482,
     "skill_label": "Workflow Automation",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48160,7 +48160,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11875,
+    "id": 14483,
     "skill_label": "Workflow Design",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48170,7 +48170,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11876,
+    "id": 14484,
     "skill_label": "Workflow Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48180,7 +48180,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11877,
+    "id": 14485,
     "skill_label": "Workflow Optimization",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48190,7 +48190,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11878,
+    "id": 14486,
     "skill_label": "Workflow Orchestration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48200,7 +48200,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11879,
+    "id": 14487,
     "skill_label": "Workforce Analytics",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48210,7 +48210,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11880,
+    "id": 14488,
     "skill_label": "Workforce Management",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48220,7 +48220,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11881,
+    "id": 14489,
     "skill_label": "Workforce Planning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48230,7 +48230,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11882,
+    "id": 14490,
     "skill_label": "Writing User Stories",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48240,7 +48240,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11883,
+    "id": 14491,
     "skill_label": "Written Communication",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48250,7 +48250,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11884,
+    "id": 14492,
     "skill_label": "XCTest",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48260,7 +48260,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11885,
+    "id": 14493,
     "skill_label": "XML",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48270,7 +48270,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11886,
+    "id": 14494,
     "skill_label": "Xcode",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48280,7 +48280,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11887,
+    "id": 14495,
     "skill_label": "Zero Trust Architecture",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48290,7 +48290,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11888,
+    "id": 14496,
     "skill_label": "cross-functional collaboration",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48300,7 +48300,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11889,
+    "id": 14497,
     "skill_label": "data analysis",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48310,7 +48310,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11890,
+    "id": 14498,
     "skill_label": "ethers.js",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48320,7 +48320,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11891,
+    "id": 14499,
     "skill_label": "fine-tuning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48330,7 +48330,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11892,
+    "id": 14500,
     "skill_label": "gRPC",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48340,7 +48340,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11893,
+    "id": 14501,
     "skill_label": "iOS",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48350,7 +48350,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11894,
+    "id": 14502,
     "skill_label": "iOS Design Patterns",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48360,7 +48360,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11895,
+    "id": 14503,
     "skill_label": "iOS Development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48370,7 +48370,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11896,
+    "id": 14504,
     "skill_label": "iOS Frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48380,7 +48380,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11897,
+    "id": 14505,
     "skill_label": "iOS SDK",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48390,7 +48390,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11898,
+    "id": 14506,
     "skill_label": "instruction tuning",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48400,7 +48400,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11899,
+    "id": 14507,
     "skill_label": "large language models",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48410,7 +48410,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11900,
+    "id": 14508,
     "skill_label": "macOS frameworks",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48420,7 +48420,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11901,
+    "id": 14509,
     "skill_label": "model development",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48430,7 +48430,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11902,
+    "id": 14510,
     "skill_label": "natural language processing",
     "esco_uri": "http://data.europa.eu/esco/skill/fff0e2cd-d0bd-4b02-9daf-158b79d9688a",
     "week": "2026-04-20",
@@ -48440,7 +48440,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11903,
+    "id": 14511,
     "skill_label": "prompt engineering",
     "esco_uri": "http://data.europa.eu/esco/skill/f5369f2f-e52b-43d8-8d31-79a6c11188d8",
     "week": "2026-04-20",
@@ -48450,7 +48450,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11904,
+    "id": 14512,
     "skill_label": "statistical techniques",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48460,7 +48460,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11905,
+    "id": 14513,
     "skill_label": "viem",
     "esco_uri": null,
     "week": "2026-04-20",
@@ -48470,7 +48470,7 @@
     "trend_confidence": 0.8
   },
   {
-    "id": 11906,
+    "id": 14514,
     "skill_label": "x86 Architecture",
     "esco_uri": null,
     "week": "2026-04-20",

--- a/scripts/pg-seed-data/fixtures/tool_demand_weekly.json
+++ b/scripts/pg-seed-data/fixtures/tool_demand_weekly.json
@@ -532,290 +532,290 @@
     "computed_at": "2026-04-17T03:27:57.500185+00:00"
   },
   {
-    "id": 268,
+    "id": 309,
     "tool_label": "Ansible",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 269,
+    "id": 310,
     "tool_label": "AWS",
     "week_start": "2026-04-20",
     "posting_count": 3,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 270,
+    "id": 311,
     "tool_label": "Azure",
     "week_start": "2026-04-20",
     "posting_count": 7,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 271,
+    "id": 312,
     "tool_label": "Bash",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 272,
+    "id": 313,
     "tool_label": "C#",
     "week_start": "2026-04-20",
     "posting_count": 2,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 273,
+    "id": 314,
     "tool_label": "C++",
     "week_start": "2026-04-20",
     "posting_count": 8,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 274,
+    "id": 315,
     "tool_label": "Cisco",
     "week_start": "2026-04-20",
     "posting_count": 2,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 275,
+    "id": 316,
     "tool_label": "Databricks",
     "week_start": "2026-04-20",
     "posting_count": 2,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 276,
+    "id": 317,
     "tool_label": "Django",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 277,
+    "id": 318,
     "tool_label": "Docker",
     "week_start": "2026-04-20",
     "posting_count": 2,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 278,
+    "id": 319,
     "tool_label": "GCP",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 279,
+    "id": 320,
     "tool_label": "Git",
     "week_start": "2026-04-20",
     "posting_count": 7,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 280,
+    "id": 321,
     "tool_label": "GitHub Actions",
     "week_start": "2026-04-20",
     "posting_count": 3,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 281,
+    "id": 322,
     "tool_label": "Go",
     "week_start": "2026-04-20",
     "posting_count": 3,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 282,
+    "id": 323,
     "tool_label": "Java",
     "week_start": "2026-04-20",
     "posting_count": 6,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 283,
+    "id": 324,
     "tool_label": "JavaScript",
     "week_start": "2026-04-20",
     "posting_count": 7,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 284,
+    "id": 325,
     "tool_label": "Jenkins",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 285,
+    "id": 326,
     "tool_label": "Jira",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 286,
+    "id": 327,
     "tool_label": "Keras",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 287,
+    "id": 328,
     "tool_label": "Linux",
     "week_start": "2026-04-20",
     "posting_count": 5,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 288,
+    "id": 329,
     "tool_label": "Microsoft Excel",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 289,
+    "id": 330,
     "tool_label": "MySQL",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 290,
+    "id": 331,
     "tool_label": "Next.js",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 291,
+    "id": 332,
     "tool_label": "Node.js",
     "week_start": "2026-04-20",
     "posting_count": 2,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 292,
+    "id": 333,
     "tool_label": "NumPy",
     "week_start": "2026-04-20",
     "posting_count": 3,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 293,
+    "id": 334,
     "tool_label": "Pandas",
     "week_start": "2026-04-20",
     "posting_count": 2,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 294,
+    "id": 335,
     "tool_label": "Power BI",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 295,
+    "id": 336,
     "tool_label": "PowerPoint",
     "week_start": "2026-04-20",
     "posting_count": 3,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 296,
+    "id": 337,
     "tool_label": "Prisma",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 297,
+    "id": 338,
     "tool_label": "Python",
     "week_start": "2026-04-20",
     "posting_count": 19,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 298,
+    "id": 339,
     "tool_label": "PyTorch",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 299,
+    "id": 340,
     "tool_label": "R",
     "week_start": "2026-04-20",
     "posting_count": 3,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 300,
+    "id": 341,
     "tool_label": "React",
     "week_start": "2026-04-20",
     "posting_count": 4,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 301,
+    "id": 342,
     "tool_label": "Rust",
     "week_start": "2026-04-20",
     "posting_count": 3,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 302,
+    "id": 343,
     "tool_label": "Scala",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 303,
+    "id": 344,
     "tool_label": "Spring Boot",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 304,
+    "id": 345,
     "tool_label": "SQL",
     "week_start": "2026-04-20",
     "posting_count": 8,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 305,
+    "id": 346,
     "tool_label": "Tableau",
     "week_start": "2026-04-20",
     "posting_count": 2,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 306,
+    "id": 347,
     "tool_label": "TensorFlow",
     "week_start": "2026-04-20",
     "posting_count": 3,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 307,
+    "id": 348,
     "tool_label": "Terraform",
     "week_start": "2026-04-20",
     "posting_count": 1,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   },
   {
-    "id": 308,
+    "id": 349,
     "tool_label": "TypeScript",
     "week_start": "2026-04-20",
     "posting_count": 3,
-    "computed_at": "2026-04-28T23:43:21.268394+00:00"
+    "computed_at": "2026-04-29T05:53:53.482524+00:00"
   }
 ]

--- a/scripts/sweep_unclassified_spam.py
+++ b/scripts/sweep_unclassified_spam.py
@@ -1,0 +1,285 @@
+# ruff: noqa: T201
+"""Periodic sweeper: classify ``dbo.job_postings`` rows missing a spam tier — JIE #308 Fix C.
+
+Background
+----------
+Pre-JIE #308, `enrichment/job_postings_promotion.py` had three structural
+defects on the spam classification pipeline:
+
+1. None of `_UPDATE_CLEAN_SQL` / `_UPDATE_FLAGGED_SQL` / `_UPDATE_UNCERTAIN_SQL`
+   wrote `spam_tier`, so the column stayed NULL on every promoted row.
+2. `_UPDATE_UNCERTAIN_SQL` wrote neither `is_spam` nor `spam_score`, so
+   uncertain rows were indistinguishable from "never classified."
+3. PR #303's orphan-promotion path (`_insert_job_posting_from_normalized`)
+   bypasses `apply_enrichment_to_job_postings` entirely, so orphans land in
+   `job_postings` with all spam columns NULL.
+
+The Fix B-1 SQL changes close defects #1 and #2 going forward. This sweeper
+closes defect #3 and provides eventual consistency for any historical or
+future row whose spam classification doesn't reach the live promotion path:
+it finds rows where ``spam_tier IS NULL`` and runs the classifier on them.
+
+Mirrors the pattern of ``scripts/sweep_unpromoted_normalized_jobs.py`` (PR
+#301): default dry-run, a 1-hour grace window to avoid racing live promotion,
+``--limit`` for staged runs, idempotent under re-runs.
+
+Usage
+-----
+.. code-block:: bash
+
+    # Dry run (default — counts candidates, makes no writes, no LLM calls)
+    python scripts/sweep_unclassified_spam.py
+
+    # Apply: classify and update up to 200 rows older than 1 hour
+    python scripts/sweep_unclassified_spam.py --apply
+
+    # Larger run with custom grace window
+    python scripts/sweep_unclassified_spam.py --apply --limit 500 --grace-minutes 30
+
+Idempotent — only touches rows where ``spam_tier IS NULL``. Reads
+``PYTHON_DATABASE_URL`` from ``.env``.
+
+**Important:** export fixtures before running with ``--apply``. Per the
+JIE database protection rules (``~/.claude/CLAUDE.md``), ``job_postings``
+mutations require a fixture snapshot first.
+
+.. code-block:: bash
+
+    python scripts/pg-seed-data/export_fixtures.py --scope all
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import text  # noqa: E402
+
+from common.data_store.database import get_engine, session_scope  # noqa: E402
+from common.env import load_repo_root_dotenv  # noqa: E402
+from enrichment.classifiers.spam_preview import (  # noqa: E402
+    apply_spam_tiers,
+    score_spam_preview,
+)
+from enrichment.job_postings_promotion import _UPDATE_SPAM_ONLY_SQL  # noqa: E402
+
+log = structlog.get_logger()
+
+
+# Find rows that need classification: spam_tier NULL (the ground truth flag
+# for "we never classified this"). Join out to extracted_intelligence so the
+# classifier can read skills / tasks / responsibilities for context — many
+# rows have NULL extraction, in which case the classifier degrades to
+# "uncertain" gracefully.
+_FETCH_CANDIDATES_SQL = text(
+    """
+    WITH unprocessed AS (
+        SELECT DISTINCT ON (jp.job_posting_id)
+               jp.job_posting_id,
+               jp.job_title,
+               jp.job_description,
+               jp.createdat,
+               ei.skills,
+               ei.tools,
+               ei.tasks,
+               ei.responsibilities,
+               ei.context,
+               COALESCE(ei.extraction_failed, FALSE) AS extraction_failed
+        FROM dbo.job_postings AS jp
+        LEFT JOIN dbo.normalized_jobs AS nj
+            ON nj.source = jp.source AND nj.external_id = jp.external_id
+        LEFT JOIN dbo.extracted_intelligence AS ei
+            ON ei.normalized_job_id = nj.id
+        WHERE jp.spam_tier IS NULL
+          AND jp.createdat < NOW() - make_interval(mins => :grace_minutes)
+        ORDER BY jp.job_posting_id, ei.extracted_at DESC NULLS LAST
+    )
+    SELECT job_posting_id::text AS job_posting_id,
+           job_title,
+           job_description,
+           skills,
+           tools,
+           tasks,
+           responsibilities,
+           context,
+           extraction_failed
+    FROM unprocessed
+    ORDER BY createdat ASC
+    LIMIT :lim
+    """
+)
+
+
+def _extraction_dict(row: Any) -> tuple[dict[str, Any], bool, bool]:
+    """Build the ``extraction`` dict the classifier expects + the failure flags."""
+    extraction_failed = bool(row.get("extraction_failed"))
+    extraction: dict[str, Any] = {}
+    for key in ("skills", "tools", "tasks", "responsibilities", "context"):
+        val = row.get(key)
+        if val is not None:
+            extraction[key] = val
+    extraction_empty = not extraction and not extraction_failed
+    return extraction, extraction_failed, extraction_empty
+
+
+def sweep(*, limit: int = 200, grace_minutes: int = 60, apply: bool = False) -> dict[str, int]:
+    """Classify up to ``limit`` rows where ``spam_tier IS NULL``.
+
+    Returns counts: ``{"candidates": N, "classified_clean": N,
+    "classified_flagged": N, "classified_uncertain": N, "failed": N}``.
+
+    When ``apply=False`` (default), counts only — no LLM calls, no writes.
+    """
+    engine = get_engine()
+    counts = {
+        "candidates": 0,
+        "classified_clean": 0,
+        "classified_flagged": 0,
+        "classified_uncertain": 0,
+        "failed": 0,
+    }
+
+    with engine.connect() as conn:
+        rows = (
+            conn.execute(
+                _FETCH_CANDIDATES_SQL,
+                {"lim": limit, "grace_minutes": grace_minutes},
+            )
+            .mappings()
+            .all()
+        )
+
+    counts["candidates"] = len(rows)
+    if not rows:
+        log.info("spam_sweep_no_candidates", limit=limit, grace_minutes=grace_minutes)
+        return counts
+
+    log.info(
+        "spam_sweep_candidates_found",
+        n=len(rows),
+        apply=apply,
+        grace_minutes=grace_minutes,
+    )
+
+    if not apply:
+        for row in rows[:10]:
+            print(f"  [dry-run] job_posting_id={row['job_posting_id']} title={(row.get('job_title') or '')[:60]!r}")
+        if len(rows) > 10:
+            print(f"  [dry-run] ... and {len(rows) - 10} more")
+        return counts
+
+    for row in rows:
+        jp_id = row["job_posting_id"]
+        try:
+            extraction, extraction_failed, extraction_empty = _extraction_dict(dict(row))
+            result = score_spam_preview(
+                job_title=row.get("job_title") or "",
+                job_description=row.get("job_description") or "",
+                extraction=extraction,
+                extraction_failed=extraction_failed,
+                extraction_empty=extraction_empty,
+            )
+
+            # Map the classifier output to the strict 4-state model documented
+            # in the JIE #308 plan: clean / flagged / uncertain / rejected.
+            # Rejected rows are deliberately surfaced (is_spam=TRUE) here,
+            # unlike the live promotion path that skips the UPDATE entirely —
+            # the sweeper's role is to record what the classifier saw, even
+            # for confirmed spam, so the column reflects ground truth.
+            if result.spam_score is None:
+                tier = "uncertain"
+                is_spam: bool | None = None
+                spam_score: float | None = None
+            else:
+                is_spam, tier = apply_spam_tiers(float(result.spam_score))
+                spam_score = float(result.spam_score)
+
+            with session_scope() as session:
+                session.execute(
+                    _UPDATE_SPAM_ONLY_SQL,
+                    {
+                        "job_posting_id": jp_id,
+                        "is_spam": is_spam,
+                        "spam_score": spam_score,
+                        "spam_tier": tier,
+                    },
+                )
+
+            if tier == "clean":
+                counts["classified_clean"] += 1
+            elif tier == "flagged":
+                counts["classified_flagged"] += 1
+            else:
+                counts["classified_uncertain"] += 1
+            log.info(
+                "spam_sweep_classified",
+                job_posting_id=jp_id,
+                tier=tier,
+                spam_score=spam_score,
+            )
+        except Exception as exc:
+            counts["failed"] += 1
+            log.warning(
+                "spam_sweep_failed",
+                job_posting_id=jp_id,
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+
+    log.info("spam_sweep_complete", **counts)
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Periodic sweeper: classify job_postings rows missing spam_tier (JIE #308). "
+            "Default is dry-run; pass --apply to run the classifier and write. "
+            "Export fixtures BEFORE --apply per JIE database protection rules."
+        )
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually run the classifier and write results (without this flag, runs in dry-run mode).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=200,
+        help="Maximum rows to classify per run. Default 200 — safe for hourly cron.",
+    )
+    parser.add_argument(
+        "--grace-minutes",
+        type=int,
+        default=60,
+        help="Skip rows newer than this many minutes — avoids racing live promotion.",
+    )
+    args = parser.parse_args()
+
+    load_repo_root_dotenv()
+    counts = sweep(limit=args.limit, grace_minutes=args.grace_minutes, apply=args.apply)
+
+    print()
+    print("=" * 60)
+    print(f"Spam sweep summary ({'APPLY' if args.apply else 'DRY-RUN'}):")
+    print(f"  candidates found       : {counts['candidates']}")
+    if args.apply:
+        print(f"  classified clean       : {counts['classified_clean']}")
+        print(f"  classified flagged     : {counts['classified_flagged']}")
+        print(f"  classified uncertain   : {counts['classified_uncertain']}")
+        print(f"  failed                 : {counts['failed']}")
+    print("=" * 60)
+    if args.apply and counts["failed"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_backfill_spam_classification.py
+++ b/tests/test_backfill_spam_classification.py
@@ -1,0 +1,170 @@
+"""Tests for scripts/backfill_spam_classification.py — JIE #308 PR-2."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import scripts.backfill_spam_classification as backfill_module  # noqa: E402
+
+
+def test_module_importable() -> None:
+    """Smoke: the script imports + exposes the public surface."""
+    assert callable(backfill_module.backfill)
+    assert callable(backfill_module.main)
+
+
+def _engine_returning_rows(rows: list[dict]) -> MagicMock:
+    """Mock engine whose .connect() returns rows for the candidate query."""
+    mappings = MagicMock()
+    mappings.all.return_value = rows
+    cursor = MagicMock()
+    cursor.mappings.return_value = mappings
+    conn = MagicMock()
+    conn.execute.return_value = cursor
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    engine = MagicMock()
+    engine.connect.return_value = conn
+    return engine
+
+
+def _candidate_row(**overrides) -> dict:
+    base = {
+        "job_posting_id": "00000000-0000-0000-0000-000000000001",
+        "job_title": "Software Engineer",
+        "job_description": "Build things.",
+        "skills": [{"skill_label": "Python"}],
+        "tools": None,
+        "tasks": None,
+        "responsibilities": None,
+        "context": None,
+        "extraction_failed": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _spam_result(*, score: float | None) -> MagicMock:
+    r = MagicMock()
+    r.spam_score = score
+    r.llm_cost_usd = 0.002
+    r.cost_usd = 0.002
+    return r
+
+
+def test_dry_run_makes_no_classifier_or_writes() -> None:
+    fake_engine = _engine_returning_rows([_candidate_row()])
+    with (
+        patch.object(backfill_module, "get_engine", return_value=fake_engine),
+        patch.object(backfill_module, "score_spam_preview") as mock_clf,
+        patch.object(backfill_module, "session_scope") as mock_scope,
+    ):
+        counts = backfill_module.backfill(limit=5000, grace_minutes=0, apply=False)
+    assert counts["candidates"] == 1
+    mock_clf.assert_not_called()
+    mock_scope.assert_not_called()
+
+
+def test_apply_classifies_and_writes_via_spam_only_sql() -> None:
+    fake_engine = _engine_returning_rows([_candidate_row()])
+    session = MagicMock()
+    scope_cm = MagicMock()
+    scope_cm.__enter__.return_value = session
+    scope_cm.__exit__.return_value = False
+
+    with (
+        patch.object(backfill_module, "get_engine", return_value=fake_engine),
+        patch.object(backfill_module, "score_spam_preview", return_value=_spam_result(score=0.2)),
+        patch.object(backfill_module, "session_scope", return_value=scope_cm),
+    ):
+        counts = backfill_module.backfill(limit=5000, grace_minutes=0, apply=True, max_cost_usd=10)
+
+    assert counts["classified_clean"] == 1
+    assert counts["cost_usd"] > 0
+    params = session.execute.call_args.args[1]
+    assert params["spam_tier"] == "clean"
+    assert params["is_spam"] is False
+
+
+def test_max_cost_cap_stops_processing_partway() -> None:
+    """When accumulated cost exceeds --max-cost-usd, the loop stops gracefully."""
+    rows = [_candidate_row(job_posting_id=f"00000000-0000-0000-0000-{i:012d}") for i in range(10)]
+    fake_engine = _engine_returning_rows(rows)
+    session = MagicMock()
+    scope_cm = MagicMock()
+    scope_cm.__enter__.return_value = session
+    scope_cm.__exit__.return_value = False
+
+    # Each row "costs" $0.50 — cap of $1.00 should stop after 2 rows
+    expensive = MagicMock()
+    expensive.spam_score = 0.2
+    expensive.llm_cost_usd = 0.5
+    expensive.cost_usd = 0.5
+
+    with (
+        patch.object(backfill_module, "get_engine", return_value=fake_engine),
+        patch.object(backfill_module, "score_spam_preview", return_value=expensive),
+        patch.object(backfill_module, "session_scope", return_value=scope_cm),
+    ):
+        counts = backfill_module.backfill(limit=5000, grace_minutes=0, apply=True, max_cost_usd=1.0)
+
+    assert counts["candidates"] == 10
+    # 2 classified before the cap kicks in (cost goes 0.5 → 1.0; on the 3rd
+    # iteration accumulated_cost >= max_cost_usd so the loop breaks).
+    assert counts["classified_clean"] == 2
+    assert counts["stopped_on_cost_cap"] is True
+
+
+def test_no_candidates_returns_zero_counts() -> None:
+    fake_engine = _engine_returning_rows([])
+    with patch.object(backfill_module, "get_engine", return_value=fake_engine):
+        counts = backfill_module.backfill(limit=5000, grace_minutes=0, apply=False)
+    assert counts["candidates"] == 0
+
+
+def test_uncertain_path_when_classifier_returns_no_score() -> None:
+    fake_engine = _engine_returning_rows([_candidate_row(extraction_failed=True)])
+    session = MagicMock()
+    scope_cm = MagicMock()
+    scope_cm.__enter__.return_value = session
+    scope_cm.__exit__.return_value = False
+
+    with (
+        patch.object(backfill_module, "get_engine", return_value=fake_engine),
+        patch.object(backfill_module, "score_spam_preview", return_value=_spam_result(score=None)),
+        patch.object(backfill_module, "session_scope", return_value=scope_cm),
+    ):
+        counts = backfill_module.backfill(limit=5000, grace_minutes=0, apply=True)
+
+    assert counts["classified_uncertain"] == 1
+    params = session.execute.call_args.args[1]
+    assert params["is_spam"] is None
+    assert params["spam_score"] is None
+    assert params["spam_tier"] == "uncertain"
+
+
+def test_failure_increments_failed_counter() -> None:
+    fake_engine = _engine_returning_rows([_candidate_row()])
+    with (
+        patch.object(backfill_module, "get_engine", return_value=fake_engine),
+        patch.object(backfill_module, "score_spam_preview", side_effect=RuntimeError("LLM down")),
+        patch.object(backfill_module, "session_scope") as mock_scope,
+    ):
+        counts = backfill_module.backfill(limit=5000, grace_minutes=0, apply=True)
+    assert counts["failed"] == 1
+    assert counts["classified_clean"] == 0
+    mock_scope.assert_not_called()
+
+
+def test_row_cost_falls_back_when_attrs_missing() -> None:
+    """When a SpamPreviewResult lacks llm_cost_usd / cost_usd, use the fallback estimate."""
+
+    class BareResult:
+        spam_score = 0.2
+
+    cost = backfill_module._row_cost(BareResult())
+    assert cost == backfill_module._FALLBACK_ROW_COST_USD

--- a/tests/test_sweep_unclassified_spam.py
+++ b/tests/test_sweep_unclassified_spam.py
@@ -1,0 +1,187 @@
+"""Tests for scripts/sweep_unclassified_spam.py — JIE #308 Fix C."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import scripts.sweep_unclassified_spam as sweep_module  # noqa: E402
+
+
+def test_module_importable() -> None:
+    """Smoke: the script imports + exposes the public surface."""
+    assert callable(sweep_module.sweep)
+    assert callable(sweep_module.main)
+
+
+def _engine_returning_rows(rows: list[dict]) -> MagicMock:
+    """Mock engine whose .connect() returns rows for the candidate query."""
+    mappings = MagicMock()
+    mappings.all.return_value = rows
+    cursor = MagicMock()
+    cursor.mappings.return_value = mappings
+    conn = MagicMock()
+    conn.execute.return_value = cursor
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = False
+    engine = MagicMock()
+    engine.connect.return_value = conn
+    return engine
+
+
+def _candidate_row(**overrides) -> dict:
+    base = {
+        "job_posting_id": "00000000-0000-0000-0000-000000000001",
+        "job_title": "Software Engineer",
+        "job_description": "Build things.",
+        "skills": [{"skill_label": "Python"}],
+        "tools": None,
+        "tasks": None,
+        "responsibilities": None,
+        "context": None,
+        "extraction_failed": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _spam_result(*, score: float | None, tier: str = "clean") -> MagicMock:
+    r = MagicMock()
+    r.spam_score = score
+    r.tier = tier
+    r.is_spam = False if tier == "clean" else None if tier == "flagged" else True if tier == "rejected" else None
+    r.degraded = score is None
+    return r
+
+
+def test_dry_run_counts_candidates_without_writes_or_llm() -> None:
+    """Dry-run mode counts candidates only — no session_scope, no classifier call."""
+    fake_engine = _engine_returning_rows(
+        [_candidate_row(), _candidate_row(job_posting_id="00000000-0000-0000-0000-000000000002")]
+    )
+
+    with (
+        patch.object(sweep_module, "get_engine", return_value=fake_engine),
+        patch.object(sweep_module, "score_spam_preview") as mock_classifier,
+        patch.object(sweep_module, "session_scope") as mock_scope,
+    ):
+        counts = sweep_module.sweep(limit=200, grace_minutes=60, apply=False)
+
+    assert counts["candidates"] == 2
+    assert counts["classified_clean"] == 0
+    mock_classifier.assert_not_called()
+    mock_scope.assert_not_called()
+
+
+def test_no_candidates_returns_zero_counts() -> None:
+    """When the candidate query returns zero rows, all counts stay at 0."""
+    fake_engine = _engine_returning_rows([])
+
+    with patch.object(sweep_module, "get_engine", return_value=fake_engine):
+        counts = sweep_module.sweep(limit=200, grace_minutes=60, apply=False)
+
+    assert counts["candidates"] == 0
+
+
+def test_apply_classifies_clean_writes_via_spam_only_sql() -> None:
+    """Apply: classifier returns score=0.2 → tier=clean → UPDATE writes is_spam=False."""
+    fake_engine = _engine_returning_rows([_candidate_row()])
+
+    session = MagicMock()
+    scope_cm = MagicMock()
+    scope_cm.__enter__.return_value = session
+    scope_cm.__exit__.return_value = False
+
+    with (
+        patch.object(sweep_module, "get_engine", return_value=fake_engine),
+        patch.object(
+            sweep_module,
+            "score_spam_preview",
+            return_value=_spam_result(score=0.2, tier="clean"),
+        ),
+        patch.object(sweep_module, "session_scope", return_value=scope_cm),
+    ):
+        counts = sweep_module.sweep(limit=200, grace_minutes=60, apply=True)
+
+    assert counts["candidates"] == 1
+    assert counts["classified_clean"] == 1
+    # The UPDATE bind params include is_spam=False, spam_tier='clean'.
+    update_call = session.execute.call_args
+    params = update_call.args[1]
+    assert params["is_spam"] is False
+    assert params["spam_tier"] == "clean"
+    assert params["spam_score"] == 0.2
+
+
+def test_apply_classifies_flagged() -> None:
+    """Apply: score=0.8 → tier=flagged → is_spam=None."""
+    fake_engine = _engine_returning_rows([_candidate_row()])
+    session = MagicMock()
+    scope_cm = MagicMock()
+    scope_cm.__enter__.return_value = session
+    scope_cm.__exit__.return_value = False
+
+    with (
+        patch.object(sweep_module, "get_engine", return_value=fake_engine),
+        patch.object(sweep_module, "score_spam_preview", return_value=_spam_result(score=0.8, tier="flagged")),
+        patch.object(sweep_module, "session_scope", return_value=scope_cm),
+    ):
+        counts = sweep_module.sweep(limit=200, grace_minutes=60, apply=True)
+
+    assert counts["classified_flagged"] == 1
+    params = session.execute.call_args.args[1]
+    assert params["is_spam"] is None
+    assert params["spam_tier"] == "flagged"
+
+
+def test_apply_uncertain_when_classifier_returns_no_score() -> None:
+    """Apply: score=None (degraded) → tier=uncertain → is_spam=NULL, spam_score=NULL."""
+    fake_engine = _engine_returning_rows([_candidate_row(extraction_failed=True)])
+    session = MagicMock()
+    scope_cm = MagicMock()
+    scope_cm.__enter__.return_value = session
+    scope_cm.__exit__.return_value = False
+
+    with (
+        patch.object(sweep_module, "get_engine", return_value=fake_engine),
+        patch.object(sweep_module, "score_spam_preview", return_value=_spam_result(score=None)),
+        patch.object(sweep_module, "session_scope", return_value=scope_cm),
+    ):
+        counts = sweep_module.sweep(limit=200, grace_minutes=60, apply=True)
+
+    assert counts["classified_uncertain"] == 1
+    params = session.execute.call_args.args[1]
+    assert params["is_spam"] is None
+    assert params["spam_score"] is None
+    assert params["spam_tier"] == "uncertain"
+
+
+def test_apply_failure_increments_failed_counter() -> None:
+    """An exception during a row's classification is caught and tallied as failure."""
+    fake_engine = _engine_returning_rows([_candidate_row()])
+
+    with (
+        patch.object(sweep_module, "get_engine", return_value=fake_engine),
+        patch.object(sweep_module, "score_spam_preview", side_effect=RuntimeError("LLM exploded")),
+        patch.object(sweep_module, "session_scope") as mock_scope,
+    ):
+        counts = sweep_module.sweep(limit=200, grace_minutes=60, apply=True)
+
+    assert counts["failed"] == 1
+    assert counts["classified_clean"] == 0
+    mock_scope.assert_not_called()
+
+
+def test_grace_window_bind_param() -> None:
+    """The candidate query receives the provided grace_minutes."""
+    fake_engine = _engine_returning_rows([])
+
+    with patch.object(sweep_module, "get_engine", return_value=fake_engine):
+        sweep_module.sweep(limit=200, grace_minutes=42, apply=False)
+
+    conn = fake_engine.connect.return_value
+    _stmt, params = conn.execute.call_args.args
+    assert params == {"lim": 200, "grace_minutes": 42}


### PR DESCRIPTION
## Summary
PR-2 of 2 for closing JIE #308. **Stacked on PR-1 (#311)** — base remains \`development\` so when PR-1 merges first the diff here will collapse to just this PR's changes.

PR-1 fixes the structural workflow (\`spam_tier\` now persisted on every promotion path; sweeper for unclassified rows; loud guard on unhandled tier).

This PR adds:
1. The **one-shot backfill** to classify the existing ~4,683 historical rows.
2. Two **smoke invariants** that gate the post-backfill DB shape.

> **Note:** \`eval/runs/findingsv2.3.md\` + fresh fixtures will be added to this PR after Phase 6.2 backfill execution (gated on Gary's explicit go-ahead per JIE database protection rules). Until then, this PR carries the script + tests + smoke; the data-half lands when we run the backfill.

## What lands

\`scripts/backfill_spam_classification.py\`:
- Wraps the same internals as \`scripts/sweep_unclassified_spam.py\` (imports \`_FETCH_CANDIDATES_SQL\` + \`_extraction_dict\` from PR-1) but with backfill defaults: \`--grace-minutes 0\`, \`--limit 5000\`.
- \`--max-cost-usd $30\` default cap (at ~$0.001-0.005/row × 4,683 rows = $5-25 expected). Stops gracefully and prints a partial-completion summary if exceeded; can resume by re-running.
- Idempotent (only touches \`spam_tier IS NULL\` rows).

\`tests/test_backfill_spam_classification.py\`:
- 8 tests: importable, dry-run no-write, apply happy-path, cost-cap interrupt, no-candidates, uncertain path, failure tally, fallback cost extraction.

\`eval/tests/test_smoke_borderplex_data_gap.py\`:
- \`test_spam_tier_populated_above_floor\` — ≥80% of \`job_postings\` rows have non-NULL \`spam_tier\`.
- \`test_clean_row_count_above_minimum\` — ≥1,000 rows have \`spam_tier = 'clean'\` (was 0 pre-#308).
- These will FAIL locally pre-backfill (expected — they're the post-Phase-6.2 gate). CI skips when no DB is reachable, same as the existing 4 invariants.

## Phase 6.2 execution sequence (post-PR-1 merge, gated)
\`\`\`bash
# 0. backup
python scripts/pg-seed-data/export_fixtures.py --scope all
# 1. dry-run to confirm candidate count
python scripts/backfill_spam_classification.py
# expect: candidates ≈ 4,683-4,710
# 2. apply
python scripts/backfill_spam_classification.py --apply
# expect: classified_clean ~ majority, flagged tail, uncertain on rows w/o EI, failed near 0
# 3. verify sweeper now finds 0 candidates
python scripts/sweep_unclassified_spam.py
# 4. refresh aggregates
python scripts/refresh_aggregates.py
# 5. re-export fresh fixtures
python scripts/pg-seed-data/export_fixtures.py --scope all
# 6. re-run smoke (now expect all 6 invariants pass)
pytest eval/tests/test_smoke_borderplex_data_gap.py -v
# 7. live probes against gq-041..050 (scratch sim, not committed)
\`\`\`

## Regression invariants — preserved
Same as PR-1: PR #301 \`promoted_at\`, PR #303 orphan path, PR #304 \`zip_code\`, PR #307 smoke (4 existing invariants stay green; 2 added), PR #310 \`is_spam = FALSE\` filter (same column semantics — flagged stays NULL post-backfill).

## Test plan
- [x] \`pytest tests/test_backfill_spam_classification.py\` — 8 pass
- [x] \`ruff check + ruff format\` clean
- [x] Live sweeper / backfill SQL verified against Gary's DB (PR-1 work — same SELECT query)
- [ ] CI green (will appear after PR-1 merges and this PR's diff settles)
- [ ] Phase 6.2 backfill run (gated)
- [ ] After backfill: append findings v2.3 + fresh fixtures + Bryan re-probe before final merge
- [ ] Bryan Smoke 5 sign-off in \`#eval-harness\`

Closes #308.