### PR TITLE
fix(#322): replace LFS with GitHub Release bundle for heavy fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,4 @@
-scripts/pg-seed-data/fixtures/extracted_intelligence.json filter=lfs diff=lfs merge=lfs -text
-scripts/pg-seed-data/fixtures/raw_ingested_jobs.json filter=lfs diff=lfs merge=lfs -text
-scripts/pg-seed-data/fixtures/job_postings.json filter=lfs diff=lfs merge=lfs -text
-scripts/pg-seed-data/fixtures/normalized_jobs.json filter=lfs diff=lfs merge=lfs -text
-scripts/pg-seed-data/fixtures/llm_audit_log.json filter=lfs diff=lfs merge=lfs -text
-scripts/pg-seed-data/fixtures/postal_geo_data.json filter=lfs diff=lfs merge=lfs -text
+# Heavy seed fixtures used to be tracked in Git LFS. As of issue #322 they are
+# distributed via GitHub Release assets instead — the org-wide LFS bandwidth
+# budget was exhausted. See scripts/pg-seed-data/README.md for the new flow.
+# This file intentionally left near-empty until a future need arises.

--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,17 @@ docs/findings/generate-*.cjs
 # canonical seed set. Safe to delete locally once the backfills are
 # verified merged on `development`.
 scripts/pg-seed-data/fixtures-pre-*/
+
+# Heavy seed fixtures — distributed via GitHub Release bundle (#322).
+# Devs run `python scripts/pg-seed-data/sync_fixtures.py` to populate
+# these locally; they must NEVER be committed to git.
+scripts/pg-seed-data/fixtures/extracted_intelligence.json
+scripts/pg-seed-data/fixtures/raw_ingested_jobs.json
+scripts/pg-seed-data/fixtures/job_postings.json
+scripts/pg-seed-data/fixtures/normalized_jobs.json
+scripts/pg-seed-data/fixtures/llm_audit_log.json
+scripts/pg-seed-data/fixtures/postal_geo_data.json
+
+# Local bundle artifact produced by publish_fixtures.py before upload.
+# Cleaned up automatically on success; gitignored as belt + suspenders.
+fixtures-v*.tar.zst

--- a/scripts/pg-seed-data/README.md
+++ b/scripts/pg-seed-data/README.md
@@ -2,25 +2,32 @@
 
 Seed a fresh PostgreSQL container with reference data for the watechcoalition platform.
 
-## Prerequisites: Git LFS
+## Prerequisites: heavy fixture sync (issue #322)
 
-Five fixtures (`extracted_intelligence.json`, `raw_ingested_jobs.json`,
-`job_postings.json`, `normalized_jobs.json`, `llm_audit_log.json`) are stored
-via [Git LFS](https://git-lfs.com/) because they exceed GitHub's 50 MB
-recommendation. **Install Git LFS once before cloning** or your seed will
-silently load empty arrays from 133-byte pointer files:
+Six heavy fixtures (`extracted_intelligence.json`, `raw_ingested_jobs.json`,
+`job_postings.json`, `normalized_jobs.json`, `llm_audit_log.json`,
+`postal_geo_data.json`) are **not** in git — they're published as a single
+zstd-compressed bundle on a [GitHub Release](https://github.com/Building-With-Agents/job-intelligence-engine/releases)
+because they exceed GitHub's plain-git limits and the org-wide LFS bandwidth
+budget is exhausted.
+
+**Run once after cloning, and every time you pull a `fixtures-manifest.json` change:**
 
 ```bash
-# Install (one-time, system-level)
-git lfs install                     # macOS / Linux (with git-lfs already on PATH)
-# Windows: included with Git for Windows; if missing, run: winget install GitHub.GitLFS
-
-# If you already cloned without LFS, fetch the real files:
-git lfs pull
+python scripts/pg-seed-data/sync_fixtures.py
 ```
 
+That script reads `fixtures-manifest.json`, downloads the pinned bundle from
+the GitHub Release via `gh release download`, verifies the SHA256, and
+extracts the JSON files into `scripts/pg-seed-data/fixtures/`. Idempotent —
+re-running is a no-op if the local files are already in sync (use `--force`
+to re-download).
+
+**Prerequisite: `gh` authenticated.** Run `gh auth status` to verify; if not,
+`gh auth login` first.
+
 Verify with `ls -la scripts/pg-seed-data/fixtures/extracted_intelligence.json` —
-you should see ~120 MB, not ~133 bytes.
+you should see ~120 MB after sync.
 
 ## Quick Start (Junior Devs)
 
@@ -135,7 +142,7 @@ scripts/pg-seed-data/
 
 ## For Admins: Re-exporting Fixtures
 
-If the admin database changes, re-export fixtures:
+If the admin database changes, re-export fixtures and publish a new bundle:
 
 ```bash
 # 1. Ensure PYTHON_DATABASE_URL points to the admin PostgreSQL instance
@@ -143,8 +150,8 @@ If the admin database changes, re-export fixtures:
 python scripts/pg-seed-data/export_fixtures.py
 
 # Or export individual scopes (all output to fixtures/):
-python scripts/pg-seed-data/export_fixtures.py --scope reference  # 40 reference tables only
-python scripts/pg-seed-data/export_fixtures.py --scope agent      # 10 agent pipeline tables only
+python scripts/pg-seed-data/export_fixtures.py --scope reference  # reference tables only
+python scripts/pg-seed-data/export_fixtures.py --scope agent      # agent pipeline tables only
 python scripts/pg-seed-data/export_fixtures.py --limit 500        # cap rows per table
 
 # 3. Optionally regenerate schema.sql
@@ -153,10 +160,20 @@ docker exec postgres-server pg_dump -U postgres -d talent_finder \
   > scripts/pg-seed-data/schema_raw.sql
 python scripts/pg-seed-data/clean_schema.py
 
-# 5. Commit updated fixtures
-git add scripts/pg-seed-data/fixtures/ scripts/pg-seed-data/schema.sql
-git commit -m "Update PostgreSQL seed fixtures"
+# 4. Publish the heavy-fixture bundle as a new GitHub Release.
+#    This bundles the 6 heavy fixtures into a tar.zst, runs `gh release create`,
+#    and rewrites scripts/pg-seed-data/fixtures-manifest.json with the new tag + SHA256.
+python scripts/pg-seed-data/publish_fixtures.py            # auto-bumps to next fixtures-vN
+python scripts/pg-seed-data/publish_fixtures.py --tag fixtures-v3  # explicit tag
+python scripts/pg-seed-data/publish_fixtures.py --dry-run  # build + verify SHA without publishing
+
+# 5. Commit small fixtures + the updated manifest. Heavy fixtures are gitignored.
+git add scripts/pg-seed-data/fixtures/ scripts/pg-seed-data/fixtures-manifest.json scripts/pg-seed-data/schema.sql
+git commit -m "Update PostgreSQL seed fixtures + bundle vN"
 ```
+
+Devs pull the manifest change in their next `git pull` and run
+`python scripts/pg-seed-data/sync_fixtures.py` to refresh local heavy fixtures.
 
 ### Adding a column to `UPSERT_UPDATE_COLUMNS`
 

--- a/scripts/pg-seed-data/fixtures-manifest.json
+++ b/scripts/pg-seed-data/fixtures-manifest.json
@@ -1,0 +1,15 @@
+{
+  "release_tag": "fixtures-v1",
+  "bundle_filename": "fixtures-v1.tar.zst",
+  "bundle_sha256": "1f8132fd180fbac506d3f2f141e523f4c129839e78ebcbe5a6759e173440c0a4",
+  "included_tables": [
+    "extracted_intelligence",
+    "raw_ingested_jobs",
+    "job_postings",
+    "normalized_jobs",
+    "llm_audit_log",
+    "postal_geo_data"
+  ],
+  "exported_at": "2026-04-30T00:43:31.673734+00:00",
+  "repo": "Building-With-Agents/job-intelligence-engine"
+}

--- a/scripts/pg-seed-data/fixtures/extracted_intelligence.json
+++ b/scripts/pg-seed-data/fixtures/extracted_intelligence.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:65f9a4218463c575eedf98fc9f293418916ed167fc3845f41a0704fa2c85edf2
-size 121115495

--- a/scripts/pg-seed-data/fixtures/job_postings.json
+++ b/scripts/pg-seed-data/fixtures/job_postings.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:729832b500be9fad5601ca29476dd2388ffd1e445b8775ce17ecd1b3833fb202
-size 59880155

--- a/scripts/pg-seed-data/fixtures/llm_audit_log.json
+++ b/scripts/pg-seed-data/fixtures/llm_audit_log.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:014ea8e4b759ff0d1d623c7a8835ca1ae973cfb6ac031feb965e8701238493db
-size 23587351

--- a/scripts/pg-seed-data/fixtures/normalized_jobs.json
+++ b/scripts/pg-seed-data/fixtures/normalized_jobs.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a95b1a688a1b4b076033f40b194d6b5d5f45861489b42e1fa49b929d3990b31
-size 19686702

--- a/scripts/pg-seed-data/fixtures/postal_geo_data.json
+++ b/scripts/pg-seed-data/fixtures/postal_geo_data.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e8fc1d490e134daf6f81938c6eb9be7b896338314e32bce8240f9c47bcc33c0f
-size 6043975

--- a/scripts/pg-seed-data/fixtures/raw_ingested_jobs.json
+++ b/scripts/pg-seed-data/fixtures/raw_ingested_jobs.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1e2d502bab87a12ecf9c43f4c646311c1164a4be56338f988d5a49a10e7d9c82
-size 50228164

--- a/scripts/pg-seed-data/publish_fixtures.py
+++ b/scripts/pg-seed-data/publish_fixtures.py
@@ -1,0 +1,186 @@
+# ruff: noqa: T201
+"""Bundle heavy seed fixtures and publish as a GitHub Release asset.
+
+Closes #322 — admin tool. Run after `export_fixtures.py` regenerates
+`fixtures/*.json` from the live source-of-truth DB. Produces a single
+`fixtures-vN.tar.zst` and creates the corresponding GitHub Release,
+then updates `fixtures-manifest.json` so devs can `sync_fixtures.py`
+to pull the new bundle.
+
+Usage::
+
+    # Default: derive next tag from the existing manifest's release_tag
+    python scripts/pg-seed-data/publish_fixtures.py
+
+    # Explicit tag (e.g., for a re-cut)
+    python scripts/pg-seed-data/publish_fixtures.py --tag fixtures-v2
+
+    # Dry-run: build bundle, print SHA, but do NOT call gh release create
+    python scripts/pg-seed-data/publish_fixtures.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import re
+import subprocess
+import sys
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import zstandard as zstd
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FIXTURES_DIR = _REPO_ROOT / "scripts" / "pg-seed-data" / "fixtures"
+_MANIFEST_PATH = _REPO_ROOT / "scripts" / "pg-seed-data" / "fixtures-manifest.json"
+
+# Fixtures that go in the release bundle. Mirrors the prior LFS tracking set.
+# Add a new entry here when a fixture grows past ~5 MB; remove if it shrinks.
+BUNDLED_TABLES: list[str] = [
+    "extracted_intelligence",
+    "raw_ingested_jobs",
+    "job_postings",
+    "normalized_jobs",
+    "llm_audit_log",
+    "postal_geo_data",
+]
+
+_REPO_FULL_NAME = "Building-With-Agents/job-intelligence-engine"
+
+
+def _next_tag(current_tag: str) -> str:
+    m = re.fullmatch(r"fixtures-v(\d+)", current_tag)
+    if not m:
+        return "fixtures-v1"
+    return f"fixtures-v{int(m.group(1)) + 1}"
+
+
+def _verify_inputs() -> None:
+    missing = [t for t in BUNDLED_TABLES if not (_FIXTURES_DIR / f"{t}.json").is_file()]
+    if missing:
+        print(f"ERROR: required fixtures missing under {_FIXTURES_DIR}: {missing}", file=sys.stderr)
+        sys.exit(2)
+
+
+def _build_bundle(target_path: Path) -> tuple[int, int]:
+    """Tar the BUNDLED_TABLES fixtures and zstd-compress to target_path.
+
+    Returns (uncompressed_bytes, compressed_bytes).
+    """
+    raw_buffer = io.BytesIO()
+    uncompressed = 0
+    with tarfile.open(fileobj=raw_buffer, mode="w") as tar:
+        for table in BUNDLED_TABLES:
+            src = _FIXTURES_DIR / f"{table}.json"
+            arcname = f"{table}.json"
+            tar.add(src, arcname=arcname)
+            uncompressed += src.stat().st_size
+
+    raw_bytes = raw_buffer.getvalue()
+    cctx = zstd.ZstdCompressor(level=19)
+    compressed = cctx.compress(raw_bytes)
+    target_path.write_bytes(compressed)
+    return uncompressed, len(compressed)
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _gh_release_create(tag: str, bundle_path: Path, notes: str) -> None:
+    cmd = [
+        "gh",
+        "release",
+        "create",
+        tag,
+        str(bundle_path),
+        "--repo",
+        _REPO_FULL_NAME,
+        "--title",
+        f"Seed fixtures bundle {tag}",
+        "--notes",
+        notes,
+    ]
+    print(f"Running: {' '.join(cmd[:6])} ...")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"ERROR: gh release create failed:\n{result.stderr}", file=sys.stderr)
+        sys.exit(3)
+    print(result.stdout.strip())
+
+
+def _write_manifest(tag: str, bundle_filename: str, sha256: str) -> None:
+    manifest = {
+        "release_tag": tag,
+        "bundle_filename": bundle_filename,
+        "bundle_sha256": sha256,
+        "included_tables": BUNDLED_TABLES,
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "repo": _REPO_FULL_NAME,
+    }
+    _MANIFEST_PATH.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(f"\nManifest written: {_MANIFEST_PATH.relative_to(_REPO_ROOT)}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", help="Override the release tag (default: increment manifest's tag)")
+    parser.add_argument("--dry-run", action="store_true", help="Build bundle, print SHA, skip release create")
+    args = parser.parse_args()
+
+    _verify_inputs()
+
+    if args.tag:
+        tag = args.tag
+    elif _MANIFEST_PATH.exists():
+        tag = _next_tag(json.loads(_MANIFEST_PATH.read_text(encoding="utf-8")).get("release_tag", "fixtures-v0"))
+    else:
+        tag = "fixtures-v1"
+
+    bundle_filename = f"{tag}.tar.zst"
+    bundle_path = _REPO_ROOT / bundle_filename
+
+    print("=" * 60)
+    print(f"Publishing fixtures bundle {tag}")
+    print("=" * 60)
+
+    uncompressed, compressed = _build_bundle(bundle_path)
+    sha = _sha256(bundle_path)
+    print(f"\nBundle: {bundle_path.name}")
+    print(f"  Uncompressed: {uncompressed:>14,} bytes")
+    print(f"  Compressed:   {compressed:>14,} bytes")
+    print(f"  Ratio:        {compressed / uncompressed:.2%}")
+    print(f"  SHA256:       {sha}")
+
+    if args.dry_run:
+        print("\nDry run: bundle and SHA computed; release NOT created. Bundle file kept for inspection.")
+        return 0
+
+    notes = (
+        f"Auto-generated heavy seed fixtures bundle.\n\n"
+        f"- Tables: `{', '.join(BUNDLED_TABLES)}`\n"
+        f"- Uncompressed: {uncompressed:,} bytes\n"
+        f"- Compressed:   {compressed:,} bytes\n"
+        f"- SHA256:       `{sha}`\n\n"
+        f"Devs: run `python scripts/pg-seed-data/sync_fixtures.py` after pulling latest "
+        f"`development` to refresh local fixtures."
+    )
+    _gh_release_create(tag, bundle_path, notes)
+    _write_manifest(tag, bundle_filename, sha)
+
+    bundle_path.unlink(missing_ok=True)
+    print(f"\nLocal bundle file removed: {bundle_path.name}")
+    print(f"\nNext: commit {_MANIFEST_PATH.relative_to(_REPO_ROOT)} and push.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pg-seed-data/sync_fixtures.py
+++ b/scripts/pg-seed-data/sync_fixtures.py
@@ -1,0 +1,162 @@
+# ruff: noqa: T201
+"""Download heavy seed fixtures from a GitHub Release bundle.
+
+Closes #322 — replaces Git LFS for the six >5 MB fixtures whose download
+would otherwise burn the org-wide LFS bandwidth budget. Small fixtures
+remain plain JSON in git for diffability; this script only handles the
+bundled heavy ones.
+
+Workflow
+--------
+1. Read `fixtures-manifest.json` for the pinned release tag and bundle SHA256.
+2. If every heavy fixture is already present locally and matches manifest
+   `included_tables`, exit early — idempotent.
+3. Otherwise: `gh release download <tag> --pattern <bundle>` into a tmpdir,
+   verify SHA256, extract into `scripts/pg-seed-data/fixtures/`.
+
+Usage::
+
+    python scripts/pg-seed-data/sync_fixtures.py
+    python scripts/pg-seed-data/sync_fixtures.py --force   # re-extract even if local
+
+Exits 0 on success, non-zero on verification or download failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+import tarfile
+import tempfile
+from io import BytesIO
+from pathlib import Path
+
+import zstandard as zstd
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FIXTURES_DIR = _REPO_ROOT / "scripts" / "pg-seed-data" / "fixtures"
+_MANIFEST_PATH = _REPO_ROOT / "scripts" / "pg-seed-data" / "fixtures-manifest.json"
+
+
+def _read_manifest() -> dict:
+    if not _MANIFEST_PATH.exists():
+        print(f"ERROR: manifest not found at {_MANIFEST_PATH}", file=sys.stderr)
+        sys.exit(2)
+    return json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _local_fixtures_match(manifest: dict) -> bool:
+    expected_tables: list[str] = manifest.get("included_tables", [])
+    for table in expected_tables:
+        path = _FIXTURES_DIR / f"{table}.json"
+        if not path.is_file() or path.stat().st_size < 1024:
+            return False
+    return True
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _gh_download(release_tag: str, pattern: str, dest_dir: Path) -> Path:
+    cmd = [
+        "gh",
+        "release",
+        "download",
+        release_tag,
+        "--repo",
+        "Building-With-Agents/job-intelligence-engine",
+        "--pattern",
+        pattern,
+        "--dir",
+        str(dest_dir),
+    ]
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"ERROR: gh release download failed:\n{result.stderr}", file=sys.stderr)
+        sys.exit(3)
+    matches = list(dest_dir.glob(pattern))
+    if len(matches) != 1:
+        print(f"ERROR: expected exactly one bundle file, got {len(matches)}: {matches}", file=sys.stderr)
+        sys.exit(4)
+    return matches[0]
+
+
+def _extract_zst_tar(bundle_path: Path, target_dir: Path, expected_tables: list[str]) -> None:
+    """Decompress .tar.zst stream and extract entries matching expected fixtures."""
+    target_dir.mkdir(parents=True, exist_ok=True)
+    expected_names = {f"{table}.json" for table in expected_tables}
+    extracted: set[str] = set()
+
+    dctx = zstd.ZstdDecompressor()
+    with bundle_path.open("rb") as compressed, dctx.stream_reader(compressed) as reader:
+        tar_bytes = BytesIO(reader.read())
+    with tarfile.open(fileobj=tar_bytes, mode="r:") as tar:
+        for member in tar.getmembers():
+            if not member.isfile():
+                continue
+            name = Path(member.name).name
+            if name not in expected_names:
+                print(f"  skip unexpected entry: {member.name}")
+                continue
+            extracted.add(name)
+            extracted_file = tar.extractfile(member)
+            if extracted_file is None:
+                continue
+            (target_dir / name).write_bytes(extracted_file.read())
+            print(f"  extracted: {name} ({member.size:,} bytes)")
+
+    missing = expected_names - extracted
+    if missing:
+        print(f"ERROR: bundle missing expected fixtures: {sorted(missing)}", file=sys.stderr)
+        sys.exit(5)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--force", action="store_true", help="Re-download even if local fixtures look complete")
+    args = parser.parse_args()
+
+    manifest = _read_manifest()
+    release_tag = manifest["release_tag"]
+    bundle_filename = manifest["bundle_filename"]
+    expected_sha = manifest["bundle_sha256"]
+    expected_tables: list[str] = manifest["included_tables"]
+
+    print("=" * 60)
+    print(f"Fixture sync — release {release_tag}")
+    print(f"Bundle: {bundle_filename}")
+    print(f"Tables: {', '.join(expected_tables)}")
+    print("=" * 60)
+
+    if not args.force and _local_fixtures_match(manifest):
+        print("All heavy fixtures already present locally. Use --force to re-download.")
+        return 0
+
+    with tempfile.TemporaryDirectory(prefix="jie-fixtures-") as tmpdir:
+        tmp_path = Path(tmpdir)
+        bundle_path = _gh_download(release_tag, bundle_filename, tmp_path)
+        actual_sha = _sha256(bundle_path)
+        if actual_sha != expected_sha:
+            print(
+                f"ERROR: SHA256 mismatch\n  expected: {expected_sha}\n  got:      {actual_sha}",
+                file=sys.stderr,
+            )
+            return 6
+        print(f"  SHA256 verified: {actual_sha}")
+        _extract_zst_tar(bundle_path, _FIXTURES_DIR, expected_tables)
+
+    print("\nDone. Heavy fixtures synced to scripts/pg-seed-data/fixtures/")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_fixture_lfs_compliance.py
+++ b/scripts/tests/test_fixture_lfs_compliance.py
@@ -1,57 +1,54 @@
-"""Guard tests for seed-fixture LFS compliance (issue #251).
+"""Guard tests for seed-fixture distribution compliance.
 
-Two invariants this PR (#285) introduced and that future re-exports must hold:
+Originally introduced for issue #251 (LFS) and reworked for issue #322
+(GitHub Release bundle replacing LFS, after the org-wide LFS bandwidth
+budget was exhausted).
+
+Two invariants the export workflow must hold:
 
 1. **Size guard.** Any committed fixture larger than `_PLAIN_TEXT_MAX_BYTES`
-   must be tracked through Git LFS via `.gitattributes`. Without this, the next
-   re-export of a heavy table silently bloats the git history and hits GitHub's
-   50 MB warning / 100 MB hard block.
+   must be distributed via the GitHub Release bundle declared in
+   ``fixtures-manifest.json`` — i.e., listed in ``included_tables``. Without
+   this, the next re-export of a heavy table silently bloats the git history
+   and trips GitHub's 50 MB warning / 100 MB hard block.
 
-2. **LFS pointer detection.** No fixture file in the working tree should be a
-   ~133-byte LFS pointer file (the placeholder Git ships when `git lfs install`
-   was never run on this clone). If pytest sees one, the dev forgot to install
-   LFS — better to fail loudly here than silently load `[]` during seed.
+2. **LFS pointer detection.** Holdover from the old LFS workflow: no fixture
+   in the working tree should be a ~133-byte LFS pointer. Marked
+   ``requires_lfs`` so CI can skip it; runs locally for devs who still have
+   stale LFS pointers from before the migration.
 
 Both checks are pure-Python, no DB, fast — safe to run in CI.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _FIXTURES_DIR = _REPO_ROOT / "scripts" / "pg-seed-data" / "fixtures"
-_GITATTRIBUTES = _REPO_ROOT / ".gitattributes"
+_MANIFEST_PATH = _REPO_ROOT / "scripts" / "pg-seed-data" / "fixtures-manifest.json"
 
-# Plain-text fixtures may not exceed this size; anything heavier MUST be LFS-tracked.
-# Set conservatively below GitHub's 50 MB warning to leave slop for one more
-# pipeline run before someone notices and adds the file to .gitattributes.
+# Plain-text fixtures may not exceed this size; anything heavier MUST be
+# distributed through the GitHub Release bundle (manifest) instead of being
+# committed to git.
 _PLAIN_TEXT_MAX_BYTES = 40 * 1024 * 1024  # 40 MB
 
 # LFS pointer files always start with this exact line.
 _LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/"
 
-# A real LFS pointer is ~130–150 bytes; anything beyond this is definitely real content.
+# A real LFS pointer is ~130–150 bytes; anything beyond is definitely real content.
 _LFS_POINTER_MAX_BYTES = 200
 
 
-def _lfs_tracked_paths() -> set[str]:
-    """Parse .gitattributes for paths routed through `filter=lfs`."""
-    if not _GITATTRIBUTES.exists():
+def _bundled_fixture_basenames() -> set[str]:
+    """Read fixtures-manifest.json and return the set of fixture filenames in the bundle."""
+    if not _MANIFEST_PATH.exists():
         return set()
-    tracked: set[str] = set()
-    for line in _GITATTRIBUTES.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if "filter=lfs" not in line:
-            continue
-        # Format: "<path-or-pattern> filter=lfs diff=lfs merge=lfs -text"
-        path = line.split()[0]
-        tracked.add(path)
-    return tracked
+    manifest = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    return {f"{table}.json" for table in manifest.get("included_tables", [])}
 
 
 def _fixture_files() -> list[Path]:
@@ -60,26 +57,28 @@ def _fixture_files() -> list[Path]:
     return sorted(p for p in _FIXTURES_DIR.iterdir() if p.is_file() and p.suffix == ".json")
 
 
-def test_heavy_fixtures_are_lfs_tracked() -> None:
-    """Any fixture above the plain-text size ceiling must appear in .gitattributes."""
-    tracked = _lfs_tracked_paths()
+def test_heavy_fixtures_are_in_release_bundle() -> None:
+    """Any fixture above the plain-text size ceiling must be in the manifest's bundle list."""
+    bundled = _bundled_fixture_basenames()
     offenders: list[str] = []
     for fixture in _fixture_files():
         size = fixture.stat().st_size
         if size <= _PLAIN_TEXT_MAX_BYTES:
             continue
-        rel = fixture.relative_to(_REPO_ROOT).as_posix()
-        if rel not in tracked:
+        if fixture.name not in bundled:
+            rel = fixture.relative_to(_REPO_ROOT).as_posix()
             offenders.append(f"  {rel} ({size / 1024 / 1024:.1f} MB)")
     if offenders:
         offender_block = "\n".join(offenders)
         threshold_mb = _PLAIN_TEXT_MAX_BYTES / 1024 / 1024
         msg = (
-            f"\nFixture files exceed {threshold_mb:.0f} MB without being Git-LFS-tracked.\n"
-            "Add each one to .gitattributes via:\n"
-            '  git lfs track "<path>"\n'
-            "Then commit .gitattributes BEFORE re-staging the fixture so the LFS\n"
-            "filter applies. See scripts/pg-seed-data/README.md for details.\n\n"
+            f"\nFixture files exceed {threshold_mb:.0f} MB without being in the GitHub "
+            "Release bundle.\n"
+            "Add each filename (without `.json`) to `included_tables` in "
+            "scripts/pg-seed-data/fixtures-manifest.json, then run:\n"
+            "  python scripts/pg-seed-data/publish_fixtures.py\n"
+            "to cut a new fixtures-vN release. The fixtures must also appear in\n"
+            "`BUNDLED_TABLES` in scripts/pg-seed-data/publish_fixtures.py.\n\n"
             f"Offenders:\n{offender_block}"
         )
         pytest.fail(msg)
@@ -89,12 +88,16 @@ def test_heavy_fixtures_are_lfs_tracked() -> None:
 def test_no_lfs_pointer_files_committed() -> None:
     """No fixture should be present as a tiny LFS pointer file in the working tree.
 
-    If this fails, the dev cloned without `git lfs install` and the fixture is the
-    133-byte pointer instead of real content. Seeding will silently load `[]`.
+    Holdover guard: if this fails, the dev cloned with the old LFS smudge filter
+    active and the fixture is the ~133-byte pointer instead of real content. After
+    issue #322 the heavy fixtures live in a GitHub Release bundle, not LFS — so a
+    pointer file here is a legacy state. Run:
 
-    Marked `requires_lfs` so CI can skip it (CI does not pull LFS to conserve the
-    GitHub LFS bandwidth budget). Devs must run `git lfs install` + `git lfs pull`
-    locally and run pytest without `-m "not requires_lfs"` to exercise this guard.
+        python scripts/pg-seed-data/sync_fixtures.py
+
+    to fetch the bundle and replace pointers with real content.
+
+    Marked `requires_lfs` so CI can skip it.
     """
     pointers: list[str] = []
     for fixture in _fixture_files():
@@ -110,11 +113,10 @@ def test_no_lfs_pointer_files_committed() -> None:
         pointer_block = "\n".join(pointers)
         msg = (
             "\nFixture(s) present as Git-LFS pointer files instead of real content.\n"
-            "This means `git lfs install` was never run on this clone, or the\n"
-            "smudge filter failed. Run:\n"
-            "  git lfs install\n"
-            "  git lfs pull\n"
-            "and re-run pytest. See scripts/pg-seed-data/README.md.\n\n"
+            "After issue #322 the heavy fixtures live in a GitHub Release bundle\n"
+            "rather than LFS. Run:\n"
+            "  python scripts/pg-seed-data/sync_fixtures.py\n"
+            "to fetch the bundle and replace these pointers with real content.\n\n"
             f"Pointer files found:\n{pointer_block}"
         )
         pytest.fail(msg)


### PR DESCRIPTION
## Summary

Closes #322. The org-wide GitHub LFS bandwidth budget is exhausted (discovered while unblocking PR #319's CI). Devs cannot pull updated heavy fixtures through LFS, and admin can't keep the team in sync with the source-of-truth DB.

This PR replaces LFS for the six heavy fixtures with a single GitHub Release asset bundled as zstd-compressed tar.

**280 MB uncompressed → 29 MB on the wire (10.34% ratio).** One download per dev refresh.

## Workflow

```
Devs:    python scripts/pg-seed-data/sync_fixtures.py
Admin:   python scripts/pg-seed-data/export_fixtures.py
         python scripts/pg-seed-data/publish_fixtures.py
         git commit scripts/pg-seed-data/fixtures-manifest.json
```

## What changed

**Added:**
- `scripts/pg-seed-data/sync_fixtures.py` — reads the manifest, `gh release download`, SHA256 verify, extract to `fixtures/`. Idempotent (no-op if local files match the manifest's `included_tables`; `--force` to re-download).
- `scripts/pg-seed-data/publish_fixtures.py` — admin tool. Tars the heavy fixtures, zstd-compresses, computes SHA256, runs `gh release create`, rewrites the manifest. Supports `--dry-run` and `--tag` overrides.
- `scripts/pg-seed-data/fixtures-manifest.json` — pins `release_tag`, `bundle_filename`, `bundle_sha256`, `included_tables`, `exported_at`. Currently points to `fixtures-v1` published from this branch.
- **First release [fixtures-v1](https://github.com/Building-With-Agents/job-intelligence-engine/releases/tag/fixtures-v1) cut** from the post-cosine cluster source-of-truth state (SHA `1f8132fd...`).

**Modified:**
- `.gitattributes` — emptied of LFS filter lines (heavy fixtures no longer LFS-tracked).
- `.gitignore` — heavy fixtures in `fixtures/` ignored; bundle tarball pattern `fixtures-v*.tar.zst` ignored as belt+suspenders.
- `scripts/pg-seed-data/README.md` — Prerequisites section rewritten for `sync_fixtures.py` flow; admin section adds the `publish_fixtures.py` step.
- `scripts/tests/test_fixture_lfs_compliance.py` — heavy-fixture guard reworked: now asserts fixtures > 40 MB are listed in the manifest's `included_tables` (was: required `filter=lfs` in `.gitattributes`). Legacy LFS pointer detector remains, marked `requires_lfs` for CI skip.

**Removed from git tracking** (kept locally; distributed via release):
- `extracted_intelligence.json` (121 MB)
- `raw_ingested_jobs.json` (50 MB)
- `job_postings.json` (60 MB)
- `normalized_jobs.json` (20 MB)
- `llm_audit_log.json` (24 MB)
- `postal_geo_data.json` (6 MB)

## Test plan

- [x] `publish_fixtures.py --dry-run` builds bundle, computes SHA: 29 MB compressed, ratio 10.34%.
- [x] `publish_fixtures.py --tag fixtures-v1` cut [fixtures-v1 release](https://github.com/Building-With-Agents/job-intelligence-engine/releases/tag/fixtures-v1) and updated the manifest.
- [x] Round-trip: moved local heavy fixtures aside, ran `sync_fixtures.py`, all 6 files restored at exact byte sizes (121,115,495 / 59,880,155 / 50,228,164 / 23,587,351 / 19,686,702 / 6,043,975), SHA256 verified.
- [x] `sync_fixtures.py` is idempotent — second run reports "All heavy fixtures already present locally."
- [x] `pytest scripts/tests/test_fixture_lfs_compliance.py -m "not requires_lfs"` — passes.
- [x] `ruff check` + `ruff format --check` — pass on the three new/modified Python files.
- [ ] CI lint + test pass on this PR.

## Notes

- The PR #319 CI workaround (`lfs: false` on `actions/checkout`, `requires_lfs` pytest marker) becomes redundant after this PR but is harmless and stays in place.
- Future fixture refreshes auto-bump the tag (`fixtures-v2`, `fixtures-v3`, ...) unless `--tag` is provided.
- `gh` must be authenticated for both `sync` and `publish` — surfaced in the README and via clear error messages.

## Out of scope (separate concerns)

- Auto-publish on a cron — manual admin trigger is fine for now.
- CDN / mirror — GitHub Release bandwidth is generous enough for cohort use.
- Differential sync — single bundle per release is simpler; revisit if download time becomes a complaint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)