### PR TITLE
Week 12: Fix #370 Model vs DB Drift (Fabian)

### DIFF
--- a/common/data_store/models.py
+++ b/common/data_store/models.py
@@ -636,7 +636,14 @@ class Company(Base):
     """
 
     __tablename__ = "companies"
-    __table_args__ = {"schema": "dbo"}
+    # The DB has a UNIQUE INDEX on company_name (idx_16826_companies_company_name_key)
+    # inherited from the Prisma-era schema. Declaring it here keeps SQLAlchemy
+    # metadata in sync with the DB so introspection / create_all on a fresh DB
+    # produces the same shape as production. See JIE#370.
+    __table_args__ = (
+        UniqueConstraint("company_name", name="uq_companies_company_name"),
+        {"schema": "dbo"},
+    )
 
     company_id: Mapped[str] = mapped_column(Text, primary_key=True)
     industry_sector_id: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,17 +12,41 @@ import uuid
 from collections.abc import Iterator
 
 import pytest
-from sqlalchemy import create_engine, delete, select, text
+from sqlalchemy import UniqueConstraint, create_engine, delete, select, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
 from common.data_store.models import (
     Base,
+    Company,
     JobIngestionRun,
     NormalizedJob,
     RawIngestedJob,
 )
+
+
+def test_company_model_declares_unique_company_name() -> None:
+    """JIE#370 — SQLAlchemy metadata must reflect the DB UNIQUE INDEX on
+    ``dbo.companies.company_name``.
+
+    Pure metadata check: runs without ``PYTHON_DATABASE_URL`` so the model
+    declaration itself is exercised in CI even when no Postgres is wired up.
+    """
+    unique_constraints = [
+        c
+        for c in Company.__table__.constraints
+        if isinstance(c, UniqueConstraint)
+    ]
+    on_company_name = [
+        c
+        for c in unique_constraints
+        if [col.name for col in c.columns] == ["company_name"]
+    ]
+    assert on_company_name, (
+        "Company.company_name must be declared UNIQUE in SQLAlchemy metadata "
+        "to match the existing dbo.companies UNIQUE INDEX (JIE#370)."
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -33,16 +33,8 @@ def test_company_model_declares_unique_company_name() -> None:
     Pure metadata check: runs without ``PYTHON_DATABASE_URL`` so the model
     declaration itself is exercised in CI even when no Postgres is wired up.
     """
-    unique_constraints = [
-        c
-        for c in Company.__table__.constraints
-        if isinstance(c, UniqueConstraint)
-    ]
-    on_company_name = [
-        c
-        for c in unique_constraints
-        if [col.name for col in c.columns] == ["company_name"]
-    ]
+    unique_constraints = [c for c in Company.__table__.constraints if isinstance(c, UniqueConstraint)]
+    on_company_name = [c for c in unique_constraints if [col.name for col in c.columns] == ["company_name"]]
     assert on_company_name, (
         "Company.company_name must be declared UNIQUE in SQLAlchemy metadata "
         "to match the existing dbo.companies UNIQUE INDEX (JIE#370)."


### PR DESCRIPTION
## Summary
Resolves #370

This PR fixes a model-vs-db drift issue by explicitly declaring the `UNIQUE` constraint on `company_name` within the SQLAlchemy `Company` model. 

The underlying database already enforces this uniqueness via the `idx_16826_companies_company_name_key` index (carried over from Prisma), but the SQLAlchemy model was missing the formal declaration. This is a pure correctness/hygiene fix to ensure tooling that introspects the model (like Alembic migrations or test fixtures) generates the correct schema.

## Changes Made
* Updated `common/data_store/models.py` to include `UniqueConstraint("company_name", name="uq_companies_company_name")` in the `Company` model's `__table_args__`.

## Acceptance Criteria Checklist
* [x] `Company` model in `common/data_store/models.py` declares the `UniqueConstraint`.
* [x] Schema dump generated via `Base.metadata.create_all(engine)` against a fresh DB now matches the source-of-truth `dbo.companies` table.
* [x] Confirmed Azure DB possesses the equivalent unique-on-name index. 
* [x] Verified no regressions on company-resolution paths (`enrichment.resolvers.company_resolver.resolve_company`).