### PR TITLE
Week 12: Pair A Phase 1 Cleanup P4 (Unify shared text normalization)

### DIFF
--- a/common/tests/test_text_normalization.py
+++ b/common/tests/test_text_normalization.py
@@ -1,0 +1,26 @@
+"""Unit tests for shared text normalization helpers."""
+
+from __future__ import annotations
+
+from common.text_normalization import normalize_label
+
+
+def test_normalize_label_idempotent() -> None:
+    raw = "  Senior\tDATA   Engineer \n"
+    once = normalize_label(raw)
+    twice = normalize_label(once)
+    assert twice == once
+
+
+def test_normalize_label_handles_none_and_empty() -> None:
+    assert normalize_label(None) == ""
+    assert normalize_label("") == ""
+
+
+def test_normalize_label_applies_nfkc_and_lowercase() -> None:
+    # Fullwidth characters should normalize to ASCII-equivalent code points.
+    assert normalize_label(" ＡＢＡＰ ") == "abap"
+
+
+def test_normalize_label_collapses_internal_whitespace() -> None:
+    assert normalize_label("Machine   \n Learning\tEngineer") == "machine learning engineer"

--- a/common/text_normalization.py
+++ b/common/text_normalization.py
@@ -1,0 +1,14 @@
+"""Shared text normalization helpers."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+
+def normalize_label(value: str | None) -> str:
+    """NFKC normalize, lowercase, strip outer whitespace, collapse internal whitespace."""
+    text = unicodedata.normalize("NFKC", value or "")
+    text = text.lower().strip()
+    text = re.sub(r"\s+", " ", text)
+    return text

--- a/scripts/seed_esco.py
+++ b/scripts/seed_esco.py
@@ -69,7 +69,6 @@ import re
 import shutil
 import sys
 import tempfile
-import unicodedata
 import urllib.request
 import zipfile
 from collections.abc import Iterable
@@ -78,6 +77,8 @@ from pathlib import Path
 from typing import Any
 
 from dotenv import load_dotenv
+
+from common.text_normalization import normalize_label
 
 load_dotenv()
 
@@ -303,10 +304,7 @@ def normalize_text(value: str | None) -> str:
     It avoids stemming here because the seed store should preserve the canonical
     labels; stemming can be applied later in the resolver if the team wants it.
     """
-    text_value = unicodedata.normalize("NFKC", value or "")
-    text_value = text_value.lower().strip()
-    text_value = re.sub(r"\s+", " ", text_value)
-    return text_value
+    return normalize_label(value)
 
 
 def split_multivalue(value: str | None) -> list[str]:

--- a/skills_extraction/extractors/taxonomy.py
+++ b/skills_extraction/extractors/taxonomy.py
@@ -27,7 +27,6 @@ import json
 import os
 import re
 import time
-import unicodedata
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +34,7 @@ import httpx
 import numpy as np
 import structlog
 
+from common.text_normalization import normalize_label
 from common.types import TaxonomyResult
 
 log = structlog.get_logger()
@@ -68,10 +68,7 @@ _PARENT_LABEL_ALIASES: dict[str, str] = {
 
 def _normalize_label(value: str | None) -> str:
     """NFKC, lowercase, strip, collapse internal whitespace."""
-    text = unicodedata.normalize("NFKC", value or "")
-    text = text.lower().strip()
-    text = re.sub(r"\s+", " ", text)
-    return text
+    return normalize_label(value)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Scope

This PR executes **Phase 1 Cleanup Pair A — P4**: unify duplicated text normalization logic by introducing a single shared helper and wiring existing callers to it.

## Why

Normalization logic was duplicated between taxonomy resolution and ESCO seeding. Consolidating into one canonical helper prevents drift and ensures future fixes apply consistently in both paths.

## Changes in this PR

- [x] Added shared helper in `common/text_normalization.py`:
  - `normalize_label(value: str | None) -> str`
  - behavior: NFKC normalize → lowercase → strip outer whitespace → collapse internal whitespace
- [x] Updated `skills_extraction/extractors/taxonomy.py` to use shared helper via `_normalize_label` compatibility wrapper
- [x] Updated `scripts/seed_esco.py` `normalize_text` to delegate to shared helper (public contract unchanged)
- [x] Added focused tests in `common/tests/test_text_normalization.py`:
  - idempotency: `normalize_label(normalize_label(x)) == normalize_label(x)`
  - `None` / empty handling
  - NFKC normalization check
  - whitespace collapse + lowercase behavior

## Out of Scope

- No retry/backoff changes (P6 already completed)
- No taxonomy cache/thread-safety changes (P2)
- No enrichment classifier refactors
- No event payload/schema changes

## Verification

- [x] `ruff check common/text_normalization.py skills_extraction/extractors/taxonomy.py scripts/seed_esco.py common/tests/test_text_normalization.py`
- [x] `pytest common/tests/test_text_normalization.py -v` *(4 passed)*
- [x] `pytest tests/test_taxonomy_resolver.py -v` *(16 passed)*
- [ ] `pytest -x` *(blocked by unrelated pre-existing failure: `common/tests/test_config_loader.py::test_env_override_emits_warning_once`)*

## Risk / Rollback

Risk is low: this is a consolidation-only refactor with preserved normalization semantics and call-site contracts.

Rollback plan: revert this PR to restore previous module-local normalization implementations.