### PR TITLE
feat(enrichment): RecordEnrichedPayload promotion boundary (Pair C P3)

### DIFF
--- a/enrichment/agent.py
+++ b/enrichment/agent.py
@@ -102,6 +102,7 @@ from enrichment.resolvers.freshness_slice import build_freshness_record_for_anal
 from enrichment.resolvers.location_resolver import resolve_location
 from enrichment.resolvers.sector_resolver import resolve_sector
 from enrichment.schemas import EnrichedJobProfile
+from enrichment.schemas import RecordEnrichedPayload
 from scripts.jsearch_enrichment_preview_lib import build_extraction_dict
 
 log = structlog.get_logger()
@@ -444,8 +445,8 @@ def _posting_for_enrichment(
 def _job_postings_promotion_payload(
     enriched: dict[str, Any],
     posting: dict[str, Any],
-) -> dict[str, Any]:
-    """Build a payload for :func:`apply_enrichment_to_job_postings` from batch enrichment output."""
+) -> RecordEnrichedPayload:
+    """Build a validated payload for :func:`apply_enrichment_to_job_postings` from batch enrichment output."""
     spam_score = enriched.get("spam_score")
     if spam_score is None:
         spam_score = posting.get("spam_score")
@@ -457,23 +458,25 @@ def _job_postings_promotion_payload(
     quality_score = enriched.get("quality_score")
     if quality_score is None:
         quality_score = posting.get("quality_score")
-    return {
-        "spam_tier": spam_tier,
-        "spam_score": spam_score,
-        "quality_score": quality_score,
-        "overall_confidence": enriched.get("overall_confidence"),
-        "field_confidence": enriched.get("field_confidence"),
-        "naics_code": enriched.get("naics_code"),
-        "soc_code": enriched.get("soc_code"),
-        "role_classification": enriched.get("role_classification"),
-        # Forward fields the promotion path COALESCEs into job_postings.
-        # Without these, seniority_level + employer_profile_id stay NULL and
-        # the backfill scripts have to plug the gap (issues #281, #282).
-        "seniority_level": enriched.get("seniority_level") or enriched.get("seniority"),
-        "seniority": enriched.get("seniority"),
-        "employer_metadata": enriched.get("employer_metadata"),
-        "company_id": enriched.get("company_id"),
-    }
+    return RecordEnrichedPayload.model_validate(
+        {
+            "spam_tier": spam_tier,
+            "spam_score": spam_score,
+            "quality_score": quality_score,
+            "overall_confidence": enriched.get("overall_confidence"),
+            "field_confidence": enriched.get("field_confidence"),
+            "naics_code": enriched.get("naics_code"),
+            "soc_code": enriched.get("soc_code"),
+            "role_classification": enriched.get("role_classification"),
+            # Forward fields the promotion path COALESCEs into job_postings.
+            # Without these, seniority_level + employer_profile_id stay NULL and
+            # the backfill scripts have to plug the gap (issues #281, #282).
+            "seniority_level": enriched.get("seniority_level") or enriched.get("seniority"),
+            "seniority": enriched.get("seniority"),
+            "employer_metadata": enriched.get("employer_metadata"),
+            "company_id": enriched.get("company_id"),
+        }
+    )
 
 
 class EnrichmentAgent(BaseAgent):
@@ -1127,7 +1130,11 @@ class EnrichmentAgent(BaseAgent):
                         source=event.payload.get("source"),
                         external_id=event.payload.get("external_id"),
                     )
-                    apply_enrichment_to_job_postings(session, nj_id, base_payload)
+                    apply_enrichment_to_job_postings(
+                        session,
+                        nj_id,
+                        RecordEnrichedPayload.model_validate(base_payload),
+                    )
             except Exception as exc:
                 log.warning(
                     "enrichment_promotion_failed",

--- a/enrichment/job_postings_promotion.py
+++ b/enrichment/job_postings_promotion.py
@@ -36,6 +36,7 @@ from enrichment.dedup import run_fuzzy_dedup
 from enrichment.dedup.types import FuzzyDedupResult
 from enrichment.employer_profile_storage import upsert_employer_profile_by_company_id
 from enrichment.resolvers.sector_resolver import resolve_sector
+from enrichment.schemas import RecordEnrichedPayload
 from scripts.jsearch_enrichment_preview_lib import build_extraction_dict
 
 log = structlog.get_logger()
@@ -794,10 +795,13 @@ def _coerce_enrichment_params(
 def apply_enrichment_to_job_postings(
     session: Session,
     normalized_job_id: int,
-    record_enriched_payload: dict[str, Any],
+    record_enriched_payload: RecordEnrichedPayload,
 ) -> bool:
     """
     Apply enrichment columns to ``job_postings`` when tier allows.
+
+    ``record_enriched_payload`` is validated at the agent boundary via
+    :class:`enrichment.schemas.RecordEnrichedPayload`.
 
     Returns True if an ``UPDATE`` ran, False if skipped (no row, no company_id,
     rejected tier, or missing quality score when needed).
@@ -821,10 +825,14 @@ def apply_enrichment_to_job_postings(
         )
         return False
 
+    payload_dict: dict[str, Any] = record_enriched_payload.model_dump(
+        mode="python",
+        exclude_unset=True,
+    )
     coercion = _coerce_enrichment_params(
         session,
         normalized_job_id,
-        record_enriched_payload,
+        payload_dict,
         resolved,
     )
     if isinstance(coercion, _PromotionCoercionSkip):

--- a/enrichment/schemas.py
+++ b/enrichment/schemas.py
@@ -4,6 +4,11 @@
 ``job_record`` is a ``dict`` for pipeline compatibility (same shape as a serialized
 :class:`~common.types.job_record.JobRecord` plus extraction fields where present).
 
+``RecordEnrichedPayload`` is the typed single-record shape for
+:func:`enrichment.job_postings_promotion.apply_enrichment_to_job_postings` (Pair C P3).
+Placed here alongside ``EnrichedJobProfile`` rather than a separate ``enrichment/types.py``
+to avoid confusion with ``enrichment.dedup.types`` (``FuzzyDedupResult``).
+
 Cross-pair field names (``soc_code``, ``naics_code``, canonical ``employer`` vs
 ``employer_profile``): ``.cursor/rules/integration-schema.mdc`` § Nestor + Fatima.
 """
@@ -12,9 +17,68 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from enrichment.adapters.models import OccupationProfile, RegionalProfile, WageEstimate
+
+
+class RecordEnrichedPayload(BaseModel):
+    """Subset of keys consumed by job postings promotion (single-record path).
+
+    Validates the flat dict passed into
+    :func:`enrichment.job_postings_promotion.apply_enrichment_to_job_postings`.
+    Unknown keys are **ignored** (``extra="ignore"``) so forward-compatible payloads
+    and merged in-memory dicts do not fail validation; malformed **types** fail with
+    ``pydantic.ValidationError``.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    spam_tier: str | None = None
+    spam_score: float | None = None
+    quality_score: float | None = None
+    quality_components: dict[str, Any] = Field(default_factory=dict)
+    field_confidence: dict[str, Any] = Field(default_factory=dict)
+    overall_confidence: float | None = None
+    naics_code: str | None = None
+    soc_code: str | None = None
+    role_classification: str | None = None
+    seniority: str | None = None
+    seniority_level: str | None = None
+    employer_metadata: dict[str, Any] | None = None
+    # Forward-compatible only: merged in-memory dicts / event-shaped payloads may carry
+    # ``company_id``; job postings promotion uses ``resolved["company_id"]`` from the DB
+    # resolve path, not this field, for employer profile SQL and posting updates.
+    company_id: str | None = None
+
+    @field_validator("spam_score", "quality_score", "overall_confidence", mode="before")
+    @classmethod
+    def _coerce_optional_float(cls, v: Any) -> float | None:
+        if v is None:
+            return None
+        if isinstance(v, bool):
+            raise ValueError("boolean is not a valid numeric score")
+        if isinstance(v, (int, float)):
+            return float(v)
+        raise ValueError(f"expected int or float, got {type(v).__name__}")
+
+    @field_validator("quality_components", "field_confidence", mode="before")
+    @classmethod
+    def _coerce_confidence_maps(cls, v: Any) -> dict[str, Any]:
+        if v is None:
+            return {}
+        if isinstance(v, dict):
+            return dict(v)
+        raise ValueError("expected dict or null")
+
+    @field_validator("employer_metadata", mode="before")
+    @classmethod
+    def _coerce_employer_metadata(cls, v: Any) -> dict[str, Any] | None:
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            return dict(v)
+        raise ValueError("expected dict or null")
 
 
 class EnrichedJobProfile(BaseModel):

--- a/enrichment/tests/test_job_postings_promotion.py
+++ b/enrichment/tests/test_job_postings_promotion.py
@@ -18,6 +18,7 @@ from enrichment.job_postings_promotion import (
     apply_enrichment_to_job_postings,
     apply_fuzzy_dedup_result,
 )
+from enrichment.schemas import RecordEnrichedPayload
 
 CURRENT_ID = "00000000-0000-0000-0000-000000000001"
 MATCHED_ID = "00000000-0000-0000-0000-000000000002"
@@ -53,7 +54,7 @@ def _execute_sql(session: MagicMock) -> list[str]:
     return [str(call.args[0]) for call in session.execute.call_args_list]
 
 
-def _promotion_payload(**overrides: object) -> dict[str, object]:
+def _promotion_payload(**overrides: object) -> RecordEnrichedPayload:
     payload: dict[str, object] = {
         "quality_score": 0.84,
         "quality_components": {"description": 0.9},
@@ -63,7 +64,7 @@ def _promotion_payload(**overrides: object) -> dict[str, object]:
         "spam_score": 0.25,
     }
     payload.update(overrides)
-    return payload
+    return RecordEnrichedPayload.model_validate(payload)
 
 
 def test_apply_fuzzy_dedup_result_clears_current_row_for_unique_posting() -> None:
@@ -330,11 +331,13 @@ def _apply_with_resolved_row_for_temporal_borderplex(resolved_row: dict[str, obj
         out = apply_enrichment_to_job_postings(
             session,
             42,
-            {
-                "spam_tier": "clean",
-                "spam_score": 0.2,
-                "quality_score": 0.85,
-            },
+            RecordEnrichedPayload.model_validate(
+                {
+                    "spam_tier": "clean",
+                    "spam_score": 0.2,
+                    "quality_score": 0.85,
+                }
+            ),
         )
     return out, session
 
@@ -447,13 +450,15 @@ def test_apply_enrichment_binds_soc_code_column_from_payload() -> None:
         out = apply_enrichment_to_job_postings(
             session,
             42,
-            {
-                "spam_tier": "clean",
-                "spam_score": 0.2,
-                "quality_score": 0.85,
-                "soc_code": "17-3029",
-                "naics_code": "541512",
-            },
+            RecordEnrichedPayload.model_validate(
+                {
+                    "spam_tier": "clean",
+                    "spam_score": 0.2,
+                    "quality_score": 0.85,
+                    "soc_code": "17-3029",
+                    "naics_code": "541512",
+                }
+            ),
         )
     assert out is True
     _stmt, params = session.execute.call_args_list[1][0]
@@ -503,12 +508,14 @@ def test_apply_enrichment_selects_employer_profile_id_when_metadata_present() ->
         out = apply_enrichment_to_job_postings(
             session,
             42,
-            {
-                "spam_tier": "clean",
-                "spam_score": 0.2,
-                "quality_score": 0.85,
-                "employer_metadata": {"company_size": "smb", "is_known_employer": True},
-            },
+            RecordEnrichedPayload.model_validate(
+                {
+                    "spam_tier": "clean",
+                    "spam_score": 0.2,
+                    "quality_score": 0.85,
+                    "employer_metadata": {"company_size": "smb", "is_known_employer": True},
+                }
+            ),
         )
 
     assert out is True
@@ -549,12 +556,14 @@ def test_apply_enrichment_persists_sector_id_for_known_role() -> None:
         out = apply_enrichment_to_job_postings(
             session,
             42,
-            {
-                "spam_tier": "clean",
-                "spam_score": 0.2,
-                "quality_score": 0.85,
-                "role_classification": "Software Engineering",
-            },
+            RecordEnrichedPayload.model_validate(
+                {
+                    "spam_tier": "clean",
+                    "spam_score": 0.2,
+                    "quality_score": 0.85,
+                    "role_classification": "Software Engineering",
+                }
+            ),
         )
 
     assert out is True
@@ -589,11 +598,13 @@ def test_apply_enrichment_persists_sector_id_for_unknown_role_fallback() -> None
         out = apply_enrichment_to_job_postings(
             session,
             42,
-            {
-                "spam_tier": "clean",
-                "spam_score": 0.2,
-                "quality_score": 0.85,
-            },
+            RecordEnrichedPayload.model_validate(
+                {
+                    "spam_tier": "clean",
+                    "spam_score": 0.2,
+                    "quality_score": 0.85,
+                }
+            ),
         )
 
     assert out is True
@@ -636,7 +647,11 @@ def test_apply_enrichment_sector_id_is_in_params_base_for_all_tiers() -> None:
             if spam_score is not None:
                 payload["spam_score"] = spam_score
 
-            out = apply_enrichment_to_job_postings(session, 42, payload)
+            out = apply_enrichment_to_job_postings(
+                session,
+                42,
+                RecordEnrichedPayload.model_validate(payload),
+            )
 
         assert out is True, f"Expected True for tier={tier}"
         _stmt, params = session.execute.call_args_list[1][0]
@@ -690,7 +705,11 @@ def _apply_with_qna_payload(session: MagicMock, resolved_row: dict, payload_over
         **payload_overrides,
     }
     with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
-        out = apply_enrichment_to_job_postings(session, 42, payload)
+        out = apply_enrichment_to_job_postings(
+            session,
+            42,
+            RecordEnrichedPayload.model_validate(payload),
+        )
 
     assert out is True
     _stmt, params = session.execute.call_args_list[1][0]
@@ -750,7 +769,7 @@ def test_apply_enrichment_derives_quality_when_payload_omits_score_jsearch_null_
         "spam_score": 0.2,
     }
     with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
-        out = apply_enrichment_to_job_postings(session, 4242, payload)
+        out = apply_enrichment_to_job_postings(session, 4242, RecordEnrichedPayload.model_validate(payload))
     assert out is True
     assert session.execute.call_count >= 3
     _stmt, params = session.execute.call_args_list[2][0]
@@ -880,7 +899,11 @@ def test_apply_enrichment_qna_fields_present_for_all_tiers(tier: str, spam_score
         payload["spam_score"] = spam_score
 
     with patch("enrichment.job_postings_promotion.resolve_sector", return_value=None):
-        out = apply_enrichment_to_job_postings(session, 42, payload)
+        out = apply_enrichment_to_job_postings(
+            session,
+            42,
+            RecordEnrichedPayload.model_validate(payload),
+        )
 
     assert out is True, f"Expected True for tier={tier!r}"
     _stmt, params = session.execute.call_args_list[1][0]

--- a/enrichment/tests/test_promotion_spam_tier_persistence.py
+++ b/enrichment/tests/test_promotion_spam_tier_persistence.py
@@ -29,6 +29,7 @@ from enrichment.job_postings_promotion import (
     _UPDATE_UNCERTAIN_SQL,
     apply_enrichment_to_job_postings,
 )
+from enrichment.schemas import RecordEnrichedPayload
 
 
 def _mapping_first(row: dict | None) -> MagicMock:
@@ -57,15 +58,17 @@ def _resolved_row() -> dict:
     }
 
 
-def _payload(*, tier: str, score: float | None) -> dict[str, object]:
-    return {
-        "quality_score": 0.84,
-        "field_confidence": {"spam_score": 0.8},
-        "overall_confidence": 0.82,
-        "spam_tier": tier,
-        "spam_score": score,
-        "naics_code": "541110",
-    }
+def _payload(*, tier: str, score: float | None) -> RecordEnrichedPayload:
+    return RecordEnrichedPayload.model_validate(
+        {
+            "quality_score": 0.84,
+            "field_confidence": {"spam_score": 0.8},
+            "overall_confidence": 0.82,
+            "spam_tier": tier,
+            "spam_score": score,
+            "naics_code": "541110",
+        }
+    )
 
 
 def _build_session() -> MagicMock:

--- a/enrichment/tests/test_record_enriched_payload.py
+++ b/enrichment/tests/test_record_enriched_payload.py
@@ -1,0 +1,60 @@
+"""Boundary validation for :class:`enrichment.schemas.RecordEnrichedPayload`."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from enrichment.schemas import RecordEnrichedPayload
+
+
+def test_record_enriched_payload_accepts_extra_keys() -> None:
+    """Unknown keys are ignored (``extra="ignore"``)."""
+    p = RecordEnrichedPayload.model_validate(
+        {
+            "spam_tier": "clean",
+            "spam_score": 0.1,
+            "quality_score": 0.9,
+            "future_unknown_field": {"nested": True},
+        }
+    )
+    assert p.spam_tier == "clean"
+    assert "future_unknown_field" not in p.model_dump()
+
+
+def test_record_enriched_payload_rejects_bad_score_type() -> None:
+    with pytest.raises(ValidationError):
+        RecordEnrichedPayload.model_validate({"spam_tier": "clean", "spam_score": "high", "quality_score": 0.9})
+
+
+def test_record_enriched_payload_rejects_bool_as_score() -> None:
+    with pytest.raises(ValidationError):
+        RecordEnrichedPayload.model_validate({"spam_tier": "clean", "spam_score": True, "quality_score": 0.9})
+
+
+def test_record_enriched_payload_rejects_non_dict_field_confidence() -> None:
+    with pytest.raises(ValidationError):
+        RecordEnrichedPayload.model_validate(
+            {"spam_tier": "clean", "spam_score": 0.1, "quality_score": 0.9, "field_confidence": []}
+        )
+
+
+def test_record_enriched_payload_rejects_non_dict_employer_metadata() -> None:
+    with pytest.raises(ValidationError):
+        RecordEnrichedPayload.model_validate(
+            {
+                "spam_tier": "clean",
+                "spam_score": 0.1,
+                "quality_score": 0.9,
+                "employer_metadata": ["not", "a", "dict"],
+            }
+        )
+
+
+def test_record_enriched_payload_coerces_int_scores_to_float() -> None:
+    p = RecordEnrichedPayload.model_validate(
+        {"spam_tier": "clean", "spam_score": 1, "quality_score": 84, "overall_confidence": 0}
+    )
+    assert p.spam_score == 1.0
+    assert p.quality_score == 84.0
+    assert p.overall_confidence == 0.0


### PR DESCRIPTION
## What changed

- `enrichment/schemas.py` — added `RecordEnrichedPayload` (Pydantic model, `extra="ignore"`) alongside `EnrichedJobProfile`; placed here to avoid confusion with `enrichment.dedup.types` (`FuzzyDedupResult`); validators raise `ValueError` so Pydantic surfaces `ValidationError`
- `enrichment/agent.py` — both promotion call paths (`_job_postings_promotion_payload` batch and single-record `process()`) now validate via `RecordEnrichedPayload.model_validate`
- `enrichment/job_postings_promotion.py` — `apply_enrichment_to_job_postings` accepts `RecordEnrichedPayload`; calls `model_dump(mode="python", exclude_unset=True)` before passing to `_coerce_enrichment_params`
- `enrichment/tests/test_record_enriched_payload.py` — new boundary tests (extra-key ignore, bad score type, bool-as-score, non-dict field_confidence, non-dict employer_metadata, int-to-float coercion)
- `enrichment/tests/test_job_postings_promotion.py` — test helpers updated to `RecordEnrichedPayload.model_validate(...)`
- `enrichment/tests/test_promotion_spam_tier_persistence.py` — `_payload()` helper updated to return `RecordEnrichedPayload`

## Unknown-keys policy

`model_config extra="ignore"` for forward-compatible payloads; wrong types fail `ValidationError`.

## Dependency

Pair C P1 (`_coerce_enrichment_params`) merged to `development` via PR #389.

## Issues

No GitHub issue — Pair C P3 (replaces closed PR #391 after P1 branch deletion).

## Verify

```
pytest enrichment/tests/test_fuzzy_dedup.py enrichment/tests/test_fuzzy_dedup_stub.py enrichment/tests/test_dedup_calibration.py -q
pytest enrichment/tests/test_job_postings_promotion.py enrichment/tests/test_record_enriched_payload.py enrichment/tests/test_promotion_spam_tier_persistence.py -q
pytest skills_extraction/tests/ -q
```

Made with [Cursor](https://cursor.com)