### PR TITLE
chore: bump fixtures-manifest to v2 (post-Phase-1 heavy bundle)

### DIFF
--- a/scripts/pg-seed-data/fixtures-manifest.json
+++ b/scripts/pg-seed-data/fixtures-manifest.json
@@ -1,7 +1,7 @@
 {
-  "release_tag": "fixtures-v1",
-  "bundle_filename": "fixtures-v1.tar.zst",
-  "bundle_sha256": "1f8132fd180fbac506d3f2f141e523f4c129839e78ebcbe5a6759e173440c0a4",
+  "release_tag": "fixtures-v2",
+  "bundle_filename": "fixtures-v2.tar.zst",
+  "bundle_sha256": "76780c827f76affd432d34e36e54959818e60f35d4664b298fb83621fcb733aa",
   "included_tables": [
     "extracted_intelligence",
     "raw_ingested_jobs",
@@ -10,6 +10,6 @@
     "llm_audit_log",
     "postal_geo_data"
   ],
-  "exported_at": "2026-04-30T00:43:31.673734+00:00",
+  "exported_at": "2026-04-30T05:22:01.855143+00:00",
   "repo": "Building-With-Agents/job-intelligence-engine"
 }


### PR DESCRIPTION
## Summary

Bumps `scripts/pg-seed-data/fixtures-manifest.json` from `fixtures-v1` → `fixtures-v2`. The new bundle was cut from a fresh export of the source-of-truth DB after PR #331 (Phase 1 UMAP clustering) merged, picking up:

- 542 additional `job_postings.canonical_role_id` assignments (1,923 → **2,465**) — re-pointed during Phase 1's persist
- New `llm_audit_log` rows (~700) from today's clustering labeler activity
- Today's `extracted_intelligence`, `normalized_jobs`, and `raw_ingested_jobs` snapshots

After this PR merges, devs running:

```bash
git pull
python scripts/pg-seed-data/sync_fixtures.py
```

…get a local DB whose `job_postings.canonical_role_id` matches the 202-row `canonical_roles.json` shipped by PR #331 — **2,465 assignments, 0 dangling FKs**.

## Bundle stats

| | fixtures-v1 | **fixtures-v2** |
|---|---:|---:|
| Uncompressed | 280,541,842 B | **281,390,581 B** |
| Compressed (zstd) | 28,996,143 B | **29,185,662 B** |
| Ratio | 10.34 % | 10.37 % |
| SHA256 | `1f8132fd…` | `76780c82…` |
| `job_postings` w/ canonical_role_id | 1,923 | **2,465** |

[Release page](https://github.com/Building-With-Agents/job-intelligence-engine/releases/tag/fixtures-v2)

## Diff

One file, 4 lines changed — the manifest:

```diff
-  "release_tag": "fixtures-v1",
-  "bundle_filename": "fixtures-v1.tar.zst",
-  "bundle_sha256": "1f8132fd180fbac506d3f2f141e523f4c129839e78ebcbe5a6759e173440c0a4",
+  "release_tag": "fixtures-v2",
+  "bundle_filename": "fixtures-v2.tar.zst",
+  "bundle_sha256": "76780c827f76affd432d34e36e54959818e60f35d4664b298fb83621fcb733aa",
-  "exported_at": "2026-04-30T00:43:31.673734+00:00",
+  "exported_at": "2026-04-30T05:22:01.855143+00:00",
```

## Test plan

- [x] Fresh export from live DB confirms `job_postings.json` now has 2,465 canonical_role_id assignments (was 1,923 in v1).
- [x] Cross-check with committed `canonical_roles.json` (202 rows on `development` after PR #331): **0 dangling FKs**.
- [x] `publish_fixtures.py` ran cleanly, SHA256 verified, bundle uploaded to the new release.
- [ ] CI lint + test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)