### PR TITLE
Week 12: Pair A Phase 1 Cleanup P6 (Add jitter to taxonomy embedding retry backoff)

### DIFF
--- a/skills_extraction/extractors/taxonomy.py
+++ b/skills_extraction/extractors/taxonomy.py
@@ -25,6 +25,7 @@ import contextlib
 import csv
 import json
 import os
+import random
 import re
 import time
 import unicodedata
@@ -423,6 +424,14 @@ def _extract_retry_after_embedding(error_message: str) -> int | None:
     return int(match.group(1)) if match else None
 
 
+def _embedding_retry_delay(retry_after: int | None, attempt: int) -> float:
+    """Return retry delay with jitter to avoid lockstep 429 retries across workers."""
+    if retry_after:
+        return float(retry_after)
+    base_delay = _EMBED_BASE_DELAY * (2 ** (attempt - 1))
+    return base_delay * random.uniform(1.0, 1.3)
+
+
 def _embed_texts_azure(
     texts: list[str],
     *,
@@ -472,7 +481,7 @@ def _embed_texts_azure(
                 response_data = _response_json_or_none(resp)
                 if resp.status_code == 429:
                     retry_after = _extract_retry_after_embedding(resp.text)
-                    delay = retry_after if retry_after else _EMBED_BASE_DELAY * (2 ** (attempt - 1))
+                    delay = _embedding_retry_delay(retry_after, attempt)
                     _log_embedding_audit_event(
                         texts,
                         response_data,
@@ -513,7 +522,7 @@ def _embed_texts_azure(
             )
             if response is not None and response.status_code == 429:
                 retry_after = _extract_retry_after_embedding(str(exc))
-                delay = retry_after if retry_after else _EMBED_BASE_DELAY * (2 ** (attempt - 1))
+                delay = _embedding_retry_delay(retry_after, attempt)
                 log.warning("embedding_rate_limited", attempt=attempt, delay_s=round(delay, 2))
                 if attempt == _EMBED_MAX_RETRIES:
                     return None


### PR DESCRIPTION
## Scope

This PR executes **Phase 1 Cleanup Pair A — P6**: add jitter to the taxonomy embedding retry loop in `skills_extraction/extractors/taxonomy.py`.

## Why

The embedding retry path used deterministic exponential backoff. In multi-instance deployments, that can cause retries to align and repeatedly hit Azure rate limits at the same time (thundering herd).

Adding jitter spreads retries across instances while preserving existing retry behavior.

## Changes in this PR

- [x] Added `_embedding_retry_delay(retry_after, attempt)` helper in `skills_extraction/extractors/taxonomy.py`
- [x] Preserved `retry_after` behavior when provided by Azure
- [x] Applied jittered exponential delay when `retry_after` is absent:
  - `base_delay * random.uniform(1.0, 1.3)`
- [x] Reused helper in both 429 retry branches in `_embed_texts_azure`
- [x] Added concise inline docstring explaining herd-avoidance intent

## Out of Scope

- No taxonomy cache refactor (P2)
- No enrichment classifier refactors
- No event payload/schema changes
- No retry policy redesign beyond jitter

## Verification

- [x] `ruff check skills_extraction/extractors/taxonomy.py`
- [x] `pytest tests/test_taxonomy_resolver.py -q` *(16 passed)*

## Risk / Rollback

Risk is low. This change does not alter success/failure contracts, retry count, or `retry_after` handling; it only randomizes fallback delay spacing to reduce synchronized retries.

Rollback plan: revert this PR to restore deterministic backoff timing.