### PR TITLE
hotfix(router): widen role resolution via representative_titles (+35% evidence)

### DIFF
--- a/analytics/query_engine/curriculum_path.py
+++ b/analytics/query_engine/curriculum_path.py
@@ -106,6 +106,7 @@ class CurriculumInputs:
     region: str
     role_matched: bool
     data_flags: dict[str, bool]
+    canonical_role_label: str | None = None
 
 
 def _empty_data_flags() -> dict[str, bool]:
@@ -517,7 +518,7 @@ def build_curriculum_inputs(
     flags = _empty_data_flags()
     phrase = _extract_role_phrase(question, role_names)
     try:
-        role_id, _label, matched = _match_canonical_role(session, phrase)
+        role_id, label, matched = _match_canonical_role(session, phrase)
     except Exception as exc:  # noqa: BLE001
         log.warning("curriculum_path_role_resolution_error", error_type=type(exc).__name__)
         return CurriculumInputs(
@@ -599,6 +600,7 @@ def build_curriculum_inputs(
         region=_REGION_LABEL,
         role_matched=True,
         data_flags=flags,
+        canonical_role_label=label,
     )
 
 

--- a/analytics/query_engine/curriculum_synthesis.py
+++ b/analytics/query_engine/curriculum_synthesis.py
@@ -52,7 +52,7 @@ FORBIDDEN:
 - Do NOT reference any external curriculum catalog, bootcamp, or university program by name.
 - If a section has no supporting data, say so explicitly — never invent content to fill it."""
 
-_USER_TEMPLATE = """Role: {canonical_role}
+_USER_TEMPLATE = """Role: {canonical_role_label}
 Period: {period}
 Region: {region}
 
@@ -194,7 +194,11 @@ def synthesize_curriculum_outline(
         return dict(_INSUFFICIENT_NO_TOP_SKILLS)
 
     user_prompt = _USER_TEMPLATE.format(
-        canonical_role=inputs.canonical_role,
+        canonical_role_label=(
+            inputs.canonical_role_label
+            or inputs.canonical_role
+            or "Unknown role"
+        ),
         period=inputs.period,
         region=inputs.region,
         top_skills_json=_json_block(inputs.top_skills),

--- a/analytics/query_engine/curriculum_synthesis.py
+++ b/analytics/query_engine/curriculum_synthesis.py
@@ -194,11 +194,7 @@ def synthesize_curriculum_outline(
         return dict(_INSUFFICIENT_NO_TOP_SKILLS)
 
     user_prompt = _USER_TEMPLATE.format(
-        canonical_role_label=(
-            inputs.canonical_role_label
-            or inputs.canonical_role
-            or "Unknown role"
-        ),
+        canonical_role_label=(inputs.canonical_role_label or inputs.canonical_role or "Unknown role"),
         period=inputs.period,
         region=inputs.region,
         top_skills_json=_json_block(inputs.top_skills),

--- a/analytics/query_engine/router.py
+++ b/analytics/query_engine/router.py
@@ -632,6 +632,58 @@ class QueryRouter:
         return [str(row[0]) for row in rows]
 
     @staticmethod
+    def _resolve_representative_titles(
+        canonical_role_ids: list[str],
+        session: Session,
+        *,
+        max_titles: int = 25,
+    ) -> list[str]:
+        """Return the union of ``representative_titles`` for the given canonical
+        roles, deduplicated and capped at ``max_titles``.
+
+        Used by routes that query ``dbo.job_postings`` directly to widen recall
+        onto postings whose ``canonical_role_id`` is NULL (~48% of the corpus
+        as of 2026-05-02 re-cluster). The clustering pipeline persists the
+        member titles per canonical role; ILIKE-matching those titles against
+        ``jp.job_title`` catches NULL-canonical_role_id postings that genuinely
+        belong to the resolved role family but missed direct assignment.
+
+        Returns an empty list when ``canonical_role_ids`` is empty or no rows
+        have populated ``representative_titles``. Cap of 25 keeps the OR'd
+        ILIKE clause tractable at top_k=5 × ~5 rep titles per role.
+        """
+        if not canonical_role_ids:
+            return []
+        rows = session.execute(
+            text(
+                """
+                SELECT representative_titles
+                FROM dbo.canonical_roles
+                WHERE role_id = ANY(:ids)
+                  AND representative_titles IS NOT NULL
+                """
+            ),
+            {"ids": canonical_role_ids},
+        ).fetchall()
+        seen: set[str] = set()
+        titles: list[str] = []
+        for row in rows:
+            rt = row[0] or []
+            if not isinstance(rt, list):
+                continue
+            for t in rt:
+                if not t or not isinstance(t, str):
+                    continue
+                norm = t.strip()
+                if not norm or norm.lower() in seen:
+                    continue
+                seen.add(norm.lower())
+                titles.append(norm)
+                if len(titles) >= max_titles:
+                    return titles
+        return titles
+
+    @staticmethod
     def _build_role_token_ilike_clauses(role_names: list[str], params: dict[str, Any]) -> list[str]:
         """Build OR'd token-ILIKE clauses against ``jp.job_title``/``jp.role_classification``.
 
@@ -778,9 +830,20 @@ class QueryRouter:
             if resolved_ids:
                 params["resolved_role_ids"] = resolved_ids
                 predicates.append("jp.canonical_role_id = ANY(:resolved_role_ids)")
+                # Widen recall onto NULL-canonical_role_id postings whose title
+                # matches a representative_title of any resolved canonical role.
+                rep_titles = self._resolve_representative_titles(resolved_ids, session)
+                rep_clauses: list[str] = []
+                for i, rep_title in enumerate(rep_titles):
+                    key = f"rep_title_{i}"
+                    params[key] = f"%{rep_title}%"
+                    rep_clauses.append(f"jp.job_title ILIKE :{key}")
+                if rep_clauses:
+                    predicates.append("(" + " OR ".join(rep_clauses) + ")")
                 log.info(
                     "query_router_role_evolution_embedding_route",
                     resolved_count=len(resolved_ids),
+                    rep_titles_count=len(rep_titles),
                 )
             if role_clauses:
                 predicates.append("(" + " OR ".join(role_clauses) + ")" if len(role_clauses) > 1 else role_clauses[0])
@@ -1272,11 +1335,22 @@ class QueryRouter:
                 placeholders = ", ".join(f":crid{i}" for i in range(len(resolved_ids)))
                 for i, rid in enumerate(resolved_ids):
                     params[f"crid{i}"] = rid
-                where_parts.append(f"jp.canonical_role_id IN ({placeholders})")
+                # Widen recall onto NULL-canonical_role_id postings whose title
+                # matches a representative_title of any resolved canonical role.
+                rep_titles = self._resolve_representative_titles(resolved_ids, session)
+                role_predicates: list[str] = [
+                    f"jp.canonical_role_id IN ({placeholders})",
+                ]
+                for i, rep_title in enumerate(rep_titles):
+                    key = f"rep_title_{i}"
+                    params[key] = f"%{rep_title}%"
+                    role_predicates.append(f"jp.job_title ILIKE :{key}")
+                where_parts.append("(" + " OR ".join(role_predicates) + ")")
                 where_parts.append("(jp.role_classification IS NULL OR jp.role_classification <> 'N/A Not an IT role')")
                 log.info(
                     "query_router_geographic_list_embedding_route",
                     resolved_count=len(resolved_ids),
+                    rep_titles_count=len(rep_titles),
                 )
             else:
                 # Tokenize each role name and OR-match every token against EITHER

--- a/analytics/query_engine/routing.py
+++ b/analytics/query_engine/routing.py
@@ -572,7 +572,14 @@ def _curriculum_to_analytics_response(
     modules: list[str] = list(synthesis.get("modules") or [])
 
     if is_suff and modules:
-        out_conf = 0.9
+        n_emps = len(ins.top_employers or [])
+        n_top_skills = len(ins.top_skills or [])
+        if n_emps >= 5 and n_top_skills >= 5:
+            out_conf = 0.9
+        elif n_emps >= 2 and n_top_skills >= 3:
+            out_conf = 0.7
+        else:
+            out_conf = 0.5
     elif is_suff:
         out_conf = 0.4
     else:

--- a/analytics/tests/test_router.py
+++ b/analytics/tests/test_router.py
@@ -511,34 +511,40 @@ class TestRoleEmbeddingResolution:
         resolve_result = MagicMock()
         resolve_result.fetchall.return_value = [("resolved-role-id-aa",), ("resolved-role-id-bb",)]
 
+        # rep_titles_widening fetches representative_titles for the resolved IDs
+        # (PR#355 C1). Empty list here keeps test focused on the canonical_role_id +
+        # token-ILIKE OR'd predicates this case asserts.
+        rep_titles_result = MagicMock()
+        rep_titles_result.fetchall.return_value = []
+
         select_result = MagicMock()
         select_result.__iter__ = MagicMock(return_value=iter([]))
 
         session = MagicMock(spec=Session)
-        session.execute.side_effect = [resolve_result, select_result]
+        session.execute.side_effect = [resolve_result, rep_titles_result, select_result]
 
         cls = _mk_classification("role_evolution", role_names=["Data Analyst"])
         result = QueryRouter().route(cls, session)
 
         assert result.routed is True
         assert result.tables_used == ["job_postings"]
-        assert session.execute.call_count == 2
+        assert session.execute.call_count == 3
 
         # First call is the pgvector resolution against canonical_roles.
         raw_resolve_sql = str(session.execute.call_args_list[0].args[0])
         assert "<=>" in raw_resolve_sql
         assert "CAST(:vec AS vector)" in raw_resolve_sql
 
-        # Second call is the consolidated role_evolution query against job_postings.
-        second_stmt = session.execute.call_args_list[1].args[0]
-        raw_sql = str(second_stmt)
+        # Third call is the consolidated role_evolution query against job_postings.
+        third_stmt = session.execute.call_args_list[2].args[0]
+        raw_sql = str(third_stmt)
         assert "jp.canonical_role_id = ANY(:resolved_role_ids)" in raw_sql
         assert "jp.job_title ILIKE" in raw_sql  # token-ILIKE still present
         # Both predicates OR'd inside a single grouping clause.
         assert " OR " in raw_sql
 
         # Resolved IDs are passed via execute params, not embedded in the text.
-        passed_params = session.execute.call_args_list[1].args[1]
+        passed_params = session.execute.call_args_list[2].args[1]
         assert passed_params.get("resolved_role_ids") == [
             "resolved-role-id-aa",
             "resolved-role-id-bb",
@@ -738,11 +744,16 @@ class TestRouteGeographicListStyle:
         resolve_result = MagicMock()
         resolve_result.fetchall.return_value = [("resolved-canonical-role-id",)]
 
+        # rep_titles_widening fetches representative_titles for the resolved IDs
+        # (PR#355 C1). Empty list keeps the assertion surface unchanged.
+        rep_titles_result = MagicMock()
+        rep_titles_result.fetchall.return_value = []
+
         list_result = MagicMock()
         list_result.__iter__ = MagicMock(return_value=iter([]))
 
         session = MagicMock(spec=Session)
-        session.execute.side_effect = [resolve_result, list_result]
+        session.execute.side_effect = [resolve_result, rep_titles_result, list_result]
 
         cls = _mk_classification(
             "geographic",
@@ -757,16 +768,16 @@ class TestRouteGeographicListStyle:
         )
 
         assert result.routed is True
-        assert session.execute.call_count == 2
+        assert session.execute.call_count == 3
 
         raw_resolve = str(session.execute.call_args_list[0].args[0])
         assert "<=>" in raw_resolve
 
-        raw_list = str(session.execute.call_args_list[1].args[0])
+        raw_list = str(session.execute.call_args_list[2].args[0])
         assert "canonical_role_id IN" in raw_list
         assert "resolved-canonical-role-id" not in raw_list
 
-        list_params = session.execute.call_args_list[1].args[1]
+        list_params = session.execute.call_args_list[2].args[1]
         assert list_params.get("crid0") == "resolved-canonical-role-id"
         assert list_params.get("city") == "El Paso"
         title_keys = [k for k in list_params if k.startswith("role_title_")]


### PR DESCRIPTION
## Summary

Three demo-readiness hotfixes for the May 6 stakeholder demo, all on the same branch. Each is independently reviewable.

| # | Commit | What it changes | Risk |
|---|---|---|---|
| **C1** | `b59b112` | Widen role resolution via `canonical_roles.representative_titles` in two routes | Low — additive ILIKE clauses, never narrows |
| **C2** | `7c365a8` | Fix curriculum role-label leak ([JIE#356](https://github.com/Building-With-Agents/job-intelligence-engine/issues/356)) | Low — additive dataclass field, surgical |
| **C3** | `7cf3cb5` | Taper curriculum confidence by employer + skill volume | Low — only `_curriculum_to_analytics_response` |

---

## C1 — Widen role resolution via `representative_titles`

Adds a second router-side widening step in two routes that query `dbo.job_postings` directly. After resolving free-text role names to `canonical_role_id`s via embedding similarity, the router now ALSO pulls each resolved role's `representative_titles` and OR-matches them against `jp.job_title`.

**Why:** After the 2026-05-02 re-cluster, 47.7% of `dbo.job_postings` rows have `canonical_role_id IS NULL`. Those postings are unreachable via the existing `canonical_role_id IN (resolved_ids)` predicate — they only get matched via the verbatim user-word ILIKE fallback. Many of those NULL-canonical postings DO genuinely belong to a resolved role family — their `job_title` matches a known `representative_title` of one of the canonical roles.

**Live SQL simulation (Gary's SoT DB, 2026-05-02):**

```
Resolved roles:
  Senior Healthcare Data Analyst, Data Scientist,
  Law Enforcement Data Analyst, Data Analyst in Public Health,
  HRIS Data Analyst

OLD path (canonical IN + user-word ILIKE): 99 postings
NEW path (above + rep_titles ILIKE):       134 postings
DELTA: +35 postings (+35% increase)
```

**What changes:** New helper `QueryRouter._resolve_representative_titles(canonical_role_ids, session, *, max_titles=25)` returns the deduplicated union of `representative_titles` for the given canonical_role_ids, capped at 25 to keep the OR'd ILIKE clause tractable. Wired into `_route_role_evolution` (~line 778) and the geographic-list route (~line 1271). Workflow route is unaffected. Logs emit `rep_titles_count` alongside `resolved_count` for observability.

---

## C2 — Fix curriculum role-label leak ([JIE#356](https://github.com/Building-With-Agents/job-intelligence-engine/issues/356))

Curriculum-path synthesis was rendering the raw `canonical_role_id` UUID into the "Role:" line of every curriculum answer:

```
## Program scope
- **Role:** 15b0f651-0cfa-5f0b-9f83-f9f47c109587
```

The label was already fetched by `_match_canonical_role()` but discarded at the call site, so the synthesis LLM only had the UUID to render.

**Fix is additive and minimal:**
- `CurriculumInputs` gains a `canonical_role_label` field (default `None`)
- `build_curriculum_inputs()` captures the label instead of discarding it
- `curriculum_synthesis._USER_TEMPLATE` renames the placeholder to `{canonical_role_label}`; the `.format()` call falls back to UUID then `"Unknown role"` to stay render-safe
- The UUID remains in `inputs.canonical_role` for tracing and for the truthiness gate at line 188

**Verified post-restart on hotfix branch via `test-7-candidates.py`:**
- gq-073 → `**Role:** AI Security Engineer` (was UUID)
- gq-072 → `**Role:** Autonomous AI Agent Engineer` (was UUID); 8-module rich output preserved (Virtual Vocations, Outlier, Adobe)

---

## C3 — Taper curriculum confidence by employer + skill volume

The curriculum response confidence was hardcoded to `0.9` whenever the synthesizer returned modules, regardless of how thin the underlying data was. This produced `confidence: high` on 1-of-1-sample answers (gq-073) while the answer text honestly admitted minimal evidence — a confidence/text mismatch a stakeholder would rightly distrust.

**Replaced the single `0.9` branch with a small ladder:**

```python
if is_suff and modules:
    n_emps = len(ins.top_employers or [])
    n_top_skills = len(ins.top_skills or [])
    if n_emps >= 5 and n_top_skills >= 5:
        out_conf = 0.9      # high
    elif n_emps >= 2 and n_top_skills >= 3:
        out_conf = 0.7      # medium
    else:
        out_conf = 0.5      # low
```

**Out of scope:** the shared `_blend_confidence` formula in `evidence.py` (governs comparison/geographic/workflow/trend/role_evolution/emergence/disruption) is intentionally NOT touched — too broad-reach for the 4-day demo window.

**Verified:**
- gq-073: `high` → `low` (1-of-1 sample data; signal now matches text)
- gq-072: stays `high` (rich data: 5 employers, 8+ top skills)
- All 5 non-curriculum candidates: confidence labels stable

---

## Locked May 6 demo set (6 questions)

All live-verified against `localhost:8012/api/laborpulse/query` post-fix. Demo prompts are **de-Borderplex'd** — the regional filter was redundant given the dataset is Borderplex-only and the curriculum path's regional anchor is hardcoded in `curriculum_path._REGION_LABEL`. Future tenant-scoped resolver will derive region from user access; these prompts are forward-compatible.

| # | gq | intent | confidence | evidence | cost | demo angle |
|---|---|---|---|---|---|---|
| 1 | gq-052 | comparison | high | 10 | $0.0049 | Cloud (33+5) > Cyber (14+5) — clean numeric contrast |
| 2 | gq-060 | comparison | medium | 8 | $0.0046 | "Continuous Integration" 29 vs "CI/CD" 15 — terms aren't interchangeable |
| 3 | gq-072 | curriculum | high | 4 | $0.00 | 8-module AI-agent-dev curriculum, named employers (Virtual Vocations, Outlier, Adobe) |
| 4 | gq-073 | curriculum | **low** | 4 | $0.00 | 1-of-1 cybersec — calibration showcase paired with #3 |
| 5 | gq-081 (reworded) | workflow | medium | 49 | $0.0210 | CI/CD + IaC tools (Terraform, K8s, AWS, Azure); honest sequence-not-surfaced hedge |
| 6 | gq-087 (reworded) | workflow | medium | 49 | $0.0212 | MLOps honest-limits — names AI Solutions Architect roles |

**Total demo cost ≈ $0.066 per full run-through.**

**Calibration narrative:** gq-072 (rich data → high) vs gq-073 (1-of-1 → low) demonstrates that the system's confidence labels are **calibrated**, not boilerplate.

**Demo prompts** (golden corpus stays untouched per [JIE#357](https://github.com/Building-With-Agents/job-intelligence-engine/issues/357); demo runner uses these reworded variants):

1. *"How does demand for Cloud Computing skills compare to Cybersecurity skills — which domain has more job postings?"*
2. *"How does demand for Continuous Integration skills compare to CI/CD skills — are employers using these terms interchangeably or is one more prevalent?"*
3. *"What should an AI agent developer training program cover given current postings — which LLM frameworks (LangChain, LangGraph), orchestration patterns, and integration skills are in demand?"*
4. *"What should a cybersecurity training program cover given current cybersecurity postings — which certifications, tools, and AI-augmentation skills should be included?"*
5. *"What CI/CD, release automation, and infrastructure-as-code skills appear in active IT job postings, and what does the typical build / test / deploy sequence look like in `extracted_intelligence` tasks?"*
6. *"What MLOps and model-lifecycle steps (training → deploy → monitor) appear in IT job postings, and which tasks in `extracted_intelligence` support answering 'what happens in what order'?"*

gq-081 + gq-087 each verified 3/3 stable runs at medium / 49 evidence / ~$0.021 / ~13s. The phrase **"IT job postings"** (not "IT postings") is required for both — the role-extractor's noun-phrase parsing is brittle without "job" and routes to a narrower role family.

---

## Test plan

- [ ] Pull this branch on the JIE-running machine and restart `python scripts/run_analytics_api.py`
- [ ] Re-run `python C:/Users/garyl/AppData/Local/Temp/test-final-6.py` against wfd-os LaborPulse — confirm 6/6 match the table above
- [ ] Confirm no UUIDs appear in any curriculum answer's `## Program scope` block
- [ ] Confirm gq-073 reports `confidence: low` (not `high`) and gq-072 stays `high`
- [ ] Optional: full eval baseline against `dev-verify-2026-05-01.json` — expect `evidence_citation` mean flat-or-improved
- [ ] No regression on any of the 90 golden questions (changes only ADD data or rename a prompt placeholder)

---

## Risk

Low across all three commits.
- C1 only OR's additional ILIKE clauses — never narrows.
- C2 is an additive dataclass field with default `None`; existing call sites and tests unchanged.
- C3 only touches `_curriculum_to_analytics_response`; non-curriculum confidence path untouched.

---

## Connects to

- [JIE#341](https://github.com/Building-With-Agents/job-intelligence-engine/issues/341) — Pair D demo readiness P0 (this PR delivers the locked demo set)
- [JIE#356](https://github.com/Building-With-Agents/job-intelligence-engine/issues/356) — UUID leak (closed by C2)
- [JIE#357](https://github.com/Building-With-Agents/job-intelligence-engine/issues/357) — workflow router role-extraction instability (filed during this work, deferred post-demo to Pair D)
- IMP-033 reading on curriculum-planning — surfaced JIE#356 + JIE#357 during live setup verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
