### PR TITLE
Week 10 eval baseline — #340 #344 #345

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -44,6 +44,10 @@ python -m eval.qa_eval --prompt-version v1-baseline
 
 > Corpus is 9 intents × 10 golden questions. The full baseline requires all rubrics authored; rows with empty `must_include` will distort `evidence_citation`.
 
+### Pair C geographic + comparison cohort (`--cohort pair-c-geo-comp`)
+
+Expands to **`gq-041` … `gq-060`** (20 golden rows). Optional **`--golden-ids id1,id2,...`** trims to an explicit list; when that list is **non-empty** after parsing, it **overrides** `--cohort` and **`--limit`**. Filtered questions always run in **lexicographic order by `id`**. Run summaries (`--json` / `--output-json`) include per-item **`composite`** (same definition as `eval.qa_scoring.composite_score`) and run-level **`composite_mean`**, **`composite_p25`**, **`composite_p25_method`**.
+
 ### Smoke (3 questions, no Langfuse)
 
 Runs locally without calling Langfuse (no keys required):

--- a/eval/qa_eval.py
+++ b/eval/qa_eval.py
@@ -8,11 +8,17 @@ When applicable, per-item ``answerability`` and ``correct_refusal`` are also
 emitted (not part of the four-metric mean). Run-level includes ``mean_*`` and
 ``refusal_correctness_rate`` / ``mean_answerability`` with cohort comments.
 
+**Pair C cohort (#340):** ``--cohort pair-c-geo-comp`` → ``gq-041``..``gq-060``; optional
+``--golden-ids`` (non-empty overrides cohort and ``--limit``). Filtered questions run in
+lexicographic ``id`` order. JSON adds per-item ``composite`` and run-level ``composite_mean`` /
+``composite_p25`` / ``composite_p25_method`` (see ``eval.qa_scoring.composite_score``).
+
 Usage (repo root, venv active)::
 
     python -m eval.qa_eval --prompt-version v1-baseline
     python -m eval.qa_eval --prompt-version v1-baseline --limit 3 --dry-run
     python -m eval.qa_eval --prompt-version v1-baseline --dry-run --json > summary.json
+    python -m eval.qa_eval --prompt-version pairc-smoke --cohort pair-c-geo-comp --dry-run --json
 """
 
 from __future__ import annotations
@@ -20,6 +26,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import statistics
 import sys
 import time
 from pathlib import Path
@@ -39,6 +46,10 @@ load_dotenv(_REPO_ROOT / ".env")
 from analytics.query_engine.routing import run_analytics_qna  # noqa: E402
 from common.data_store.database import session_scope  # noqa: E402
 from common.llm_adapter import resolve_llm_route  # noqa: E402
+from eval.qa_eval_cohorts import (  # noqa: E402
+    filter_and_sort_golden_questions,
+    resolve_cohort_allowed_ids,
+)
 from eval.qa_eval_laborpulse_headers import laborpulse_analytics_query_headers  # noqa: E402
 from eval.qa_scoring import (  # noqa: E402
     QAItemScores,
@@ -217,6 +228,36 @@ def _task_factory(
     return task
 
 
+def _composite_distribution(values: list[float]) -> dict[str, Any]:
+    """Run-level composite mean and first quartile (``eval.qa_scoring.composite_score`` per item)."""
+    if not values:
+        return {
+            "composite_mean": None,
+            "composite_p25": None,
+            "composite_p25_method": None,
+        }
+    mean_v = sum(values) / len(values)
+    method = "statistics.quantiles(data, n=4, method='inclusive')[0]"
+    if len(values) == 1:
+        p25_v = values[0]
+        method = "single_item: p25 equals composite (n=1)"
+    else:
+        try:
+            p25_v = statistics.quantiles(values, n=4, method="inclusive")[0]
+        except statistics.StatisticsError:
+            p25_v = mean_v
+            method = "fallback_mean (StatisticsError from quantiles — insufficient distinct values)"
+    return {
+        "composite_mean": round(mean_v, 6),
+        "composite_p25": round(float(p25_v), 6),
+        "composite_p25_method": method,
+    }
+
+
+def _composite_distribution_from_rows(rows: list[tuple[str, QAItemScores, str | None]]) -> dict[str, Any]:
+    return _composite_distribution([composite_score(sc) for _, sc, _ in rows])
+
+
 def _answerability_run_summary(
     item_results: list,
 ) -> tuple[int, int, float | None]:
@@ -285,6 +326,13 @@ def _evaluator_factory(sla_seconds: float | None):
         if scores.answerability is not None:
             ab_c = (scores.comments.get("answerability") or "")[:500]
             evals.append(Evaluation(name="answerability", value=float(scores.answerability), comment=ab_c))
+        evals.append(
+            Evaluation(
+                name="composite",
+                value=float(composite_score(scores)),
+                comment="mean of scorable core four; eval.qa_scoring.composite_score",
+            )
+        )
         return evals
 
     return combined_evaluator
@@ -310,6 +358,7 @@ def _run_evaluators_average() -> list:
             "latency_sla": [],
             "answerability": [],
             "correct_refusal": [],
+            "composite": [],
         }
         for ir in item_results:
             for ev in getattr(ir, "evaluations", []) or []:
@@ -360,6 +409,18 @@ def _run_evaluators_average() -> list:
             pr = sum(ab) / len(ab)
             cmt = f"n={n_scored} intent_only_skipped={n_skip} pass_rate={pr:.4f}"
             out.append(Evaluation(name="mean_answerability", value=pr, comment=cmt))
+
+        comp_vals = sums["composite"]
+        if comp_vals:
+            n_excl = n_total - len(comp_vals)
+            cmt = f"n_scored={len(comp_vals)} n_excluded={n_excl} n_total={n_total}"
+            out.append(
+                Evaluation(
+                    name="mean_composite",
+                    value=sum(comp_vals) / len(comp_vals),
+                    comment=cmt,
+                )
+            )
 
         def _mavg(k: str) -> float | None:
             xs = sums.get(k) or []
@@ -644,7 +705,18 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--prompt-version", required=True, help="Run name / version tag (e.g. v1-baseline)")
     p.add_argument("--json-path", type=Path, default=DEFAULT_JSON_PATH, help="Golden questions JSON")
     p.add_argument("--dataset-name", default=DEFAULT_DATASET_NAME, help="Langfuse dataset name")
-    p.add_argument("--limit", type=int, default=None, help="Evaluate only first N questions")
+    p.add_argument("--limit", type=int, default=None, help="Evaluate only first N questions (ignored with --cohort/--golden-ids)")
+    p.add_argument(
+        "--cohort",
+        default=None,
+        help="Named golden cohort (e.g. pair-c-geo-comp → gq-041..gq-060). Ignored when --golden-ids is non-empty.",
+    )
+    p.add_argument(
+        "--golden-ids",
+        default=None,
+        metavar="IDS",
+        help="Comma-separated golden question ids; non-empty list overrides --cohort and --limit.",
+    )
     p.add_argument("--dry-run", action="store_true", help="Do not call Langfuse; still run Q&A and print summary")
     p.add_argument(
         "--use-http",
@@ -683,7 +755,24 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     golden_by_id = {str(r["id"]): r for r in all_questions}
-    questions = all_questions[: max(0, args.limit)] if args.limit is not None else all_questions
+
+    try:
+        allowed_ids = resolve_cohort_allowed_ids(cohort=args.cohort, golden_ids_csv=args.golden_ids)
+    except ValueError as exc:
+        log.error("cohort_resolve_failed", error=str(exc))
+        return 1
+
+    cohort_or_golden = allowed_ids is not None
+    if cohort_or_golden:
+        if args.limit is not None:
+            log.warning(
+                "cohort_ignores_limit",
+                limit=args.limit,
+                msg="--limit ignored when --cohort or non-empty --golden-ids is active",
+            )
+        questions = filter_and_sort_golden_questions(all_questions, allowed_ids)
+    else:
+        questions = all_questions[: max(0, args.limit)] if args.limit is not None else all_questions
 
     from eval._config import qa_latency_sla_seconds
 
@@ -716,6 +805,7 @@ def main(argv: list[str] | None = None) -> int:
                         "latency_sla": sc.latency_sla,
                         "answerability": sc.answerability,
                         "correct_refusal": sc.correct_refusal,
+                        "composite": round(composite_score(sc), 6),
                     },
                     "error": err,
                 }
@@ -747,6 +837,7 @@ def main(argv: list[str] | None = None) -> int:
                 f"{e}->{p}": c for (e, p), c in sorted(confusion_rows(intent_pairs).items())
             }
             payload_local["intent_classification"] = intent_classification_report(intent_pairs)
+        payload_local.update(_composite_distribution_from_rows(rows))
 
         if args.json:
             sys.stdout.write(json.dumps(payload_local, indent=2) + "\n")
@@ -785,13 +876,18 @@ def main(argv: list[str] | None = None) -> int:
         "llm_synthesis": run_synthesis_deployment,
     }
 
-    # Hosted dataset run only when using the full uploaded dataset (--limit uses local JSON experiment).
-    use_hosted_dataset = not args.local_experiment_only and args.limit is None
+    # Hosted dataset run only when using the full uploaded dataset (--limit or cohort uses local JSON).
+    use_hosted_dataset = not args.local_experiment_only and args.limit is None and not cohort_or_golden
     if args.limit is not None and not args.dry_run:
         log.warning(
             "limit_forces_local_langfuse_experiment",
             limit=args.limit,
             msg="Dataset run linking to LaborPulse Golden Questions requires full corpus; using local JSON for this run.",
+        )
+    if cohort_or_golden and not args.dry_run and not args.local_experiment_only:
+        log.warning(
+            "cohort_forces_local_langfuse_experiment",
+            msg="Named cohort / golden-ids subset uses local JSON experiment (not hosted dataset items).",
         )
 
     try:
@@ -839,6 +935,12 @@ def main(argv: list[str] | None = None) -> int:
         "n_intent_only_skipped": n_items - len(ab_vals),
         "pass_rate": (sum(ab_vals) / len(ab_vals)) if ab_vals else 0.0,
     }
+    comp_lf: list[float] = []
+    for it in items_out:
+        cv = (it.get("scores") or {}).get("composite")
+        if isinstance(cv, (int, float)):
+            comp_lf.append(float(cv))
+
     payload_lf: dict[str, Any] = {
         "prompt_version": args.prompt_version,
         "dataset_run_id": result.dataset_run_id,
@@ -846,6 +948,7 @@ def main(argv: list[str] | None = None) -> int:
         "answerability_summary": answerability_summary,
         "items": items_out,
     }
+    payload_lf.update(_composite_distribution(comp_lf))
     if args.json:
         sys.stdout.write(json.dumps(payload_lf, indent=2) + "\n")
     else:

--- a/eval/qa_eval.py
+++ b/eval/qa_eval.py
@@ -705,7 +705,9 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--prompt-version", required=True, help="Run name / version tag (e.g. v1-baseline)")
     p.add_argument("--json-path", type=Path, default=DEFAULT_JSON_PATH, help="Golden questions JSON")
     p.add_argument("--dataset-name", default=DEFAULT_DATASET_NAME, help="Langfuse dataset name")
-    p.add_argument("--limit", type=int, default=None, help="Evaluate only first N questions (ignored with --cohort/--golden-ids)")
+    p.add_argument(
+        "--limit", type=int, default=None, help="Evaluate only first N questions (ignored with --cohort/--golden-ids)"
+    )
     p.add_argument(
         "--cohort",
         default=None,

--- a/eval/qa_eval_cohorts.py
+++ b/eval/qa_eval_cohorts.py
@@ -1,0 +1,59 @@
+﻿"""Golden-question cohort allowlists for Q&A eval (Pair C Week 10).
+
+``--golden-ids`` overrides ``--cohort`` when the parsed ID list is non-empty.
+See ``eval/qa_eval.py`` argparse help for precedence.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+PAIR_C_GEO_COMP_COHORT = "pair-c-geo-comp"
+PAIR_C_GEO_COMP_IDS: tuple[str, ...] = tuple(f"gq-{i:03d}" for i in range(41, 61))
+
+
+def parse_golden_ids_csv(raw: str | None) -> list[str]:
+    """Split comma-separated golden ids; trim whitespace; drop empties."""
+    if not raw or not str(raw).strip():
+        return []
+    return [p.strip() for p in str(raw).split(",") if p.strip()]
+
+
+def resolve_cohort_allowed_ids(
+    *,
+    cohort: str | None,
+    golden_ids_csv: str | None,
+) -> list[str] | None:
+    """Return allowlist of golden ``id`` strings, or ``None`` for full corpus.
+
+    Precedence:
+    1. If ``golden_ids_csv`` parses to a non-empty list → use those ids (caller sorts).
+    2. Else if ``cohort`` is ``pair-c-geo-comp`` → fixed Pair C geographic + comparison ids.
+    3. Else if ``cohort`` is set → unknown cohort, raise.
+    4. Else → ``None`` (full corpus, subject to ``--limit`` in the caller).
+    """
+    explicit = parse_golden_ids_csv(golden_ids_csv)
+    if explicit:
+        return explicit
+    if cohort is None or not str(cohort).strip():
+        return None
+    c = str(cohort).strip()
+    if c == PAIR_C_GEO_COMP_COHORT:
+        return list(PAIR_C_GEO_COMP_IDS)
+    raise ValueError(f"Unknown --cohort {c!r}; supported: {PAIR_C_GEO_COMP_COHORT!r}")
+
+
+def filter_and_sort_golden_questions(
+    all_questions: list[dict[str, Any]],
+    allowed_ids: list[str],
+) -> list[dict[str, Any]]:
+    """Return golden rows for ``allowed_ids``, sorted lexicographically by ``id``.
+
+    Raises ``ValueError`` if any id is missing from the corpus.
+    """
+    golden_by_id = {str(r["id"]): r for r in all_questions}
+    missing = [i for i in allowed_ids if i not in golden_by_id]
+    if missing:
+        raise ValueError(f"Golden file missing ids (check --golden-ids / --cohort): {missing}")
+    rows = [golden_by_id[i] for i in allowed_ids]
+    return sorted(rows, key=lambda r: str(r["id"]))

--- a/eval/qa_eval_cohorts.py
+++ b/eval/qa_eval_cohorts.py
@@ -1,4 +1,4 @@
-﻿"""Golden-question cohort allowlists for Q&A eval (Pair C Week 10).
+"""Golden-question cohort allowlists for Q&A eval (Pair C Week 10).
 
 ``--golden-ids`` overrides ``--cohort`` when the parsed ID list is non-empty.
 See ``eval/qa_eval.py`` argparse help for precedence.

--- a/eval/qa_prompt_iteration_log.md
+++ b/eval/qa_prompt_iteration_log.md
@@ -22,6 +22,7 @@ adopted from v2 onward per IMP-030 / JIE #287).
 | `nestor-baseline` | 2026-04-30 | Nestor | Langfuse UI annotation | Human annotation of gq-031..gq-040 (10 of 90 items); all 3 scores per question. Reconstructed from chronological order on trace `84ab514155f87ac26` — Langfuse queue applied all annotations to one trace rather than each question's trace. Mapping confirmed by annotator. | — | — | correctness=**0.25** (n=10), decision_relevance=**0.10** (n=10), followup_quality=**0.30** (n=10) | [`eval/runs/nestor_baseline_run_langfuse_annotations.json`](runs/nestor_baseline_run_langfuse_annotations.json) |
 | `nestor-v2-role-evolution-fix` | 2026-04-30 | Nestor | v2 automated scorer | **Atomic fix:** `_route_role_evolution` rewritten to query `job_postings GROUP BY temporal_period` instead of static `canonical_roles` snapshot. On gq-031..040: `correct_refusal` **+0.30** (0.70→1.00), `must_include_recall` **+0.09** (0.68→0.78). Three previously-refusing questions (gq-032, gq-035, gq-036) now produce data-backed answers. `extracted_intelligence` skill data still absent — see DEV-005. Human annotation pending. | — | **0.52** (n=50) | *pending annotation* | — |
 | `dev-verify-2026-05-01` | 2026-05-01 | Gary (post-merge re-audit) | v2 automated scorer | **Post-merge re-audit** of `origin/development` after #288/#294/#295/#335/#336/#337 squash-merged. Run against Gary's SoT DB. Headline: `intent_accuracy` 0.822 (regressed from 1.000 — 16/90 misclassifications), `evidence_citation` 0.571 (regressed from 0.752 — driven by employer 10/10 refusing on `_route_employer` ILIKE bug + disruption 10/10 refusing on `skill_taxonomy_gate_blocked`), `confidence_self_consistency` 0.973 (improved), `latency_sla` 1.000, `answerability` 0.460 (improved). Filed 3 regression-fix issues with regression-discipline pivots: #346 (Pair D, employer router), #347 (Pair A, disruption narrow scoping — includes gq-026 golden label review as a sub-task), #348 (Pair C, geographic add-only fix). Filed #349 backlog (taxonomy expansion). Step-9 ranking: 51/90 demo-eligible, all of Pair D's curation criteria green. | **0.698** geo | **0.460** (n=50) | — | [`eval/runs/findings-dev-verify-2026-05-01.md`](runs/findings-dev-verify-2026-05-01.md) |
+| `pairc-week10-harness` | 2026-05-04 | Pair C | v2 | **#340 harness:** cohort CLI (`--cohort pair-c-geo-comp`, `--golden-ids` precedence), lexicographic run order, per-item + run-level **composite** in JSON, Langfuse `Evaluation(name="composite")` + `mean_composite`. Iteration cycles document methodology; headline scores require a DB-backed `--dry-run` or Langfuse re-run — see Pair C table below and [`eval/runs/qa-pairc-week10-harness-contract.json`](runs/qa-pairc-week10-harness-contract.json). | — | — | — | [`eval/runs/findings-pairc-cycle1-baseline.md`](runs/findings-pairc-cycle1-baseline.md) |
 
 > **v2 vs v2.1 note:** scorer logic did not change between v2 and v2.1.
 > The only difference is that aggregate tables were empty during the v2 run
@@ -290,6 +291,20 @@ era for the requested role, giving the synthesis the skill-evolution evidence it
 
 ---
 
+### Pair C — Week 10 cohort iteration (#340)
+
+Cumulative iteration arc over **`gq-041` … `gq-060`** (geographic + comparison). Each cycle: sort cohort by composite (worst first), inspect top **5** failures, pick **one** primary bucket (intent vs SQL vs synthesis), apply **one** stacked change. Cycles **stack** unless explicitly labeled A/B vs baseline.
+
+| Cycle | Before cohort composite (mean / p25) | Failure pattern (top-5 skew) | Single change (file + summary) | After (mean / p25) | Outcome / link |
+|-------|----------------------------------------|--------------------------------|----------------------------------|--------------------|----------------|
+| 1 | *TBD — run `python -m eval.qa_eval --prompt-version pairc-week10-c1 --cohort pair-c-geo-comp --dry-run --output-json eval/runs/qa-pairc-week10-c1.json`* | Baseline inventory | Document harness + cohort contract only (`eval/qa_eval.py`, `eval/qa_eval_cohorts.py`, composite JSON + Langfuse alignment) | — | [`findings-pairc-cycle1-baseline.md`](runs/findings-pairc-cycle1-baseline.md) |
+| 2 | — | — | *Reserved for first routing / SQL / synthesis fix once baseline numbers captured* | — | [`findings-pairc-cycle2-baseline.md`](runs/findings-pairc-cycle2-baseline.md) |
+| 3 | — | — | *Reserved for follow-on stacked change* | — | [`findings-pairc-cycle3-baseline.md`](runs/findings-pairc-cycle3-baseline.md) |
+
+**Langfuse:** When keys are present, capture **`dataset_run_id` + `dataset_run_url`** per cycle in the JSON artifact comments or iteration notes. CI remains offline for scored runs; local-only capture is acceptable per IMP-030.
+
+---
+
 ## Changelog
 
 | Date | Who | Change |
@@ -298,3 +313,4 @@ era for the requested role, giving the synthesis the skill-evolution evidence it
 | 2026-04-23 | Bryan + Emilio | v1-baseline run complete (composite 0.875, answerability 0.260); added DEV-004 for `--use-http` regression |
 | 2026-04-27 | Bryan | Restructured per JIE #287: per-run analysis moved to `eval/runs/findings*.md` pattern; log now holds version history table + DEV registry only. Added v2 and v2.1 rows; updated DEV-004 status to Resolved |
 | 2026-04-30 | Nestor | Added `nestor-baseline` human-annotation row (Langfuse reconstruction); added `nestor-v2-role-evolution-fix` row with final automated-score results; created `findings_nestor_v2_role_evolution_fix.md`; documented DEV-005 |
+| 2026-05-04 | Pair C | #340 harness: cohort + golden-id precedence, composite JSON + Langfuse `composite` / `mean_composite`; Pair C iteration table + cycle findings stubs; contract JSON |

--- a/eval/runs/findings-employer-drilldown-baseline.md
+++ b/eval/runs/findings-employer-drilldown-baseline.md
@@ -1,0 +1,60 @@
+# Employer drill-down — Ask the Data Q&A baseline (#344)
+
+## Snapshot header
+
+| Field | Value |
+|-------|--------|
+| **Date** | 2026-05-04 |
+| **Branch / SHA** | `fix/week10-eval-baseline-340-344-345` (see git at commit time) |
+| **DB provenance** | Local / SoT PostgreSQL via `PYTHON_DATABASE_URL` (not bundled with repo). |
+| **`job_postings` approx. count** | *Populate from* `SELECT COUNT(*) FROM dbo.job_postings` *on your DB* (Week 9 audit cited **~2,696** postings on the audited snapshot; see [`week-09-temporal-employer-audit.md`](../../docs/findings/week-09-temporal-employer-audit.md)). |
+
+---
+
+## Q&A path
+
+- **Default harness path:** in-process `run_analytics_qna` (`analytics.query_engine.routing`).
+- **Optional:** `python -m eval.qa_eval --use-http --analytics-base-url …` for wire-level parity with deployed `POST /analytics/query`.
+
+---
+
+## SQL guardrails — `validate_ask_the_data_sql`
+
+NL-generated SQL is validated in **`analytics/query_engine/sql_guardrails.py`** via **`validate_ask_the_data_sql(sql) -> (ok, reason, normalized_sql)`** (SELECT-only, allowed tables, row cap, timeout semantics per tests in `analytics/query_engine/tests/test_ask_the_data_guardrails.py`).
+
+**Allowlist (employer drill-down relevant):**
+
+- **`dbo.employer_profiles`** — employer attributes keyed for stakeholder drill-down.
+- **`dbo.skill_demand_weekly`** — weekly skill demand; carries **`employer_count`** (IMP-021 / distinct employers in the bucket; see `common.data_store.models.SkillDemandWeekly` and `.cursor/rules/skill-tool-demand.mdc`).
+
+Hop-by-hop row counts and orphan analysis for the “data engineer” style path are automated in **`scripts/employer_drill_down_audit.py`**. On Windows, prefer:
+
+```powershell
+$env:PYTHONIOENCODING = "utf-8"
+python scripts/employer_drill_down_audit.py
+```
+
+---
+
+## Evidence chain (conceptual)
+
+1. **`skill_demand_weekly`** — filter by `skill_label` / `week_start`; read `posting_count`, **`employer_count`**.
+2. **`extracted_intelligence`** / **`normalized_jobs`** / **`job_postings`** — promotion chain for posting-level evidence.
+3. **`companies`** — name / geo / sector joins.
+4. **`employer_profiles`** — `company_id` join; `is_known_employer`, sector, size band.
+
+Week 9 audit (**#289**-class data gaps if `employer_profile_id` null on postings) is summarized in [`docs/findings/week-09-temporal-employer-audit.md`](../../docs/findings/week-09-temporal-employer-audit.md): structural validity of the join graph vs fixture-era NULL FKs and orphaned `normalized_jobs`.
+
+---
+
+## Risks / follow-ups
+
+- **Orphans:** `normalized_jobs` without `job_postings` promotion inflate “missing evidence” in Q&A traces; distinguish from SQL refusal.
+- **Employer profile FK:** until `job_postings.employer_profile_id` is populated, drill-down from postings → `employer_profiles` may be empty even when profiles exist (**#289**).
+- **Sector join quality:** `skill_demand_weekly` ↔ `sector_summary_weekly` may return sparse “Other” buckets until NAICS backfill (Week 9 doc §6).
+
+---
+
+## Acceptance note
+
+This file satisfies the **documentation** checklist for #344; remaining gaps (live row counts, post-fix re-audit) are tracked in the PR body if using **`Refs #344`**.

--- a/eval/runs/findings-geographic-borderplex-baseline.md
+++ b/eval/runs/findings-geographic-borderplex-baseline.md
@@ -1,0 +1,42 @@
+# Geographic Borderplex — Q&A baseline (#345)
+
+## Snapshot header
+
+| Field | Value |
+|-------|--------|
+| **Date** | 2026-05-04 |
+| **Branch / SHA** | `fix/week10-eval-baseline-340-344-345` (see git at commit time) |
+| **DB provenance** | Local / SoT PostgreSQL via `PYTHON_DATABASE_URL`. |
+| **`job_postings` approx. count** | *Run on your DB* (Week 9 table cited **~2,696** on audited snapshot). |
+
+---
+
+## Location signals
+
+- **Posting-level:** `job_postings` location fields (city / state / zip / county text) vs enrichment-derived **`borderplex_subregion`**.
+- **`borderplex_subregion` enum (integration contract):** `el_paso` \| `las_cruces` \| `ciudad_juarez` \| `regional` \| `unknown` (see `.cursor/rules/integration-schema.mdc`).
+
+---
+
+## Aggregates — `geo_demand_weekly` vs city-level
+
+- **`geo_demand_weekly`** rolls demand into **Borderplex subregion buckets** only (not full street-level or arbitrary city polygons). For stakeholder questions that imply “El Paso city limits” vs “Las Cruces MSA”, the aggregate may answer at **subregion** grain only.
+- **Gap taxonomy:**
+  - **Data normalization** — missing or coarse `borderplex_subregion` labels on postings; sparse `geo_demand_weekly` rows for a week.
+  - **Prompt / router** — classifier picks `geographic` but router returns `skill_demand_weekly` without geo predicates (see Week 9 trend example in [`week-09-temporal-employer-audit.md`](../../docs/findings/week-09-temporal-employer-audit.md) for “geo terms ignored” class of bug).
+
+---
+
+## Sample gold slice — `gq-041` … `gq-050`
+
+Geographic + comparison Pair C questions in this id band should be re-run with the harness after DB refresh. **Capture row counts** at each evidence step (SQL result `row_count_returned`, intermediate hops if traced) and paste into a future iteration row.
+
+| ID | Intent (golden) | Row-count capture |
+|----|-----------------|-------------------|
+| gq-041 … gq-050 | *per `qa_golden_questions.json`* | *TBD — fill on scored `--dry-run`* |
+
+---
+
+## Acceptance note
+
+Baseline narrative and checklist for #345; scored re-run artifacts can ship in a follow-up PR if needed (**`Refs #345`** vs **`Fixes #345`** per acceptance).

--- a/eval/runs/findings-pairc-cycle1-baseline.md
+++ b/eval/runs/findings-pairc-cycle1-baseline.md
@@ -1,0 +1,26 @@
+# Pair C cohort — Cycle 1 baseline inventory (#340)
+
+**Run date:** 2026-05-04  
+**Branch:** `fix/week10-eval-baseline-340-344-345` (pre-SHA: commit after #340 lands)  
+**Cohort:** `gq-041` … `gq-060` via `--cohort pair-c-geo-comp`  
+**Scorer:** v2 (`eval/qa_scoring.py`)
+
+---
+
+## Scope (harness-only cycle)
+
+This cycle **does not** assert a numeric baseline from a fresh Langfuse or `--dry-run` run in CI. It **locks the evaluation contract**:
+
+- Cohort expansion and **lexicographic** execution order (`eval/qa_eval_cohorts.py`).
+- JSON export: per-item **`composite`** aligned with `composite_score`, plus **`composite_mean`**, **`composite_p25`**, **`composite_p25_method`**.
+- Langfuse: per-item **`Evaluation(name="composite")`** and run-level **`mean_composite`** when traces exist.
+
+## Next cycles (stacked)
+
+1. Re-run `python -m eval.qa_eval --prompt-version pairc-week10-c1 --cohort pair-c-geo-comp --dry-run --output-json eval/runs/qa-pairc-week10-c1.json` against a populated SoT DB; paste **mean / p25** into `qa_prompt_iteration_log.md` Pair C table.
+2. Sort by composite (worst first); classify top-5 failures into intent vs SQL vs synthesis; pick **one** code or prompt change; repeat for cycles 2–3.
+
+## References
+
+- [`eval/runs/findingsv2.md`](findingsv2.md) — findings template.
+- [`eval/runs/qa-pairc-week10-harness-contract.json`](qa-pairc-week10-harness-contract.json) — JSON shape contract.

--- a/eval/runs/findings-pairc-cycle2-baseline.md
+++ b/eval/runs/findings-pairc-cycle2-baseline.md
@@ -1,0 +1,7 @@
+# Pair C cohort — Cycle 2 (reserved)
+
+**Status:** Placeholder for the **first** stacked prompt/router/SQL fix after baseline numbers are captured in cycle 1.
+
+**Procedure:** Same cohort (`gq-041` … `gq-060`), cumulative on cycle 1 unless explicitly documented as A/B vs baseline.
+
+Update this file when cycle 2 lands with: hypothesis, top-5 worst IDs, single change (paths), before/after composite mean + p25, and Langfuse `dataset_run_id` + URL if available.

--- a/eval/runs/findings-pairc-cycle3-baseline.md
+++ b/eval/runs/findings-pairc-cycle3-baseline.md
@@ -1,0 +1,5 @@
+# Pair C cohort — Cycle 3 (reserved)
+
+**Status:** Placeholder for the **second** stacked change after cycle 2.
+
+**Procedure:** Cumulative iteration; document net cohort movement (mean + p25 of per-question composite) vs cycle 1 baseline in `qa_prompt_iteration_log.md`.

--- a/eval/runs/qa-pairc-week10-harness-contract.json
+++ b/eval/runs/qa-pairc-week10-harness-contract.json
@@ -1,0 +1,33 @@
+{
+  "_comment": "Contract example for #340 JSON export (scores are illustrative only; regenerate via qa_eval --dry-run --output-json).",
+  "prompt_version": "pairc-week10-contract-example",
+  "dry_run": true,
+  "langfuse": false,
+  "composite_mean": 0.7125,
+  "composite_p25": 0.651,
+  "composite_p25_method": "statistics.quantiles(data, n=4, method='inclusive')[0]",
+  "means": {
+    "intent_accuracy": 0.85,
+    "evidence_citation": 0.62,
+    "confidence_self_consistency": 0.98,
+    "latency_sla": 0.95
+  },
+  "items": [
+    {
+      "gq_id": "gq-041",
+      "scores": {
+        "intent_accuracy": 1.0,
+        "evidence_citation": 0.55,
+        "must_include_recall": null,
+        "evidence_overlap": null,
+        "confidence_self_consistency": 1.0,
+        "confidence_in_expected_range": null,
+        "latency_sla": 0.92,
+        "answerability": 1.0,
+        "correct_refusal": null,
+        "composite": 0.8675
+      },
+      "error": null
+    }
+  ]
+}

--- a/eval/tests/test_qa_eval_cohort_filter.py
+++ b/eval/tests/test_qa_eval_cohort_filter.py
@@ -1,0 +1,57 @@
+"""Offline tests for Pair C golden cohort resolution (JIE #340)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from eval.qa_eval_cohorts import (
+    PAIR_C_GEO_COMP_COHORT,
+    filter_and_sort_golden_questions,
+    resolve_cohort_allowed_ids,
+)
+
+
+@pytest.fixture
+def golden_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "qa_golden_questions.json"
+
+
+@pytest.fixture
+def all_questions(golden_path: Path) -> list:
+    with open(golden_path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def test_pair_c_geo_comp_expands_twenty_lex_order(all_questions: list) -> None:
+    ids = resolve_cohort_allowed_ids(cohort=PAIR_C_GEO_COMP_COHORT, golden_ids_csv=None)
+    assert ids is not None
+    assert len(ids) == 20
+    assert ids == [f"gq-{i:03d}" for i in range(41, 61)]
+    rows = filter_and_sort_golden_questions(all_questions, ids)
+    assert len(rows) == 20
+    got = [str(r["id"]) for r in rows]
+    assert got == sorted(got)
+    assert got[0] == "gq-041" and got[-1] == "gq-060"
+
+
+def test_golden_ids_override_cohort(all_questions: list) -> None:
+    ids = resolve_cohort_allowed_ids(
+        cohort=PAIR_C_GEO_COMP_COHORT,
+        golden_ids_csv="gq-060,gq-041",
+    )
+    assert ids == ["gq-060", "gq-041"]
+    rows = filter_and_sort_golden_questions(all_questions, ids)
+    assert [r["id"] for r in rows] == ["gq-041", "gq-060"]
+
+
+def test_golden_ids_missing_raises(all_questions: list) -> None:
+    with pytest.raises(ValueError, match="Golden file missing ids"):
+        filter_and_sort_golden_questions(all_questions, ["gq-041", "gq-999-missing"])
+
+
+def test_unknown_cohort_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown --cohort"):
+        resolve_cohort_allowed_ids(cohort="not-a-real-cohort", golden_ids_csv=None)


### PR DESCRIPTION
## Issue to commit SHA

| Issue | Commit | Subject |
|-------|--------|---------|
| #340 | 0c76bd3 | feat(eval): Refs #340 Pair C cohort filter and QA eval composite export |
| #344 | 92b11bc | docs(eval): Refs #344 employer drill-down Q&A baseline findings |
| #345 | 47126b4 | docs(eval): Refs #345 geographic Borderplex baseline findings |

## PR checklist

- Uses **Refs** (not Fixes) where noted: #340 iteration table still has TBD DB/Langfuse numbers; #344/#345 baseline docs reference live counts to fill on SoT DB.
- **Verify:** \pytest eval/tests/\ (51 passed, 6 skipped); \uff check eval/\.

## Summary

- **#340:** \--cohort pair-c-geo-comp\, \--golden-ids\ precedence, ignore \--limit\ when cohort/golden active; lexicographic order; JSON \composite\ + run quartiles; Langfuse \composite\ + \mean_composite\; offline tests; iteration log + cycle stubs + contract JSON.
- **#344 / #345:** Baseline findings markdown under \eval/runs/\.

Made with [Cursor](https://cursor.com)