### PR TITLE
refactor(enrichment): extract _coerce_enrichment_params (Pair C P1)

### DIFF
--- a/enrichment/job_postings_promotion.py
+++ b/enrichment/job_postings_promotion.py
@@ -21,7 +21,8 @@ from __future__ import annotations
 
 import json
 import uuid
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
 import structlog
 from sqlalchemy import text
@@ -606,36 +607,36 @@ def _apply_fuzzy_dedup_after_promotion(
         )
 
 
-def apply_enrichment_to_job_postings(
+@dataclass(frozen=True)
+class _PromotionCoercionSkip:
+    """Return when promotion must not run an ``UPDATE`` (caller returns False)."""
+
+    reason: Literal["rejected_spam", "no_quality_score", "invalid_quality_score"]
+
+
+@dataclass(frozen=True)
+class _PromotionCoercionReady:
+    """Coerced SQL bind params and spam tier state for tier routing."""
+
+    params_base: dict[str, Any]
+    tier: str
+    spam_score: Any
+    raw_tier: Any
+
+
+def _coerce_enrichment_params(
     session: Session,
     normalized_job_id: int,
     record_enriched_payload: dict[str, Any],
-) -> bool:
+    resolved: dict[str, Any],
+    job_posting_id: object,
+    company_id: object,
+) -> _PromotionCoercionSkip | _PromotionCoercionReady:
     """
-    Apply enrichment columns to ``job_postings`` when tier allows.
+    Normalize payload + resolved row into ``params_base`` and spam tier, or signal skip.
 
-    Returns True if an ``UPDATE`` ran, False if skipped (no row, no company_id,
-    rejected tier, or missing quality score when needed).
+    Pure coercion and DB reads for quality derivation / employer profile; no posting UPDATE.
     """
-    resolved = resolve_job_posting_row(session, normalized_job_id)
-    if not resolved:
-        resolved = _insert_job_posting_from_normalized(session, normalized_job_id)
-        if not resolved:
-            log.info(
-                "enrichment_promotion_no_job_posting",
-                normalized_job_id=normalized_job_id,
-            )
-            return False
-
-    job_posting_id = resolved.get("job_posting_id")
-    company_id = resolved.get("company_id")
-    if not job_posting_id or not str(company_id).strip():
-        log.warning(
-            "enrichment_promotion_skipped_no_company_id",
-            normalized_job_id=normalized_job_id,
-        )
-        return False
-
     raw_tier = record_enriched_payload.get("spam_tier")
     tier = (raw_tier or "").strip().lower() if isinstance(raw_tier, str) else ""
     spam_score = record_enriched_payload.get("spam_score")
@@ -655,7 +656,7 @@ def apply_enrichment_to_job_postings(
             normalized_job_id=normalized_job_id,
             job_posting_id=job_posting_id,
         )
-        return False
+        return _PromotionCoercionSkip(reason="rejected_spam")
 
     quality_score = record_enriched_payload.get("quality_score")
     merged_payload_for_confidence: dict[str, Any] = record_enriched_payload
@@ -678,12 +679,12 @@ def apply_enrichment_to_job_postings(
             "enrichment_promotion_skipped_no_quality_score",
             normalized_job_id=normalized_job_id,
         )
-        return False
+        return _PromotionCoercionSkip(reason="no_quality_score")
 
     try:
         qs_f = float(quality_score)
     except (TypeError, ValueError):
-        return False
+        return _PromotionCoercionSkip(reason="invalid_quality_score")
 
     fc_merged = merge_field_confidence_for_storage(merged_payload_for_confidence)
     fc_json = json.dumps(fc_merged)
@@ -775,6 +776,60 @@ def apply_enrichment_to_job_postings(
         "spam_score": None,
         **derived_output_fields,
     }
+
+    return _PromotionCoercionReady(
+        params_base=params_base,
+        tier=tier,
+        spam_score=spam_score,
+        raw_tier=raw_tier,
+    )
+
+
+def apply_enrichment_to_job_postings(
+    session: Session,
+    normalized_job_id: int,
+    record_enriched_payload: dict[str, Any],
+) -> bool:
+    """
+    Apply enrichment columns to ``job_postings`` when tier allows.
+
+    Returns True if an ``UPDATE`` ran, False if skipped (no row, no company_id,
+    rejected tier, or missing quality score when needed).
+    """
+    resolved = resolve_job_posting_row(session, normalized_job_id)
+    if not resolved:
+        resolved = _insert_job_posting_from_normalized(session, normalized_job_id)
+        if not resolved:
+            log.info(
+                "enrichment_promotion_no_job_posting",
+                normalized_job_id=normalized_job_id,
+            )
+            return False
+
+    job_posting_id = resolved.get("job_posting_id")
+    company_id = resolved.get("company_id")
+    if not job_posting_id or not str(company_id).strip():
+        log.warning(
+            "enrichment_promotion_skipped_no_company_id",
+            normalized_job_id=normalized_job_id,
+        )
+        return False
+
+    coercion = _coerce_enrichment_params(
+        session,
+        normalized_job_id,
+        record_enriched_payload,
+        resolved,
+        job_posting_id,
+        company_id,
+    )
+    if isinstance(coercion, _PromotionCoercionSkip):
+        return False
+
+    params_base = coercion.params_base
+    tier = coercion.tier
+    spam_score = coercion.spam_score
+    raw_tier = coercion.raw_tier
 
     def _finish_with_dedup() -> bool:
         _apply_fuzzy_dedup_after_promotion(

--- a/enrichment/job_postings_promotion.py
+++ b/enrichment/job_postings_promotion.py
@@ -629,14 +629,17 @@ def _coerce_enrichment_params(
     normalized_job_id: int,
     record_enriched_payload: dict[str, Any],
     resolved: dict[str, Any],
-    job_posting_id: object,
-    company_id: object,
 ) -> _PromotionCoercionSkip | _PromotionCoercionReady:
     """
     Normalize payload + resolved row into ``params_base`` and spam tier, or signal skip.
 
-    Pure coercion and DB reads for quality derivation / employer profile; no posting UPDATE.
+    Coerces promotion bind parameters and spam tier from the payload and ``resolved`` row;
+    reads ``normalized_jobs`` via ``_derive_quality_from_normalized_job`` when ``quality_score``
+    is missing; may select or upsert ``employer_profiles`` when ``employer_metadata`` is present
+    and ``company_id`` resolves. Does **not** run ``UPDATE`` on ``job_postings`` (caller only).
     """
+    job_posting_id = resolved["job_posting_id"]
+    company_id = resolved["company_id"]
     raw_tier = record_enriched_payload.get("spam_tier")
     tier = (raw_tier or "").strip().lower() if isinstance(raw_tier, str) else ""
     spam_score = record_enriched_payload.get("spam_score")
@@ -820,8 +823,6 @@ def apply_enrichment_to_job_postings(
         normalized_job_id,
         record_enriched_payload,
         resolved,
-        job_posting_id,
-        company_id,
     )
     if isinstance(coercion, _PromotionCoercionSkip):
         return False

--- a/enrichment/tests/test_job_postings_promotion.py
+++ b/enrichment/tests/test_job_postings_promotion.py
@@ -11,6 +11,9 @@ import pytest
 
 from enrichment.dedup.types import FuzzyDedupResult
 from enrichment.job_postings_promotion import (
+    _coerce_enrichment_params,
+    _PromotionCoercionReady,
+    _PromotionCoercionSkip,
     apply_enrichment_to_job_postings,
     apply_fuzzy_dedup_result,
 )
@@ -1001,3 +1004,276 @@ def test_apply_enrichment_binds_salary_period_strips_whitespace() -> None:
         {},
     )
     assert params["salary_period"] is None
+
+
+# ---------------------------------------------------------------------------
+# _coerce_enrichment_params (Pair C P1) — isolated coercion / early-exit
+# ---------------------------------------------------------------------------
+
+
+def _coerce_resolved(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "job_posting_id": "11111111-1111-1111-1111-111111111111",
+        "company_id": "22222222-2222-2222-2222-222222222222",
+        "date_posted": None,
+        "city": None,
+        "state_province": None,
+        "country": None,
+        "is_remote": None,
+        "work_arrangement": None,
+        "zip_code": None,
+        "salary_min": None,
+        "salary_max": None,
+        "salary_currency": None,
+        "salary_period": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_coerce_enrichment_params_rejected_spam() -> None:
+    session = MagicMock()
+    out = _coerce_enrichment_params(
+        session,
+        1,
+        {"spam_tier": "rejected", "spam_score": 0.95, "quality_score": 0.8},
+        _coerce_resolved(),
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+    )
+    assert isinstance(out, _PromotionCoercionSkip)
+    assert out.reason == "rejected_spam"
+    session.execute.assert_not_called()
+
+
+def test_coerce_enrichment_params_no_quality_after_derivation_none() -> None:
+    session = MagicMock()
+    with patch(
+        "enrichment.job_postings_promotion._derive_quality_from_normalized_job",
+        return_value=None,
+    ):
+        out = _coerce_enrichment_params(
+            session,
+            42,
+            {"spam_tier": "clean", "spam_score": 0.1},
+            _coerce_resolved(),
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        )
+    assert isinstance(out, _PromotionCoercionSkip)
+    assert out.reason == "no_quality_score"
+
+
+def test_coerce_enrichment_params_invalid_quality_score() -> None:
+    session = MagicMock()
+    out = _coerce_enrichment_params(
+        session,
+        1,
+        {"spam_tier": "clean", "spam_score": 0.1, "quality_score": "not-a-float"},
+        _coerce_resolved(),
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+    )
+    assert isinstance(out, _PromotionCoercionSkip)
+    assert out.reason == "invalid_quality_score"
+
+
+def test_coerce_enrichment_params_derives_tier_from_spam_score_when_tier_unset() -> None:
+    session = MagicMock()
+    with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
+        out = _coerce_enrichment_params(
+            session,
+            1,
+            {"spam_score": 0.25, "quality_score": 0.9},
+            _coerce_resolved(),
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        )
+    assert isinstance(out, _PromotionCoercionReady)
+    assert out.tier == "clean"
+    assert out.params_base["quality_score"] == 0.9
+
+
+def test_coerce_enrichment_params_naics_unknown_when_missing() -> None:
+    session = MagicMock()
+    with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
+        out = _coerce_enrichment_params(
+            session,
+            1,
+            {"spam_tier": "clean", "spam_score": 0.1, "quality_score": 0.9},
+            _coerce_resolved(),
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        )
+    assert isinstance(out, _PromotionCoercionReady)
+    assert out.params_base["naics_code"] == "unknown"
+
+
+def test_coerce_enrichment_params_naics_strips_nonempty() -> None:
+    session = MagicMock()
+    with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
+        out = _coerce_enrichment_params(
+            session,
+            1,
+            {
+                "spam_tier": "clean",
+                "spam_score": 0.1,
+                "quality_score": 0.9,
+                "naics_code": "  541512  ",
+            },
+            _coerce_resolved(),
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        )
+    assert isinstance(out, _PromotionCoercionReady)
+    assert out.params_base["naics_code"] == "541512"
+
+
+def test_coerce_enrichment_params_soc_none_when_blank() -> None:
+    session = MagicMock()
+    with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
+        out = _coerce_enrichment_params(
+            session,
+            1,
+            {"spam_tier": "clean", "spam_score": 0.1, "quality_score": 0.9, "soc_code": "   "},
+            _coerce_resolved(),
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        )
+    assert isinstance(out, _PromotionCoercionReady)
+    assert out.params_base["soc_code"] is None
+
+
+def test_coerce_enrichment_params_soc_persisted_when_present() -> None:
+    session = MagicMock()
+    with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
+        out = _coerce_enrichment_params(
+            session,
+            1,
+            {
+                "spam_tier": "clean",
+                "spam_score": 0.1,
+                "quality_score": 0.9,
+                "soc_code": "15-1252.00",
+            },
+            _coerce_resolved(),
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        )
+    assert isinstance(out, _PromotionCoercionReady)
+    assert out.params_base["soc_code"] == "15-1252.00"
+
+
+def test_coerce_enrichment_params_seniority_level_over_seniority() -> None:
+    session = MagicMock()
+    with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
+        out = _coerce_enrichment_params(
+            session,
+            1,
+            {
+                "spam_tier": "clean",
+                "spam_score": 0.1,
+                "quality_score": 0.9,
+                "seniority": "Mid",
+                "seniority_level": "Senior",
+            },
+            _coerce_resolved(),
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        )
+    assert isinstance(out, _PromotionCoercionReady)
+    assert out.params_base["seniority_level"] == "Senior"
+
+
+def test_coerce_enrichment_params_is_remote_int_coerced_to_bool() -> None:
+    session = MagicMock()
+    with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
+        out = _coerce_enrichment_params(
+            session,
+            1,
+            {"spam_tier": "clean", "spam_score": 0.1, "quality_score": 0.9},
+            _coerce_resolved(is_remote=1),
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        )
+    assert isinstance(out, _PromotionCoercionReady)
+    assert out.params_base["is_remote"] is True
+    assert isinstance(out.params_base["is_remote"], bool)
+
+
+def test_coerce_enrichment_params_employer_metadata_non_dict_skips_profile_sql() -> None:
+    session = MagicMock()
+    with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
+        out = _coerce_enrichment_params(
+            session,
+            1,
+            {
+                "spam_tier": "clean",
+                "spam_score": 0.1,
+                "quality_score": 0.9,
+                "employer_metadata": "not-a-dict",
+            },
+            _coerce_resolved(),
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        )
+    assert isinstance(out, _PromotionCoercionReady)
+    assert out.params_base["employer_profile_id"] is None
+    session.execute.assert_not_called()
+
+
+def test_coerce_enrichment_params_employer_metadata_select_then_upsert() -> None:
+    session = MagicMock()
+    ep_uuid = uuid.uuid4()
+    select_result = MagicMock()
+    select_result.scalar_one_or_none.return_value = None
+    session.execute.return_value = select_result
+    with (
+        patch("enrichment.job_postings_promotion.resolve_sector", return_value=None),
+        patch(
+            "enrichment.job_postings_promotion.upsert_employer_profile_by_company_id",
+            return_value=ep_uuid,
+        ) as mock_upsert,
+    ):
+        out = _coerce_enrichment_params(
+            session,
+            1,
+            {
+                "spam_tier": "clean",
+                "spam_score": 0.1,
+                "quality_score": 0.9,
+                "employer_metadata": {"company_size": "smb"},
+            },
+            _coerce_resolved(),
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        )
+    assert isinstance(out, _PromotionCoercionReady)
+    assert out.params_base["employer_profile_id"] == ep_uuid
+    mock_upsert.assert_called_once()
+    session.execute.assert_called_once()
+
+
+def test_coerce_enrichment_params_uses_existing_employer_profile_id() -> None:
+    session = MagicMock()
+    ep_uuid = uuid.uuid4()
+    select_result = MagicMock()
+    select_result.scalar_one_or_none.return_value = ep_uuid
+    session.execute.return_value = select_result
+    with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
+        out = _coerce_enrichment_params(
+            session,
+            1,
+            {
+                "spam_tier": "clean",
+                "spam_score": 0.1,
+                "quality_score": 0.9,
+                "employer_metadata": {"company_size": "smb"},
+            },
+            _coerce_resolved(),
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        )
+    assert isinstance(out, _PromotionCoercionReady)
+    assert out.params_base["employer_profile_id"] == ep_uuid
+    session.execute.assert_called_once()

--- a/enrichment/tests/test_job_postings_promotion.py
+++ b/enrichment/tests/test_job_postings_promotion.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import uuid
 from contextlib import nullcontext
 from datetime import datetime, timezone
@@ -1038,8 +1039,6 @@ def test_coerce_enrichment_params_rejected_spam() -> None:
         1,
         {"spam_tier": "rejected", "spam_score": 0.95, "quality_score": 0.8},
         _coerce_resolved(),
-        "11111111-1111-1111-1111-111111111111",
-        "22222222-2222-2222-2222-222222222222",
     )
     assert isinstance(out, _PromotionCoercionSkip)
     assert out.reason == "rejected_spam"
@@ -1057,8 +1056,6 @@ def test_coerce_enrichment_params_no_quality_after_derivation_none() -> None:
             42,
             {"spam_tier": "clean", "spam_score": 0.1},
             _coerce_resolved(),
-            "11111111-1111-1111-1111-111111111111",
-            "22222222-2222-2222-2222-222222222222",
         )
     assert isinstance(out, _PromotionCoercionSkip)
     assert out.reason == "no_quality_score"
@@ -1071,11 +1068,32 @@ def test_coerce_enrichment_params_invalid_quality_score() -> None:
         1,
         {"spam_tier": "clean", "spam_score": 0.1, "quality_score": "not-a-float"},
         _coerce_resolved(),
-        "11111111-1111-1111-1111-111111111111",
-        "22222222-2222-2222-2222-222222222222",
     )
     assert isinstance(out, _PromotionCoercionSkip)
     assert out.reason == "invalid_quality_score"
+
+
+def test_coerce_enrichment_params_quality_derivation_happy_path_sets_score_and_field_confidence_json() -> None:
+    session = MagicMock()
+    with (
+        patch("enrichment.job_postings_promotion.resolve_sector", return_value=None),
+        patch(
+            "enrichment.job_postings_promotion._derive_quality_from_normalized_job",
+            return_value=(0.75, {"completeness": 0.8}),
+        ),
+    ):
+        out = _coerce_enrichment_params(
+            session,
+            99,
+            {"spam_tier": "clean", "spam_score": 0.1},
+            _coerce_resolved(),
+        )
+    assert isinstance(out, _PromotionCoercionReady)
+    assert out.params_base["quality_score"] == 0.75
+    fc = out.params_base["field_confidence"]
+    assert isinstance(fc, str) and fc
+    parsed = json.loads(fc)
+    assert isinstance(parsed, dict)
 
 
 def test_coerce_enrichment_params_derives_tier_from_spam_score_when_tier_unset() -> None:
@@ -1086,8 +1104,6 @@ def test_coerce_enrichment_params_derives_tier_from_spam_score_when_tier_unset()
             1,
             {"spam_score": 0.25, "quality_score": 0.9},
             _coerce_resolved(),
-            "11111111-1111-1111-1111-111111111111",
-            "22222222-2222-2222-2222-222222222222",
         )
     assert isinstance(out, _PromotionCoercionReady)
     assert out.tier == "clean"
@@ -1102,8 +1118,6 @@ def test_coerce_enrichment_params_naics_unknown_when_missing() -> None:
             1,
             {"spam_tier": "clean", "spam_score": 0.1, "quality_score": 0.9},
             _coerce_resolved(),
-            "11111111-1111-1111-1111-111111111111",
-            "22222222-2222-2222-2222-222222222222",
         )
     assert isinstance(out, _PromotionCoercionReady)
     assert out.params_base["naics_code"] == "unknown"
@@ -1122,8 +1136,6 @@ def test_coerce_enrichment_params_naics_strips_nonempty() -> None:
                 "naics_code": "  541512  ",
             },
             _coerce_resolved(),
-            "11111111-1111-1111-1111-111111111111",
-            "22222222-2222-2222-2222-222222222222",
         )
     assert isinstance(out, _PromotionCoercionReady)
     assert out.params_base["naics_code"] == "541512"
@@ -1137,8 +1149,6 @@ def test_coerce_enrichment_params_soc_none_when_blank() -> None:
             1,
             {"spam_tier": "clean", "spam_score": 0.1, "quality_score": 0.9, "soc_code": "   "},
             _coerce_resolved(),
-            "11111111-1111-1111-1111-111111111111",
-            "22222222-2222-2222-2222-222222222222",
         )
     assert isinstance(out, _PromotionCoercionReady)
     assert out.params_base["soc_code"] is None
@@ -1157,8 +1167,6 @@ def test_coerce_enrichment_params_soc_persisted_when_present() -> None:
                 "soc_code": "15-1252.00",
             },
             _coerce_resolved(),
-            "11111111-1111-1111-1111-111111111111",
-            "22222222-2222-2222-2222-222222222222",
         )
     assert isinstance(out, _PromotionCoercionReady)
     assert out.params_base["soc_code"] == "15-1252.00"
@@ -1178,8 +1186,6 @@ def test_coerce_enrichment_params_seniority_level_over_seniority() -> None:
                 "seniority_level": "Senior",
             },
             _coerce_resolved(),
-            "11111111-1111-1111-1111-111111111111",
-            "22222222-2222-2222-2222-222222222222",
         )
     assert isinstance(out, _PromotionCoercionReady)
     assert out.params_base["seniority_level"] == "Senior"
@@ -1193,8 +1199,6 @@ def test_coerce_enrichment_params_is_remote_int_coerced_to_bool() -> None:
             1,
             {"spam_tier": "clean", "spam_score": 0.1, "quality_score": 0.9},
             _coerce_resolved(is_remote=1),
-            "11111111-1111-1111-1111-111111111111",
-            "22222222-2222-2222-2222-222222222222",
         )
     assert isinstance(out, _PromotionCoercionReady)
     assert out.params_base["is_remote"] is True
@@ -1214,8 +1218,6 @@ def test_coerce_enrichment_params_employer_metadata_non_dict_skips_profile_sql()
                 "employer_metadata": "not-a-dict",
             },
             _coerce_resolved(),
-            "11111111-1111-1111-1111-111111111111",
-            "22222222-2222-2222-2222-222222222222",
         )
     assert isinstance(out, _PromotionCoercionReady)
     assert out.params_base["employer_profile_id"] is None
@@ -1245,8 +1247,6 @@ def test_coerce_enrichment_params_employer_metadata_select_then_upsert() -> None
                 "employer_metadata": {"company_size": "smb"},
             },
             _coerce_resolved(),
-            "11111111-1111-1111-1111-111111111111",
-            "22222222-2222-2222-2222-222222222222",
         )
     assert isinstance(out, _PromotionCoercionReady)
     assert out.params_base["employer_profile_id"] == ep_uuid
@@ -1271,8 +1271,6 @@ def test_coerce_enrichment_params_uses_existing_employer_profile_id() -> None:
                 "employer_metadata": {"company_size": "smb"},
             },
             _coerce_resolved(),
-            "11111111-1111-1111-1111-111111111111",
-            "22222222-2222-2222-2222-222222222222",
         )
     assert isinstance(out, _PromotionCoercionReady)
     assert out.params_base["employer_profile_id"] == ep_uuid


### PR DESCRIPTION
## What changed
- Extracted `_coerce_enrichment_params` (plus `_PromotionCoercionSkip` / `_PromotionCoercionReady`) from `apply_enrichment_to_job_postings` in [enrichment/job_postings_promotion.py](enrichment/job_postings_promotion.py). Coercion, quality derivation, NAICS/SOC normalization, seniority/role/salary/employer bind assembly, and early-exit paths (rejected spam, missing/invalid quality) are unit-testable without running the full promotion UPDATE path.
- Parent `apply_enrichment_to_job_postings` now delegates coercion then handles tier routing, SQL updates, fuzzy dedup, and `promoted_at` stamp.

## Why
- Pair C merge gate: this refactor must land **before** Pair B duplicate-SQL unification on the same file ([phase1-cleanup-pair-c.mdc](.cursor/rules/phase1-cleanup-pair-c.mdc), [Emilio.md](docs/guides/Emilio.md)).
- Smaller review surface and isolated regression tests for each coercion branch.

## Tests
- [enrichment/tests/test_job_postings_promotion.py](enrichment/tests/test_job_postings_promotion.py): dedicated `_coerce_enrichment_params_*` tests (rejected spam, no quality after derivation, invalid quality, tier from numeric spam_score, NAICS/SOC, seniority precedence, `is_remote` int coercion, employer metadata paths).

## Verification
\\\ash
pytest enrichment/dedup/tests/ -v
pytest enrichment/tests/test_job_postings_promotion.py -v
pytest skills_extraction/extractors/tests/ -v
pytest -x
mypy enrichment/
\\\

## Issues closed
No issue — Pair C P1 (merge gate for Pair B on \job_postings_promotion.py\).

## Coordination
After merge: Discord ping to Pair B / Bryan per [Emilio.md](docs/guides/Emilio.md) and [Bryan.md](docs/guides/Bryan.md).

## Out of scope
- Pair B SQL unification; P3 Pydantic payload (separate PR after this merges).

Made with [Cursor](https://cursor.com)