### PR TITLE
docs: Phase 2 EXEMPLAR markers (dedup, Pass 1, savepoint, SOC coercion)

### DIFF
--- a/enrichment/classifiers/soc_classifier.py
+++ b/enrichment/classifiers/soc_classifier.py
@@ -98,7 +98,6 @@ def _digits_to_canonical_codes(candidate_codes: set[str]) -> dict[str, str]:
     return {k: v[0] for k, v in buckets.items() if len(v) == 1}
 
 
-# EXEMPLAR: Phase 2 reference — LLM output coercion
 # Maps free-text model replies back to a member of the candidate code set or to unclassified.
 def _resolve_llm_pick_with_reason(raw: str, candidate_codes: set[str]) -> tuple[str, str]:
     """Return ``(picked_code_or_unclassified, reason_tag)`` for logging and auditing."""

--- a/enrichment/classifiers/soc_classifier.py
+++ b/enrichment/classifiers/soc_classifier.py
@@ -98,6 +98,8 @@ def _digits_to_canonical_codes(candidate_codes: set[str]) -> dict[str, str]:
     return {k: v[0] for k, v in buckets.items() if len(v) == 1}
 
 
+# EXEMPLAR: Phase 2 reference — LLM output coercion
+# Maps free-text model replies back to a member of the candidate code set or to unclassified.
 def _resolve_llm_pick_with_reason(raw: str, candidate_codes: set[str]) -> tuple[str, str]:
     """Return ``(picked_code_or_unclassified, reason_tag)`` for logging and auditing."""
     s = (raw or "").strip()

--- a/enrichment/classifiers/soc_classifier.py
+++ b/enrichment/classifiers/soc_classifier.py
@@ -98,7 +98,6 @@ def _digits_to_canonical_codes(candidate_codes: set[str]) -> dict[str, str]:
     return {k: v[0] for k, v in buckets.items() if len(v) == 1}
 
 
-# Maps free-text model replies back to a member of the candidate code set or to unclassified.
 def _resolve_llm_pick_with_reason(raw: str, candidate_codes: set[str]) -> tuple[str, str]:
     """Return ``(picked_code_or_unclassified, reason_tag)`` for logging and auditing."""
     s = (raw or "").strip()

--- a/enrichment/dedup/types.py
+++ b/enrichment/dedup/types.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
+# EXEMPLAR: Phase 2 reference — FuzzyDedupResult is the frozen in-process contract; apply_fuzzy_dedup_result is the sole writer path for duplicate flags, and persistence still enforces additional invariants.
+
 
 class FuzzyDedupResult(BaseModel):
     """Outcome of comparing one posting against same-company survivors in a rolling window."""

--- a/enrichment/job_postings_promotion.py
+++ b/enrichment/job_postings_promotion.py
@@ -481,6 +481,7 @@ def _cluster_member_ids(session: Session, cluster_id: str, *, exclude_job_postin
     return [str(row["job_posting_id"]) for row in rows]
 
 
+# EXEMPLAR: Phase 2 reference — fuzzy dedup persistence contract validation uses imperative ValueError checks on stub, unique-clear, and clustered survivor paths before SQL updates.
 def apply_fuzzy_dedup_result(
     session: Session,
     job_posting_id: str,
@@ -583,6 +584,8 @@ def apply_fuzzy_dedup_result(
     return True
 
 
+# EXEMPLAR: Phase 2 reference — savepoint pattern
+# Dedup runs inside session.begin_nested() so failures roll back only the savepoint, not the outer promotion transaction.
 def _apply_fuzzy_dedup_after_promotion(
     session: Session,
     *,

--- a/skills_extraction/extractors/tools.py
+++ b/skills_extraction/extractors/tools.py
@@ -14,6 +14,8 @@ Week 4 implementation (Bryan + Emilio):
 Reference: ARCHITECTURE_DEEP.md § Work Intelligence Agent — Hybrid Extraction.
 """
 
+# EXEMPLAR: Phase 2 reference — Pass 1 deterministic tool extraction (catalog, aliases, field priority) before Pass 2 LLM work.
+
 from __future__ import annotations
 
 import re

--- a/skills_extraction/extractors/tools.py
+++ b/skills_extraction/extractors/tools.py
@@ -14,8 +14,6 @@ Week 4 implementation (Bryan + Emilio):
 Reference: ARCHITECTURE_DEEP.md § Work Intelligence Agent — Hybrid Extraction.
 """
 
-# EXEMPLAR: Phase 2 reference — Pass 1 deterministic tool extraction (catalog, aliases, field priority) before Pass 2 LLM work.
-
 from __future__ import annotations
 
 import re
@@ -750,6 +748,7 @@ def _compile_aliases() -> tuple[CompiledAlias, ...]:
 COMPILED_ALIASES = _compile_aliases()
 
 
+# EXEMPLAR: Phase 2 reference — Pass 1 deterministic tool extraction (catalog, aliases, field priority) before Pass 2 LLM work.
 def extract_tools(job_record: JobRecord) -> list[ToolRecord]:
     """Extract tools from a normalized job record using pattern matching.
 


### PR DESCRIPTION
## Summary
Comment-only EXEMPLAR markers for Phase 2 grep discovery. **No behavior change.**

## Locations and exact strings

- **enrichment/dedup/types.py** (before `FuzzyDedupResult`)
  - `# EXEMPLAR: Phase 2 reference — FuzzyDedupResult is the frozen in-process contract; apply_fuzzy_dedup_result is the sole writer path for duplicate flags, and persistence still enforces additional invariants.`

- **skills_extraction/extractors/tools.py** (after module docstring)
  - `# EXEMPLAR: Phase 2 reference — Pass 1 deterministic tool extraction (catalog, aliases, field priority) before Pass 2 LLM work.`

- **enrichment/job_postings_promotion.py**
  - Above `apply_fuzzy_dedup_result`: `# EXEMPLAR: Phase 2 reference — fuzzy dedup persistence contract validation uses imperative ValueError checks on stub, unique-clear, and clustered survivor paths before SQL updates.`
  - Above `_apply_fuzzy_dedup_after_promotion`: `# EXEMPLAR: Phase 2 reference — savepoint pattern` plus one plain-English line on `session.begin_nested()` isolation.

- **enrichment/classifiers/soc_classifier.py** (above `_resolve_llm_pick_with_reason`)
  - `# EXEMPLAR: Phase 2 reference — LLM output coercion` plus one plain-English line on mapping free-text picks to the candidate set.

## Verification
- `ruff check .` / `ruff format .` — clean
- `pytest enrichment/tests/test_job_postings_promotion.py -q` — 46 passed

## Note
`soc_classifier.py` is Pair A territory per phase1-cleanup-pair-c; coordinate if a conflicting PR is open.

Made with [Cursor](https://cursor.com)