### PR TITLE
Week 12: Pair A Phase 1 Cleanup P2 (Threadsafe Taxonomy Cache)

### DIFF
--- a/skills_extraction/extractors/taxonomy.py
+++ b/skills_extraction/extractors/taxonomy.py
@@ -26,8 +26,10 @@ import csv
 import json
 import os
 import re
+import threading
 import time
 import unicodedata
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -135,8 +137,6 @@ def _load_genai_extension(json_path: Path | None = None) -> dict[str, str]:
 # O*NET store loading (Step 5)
 # ---------------------------------------------------------------------------
 
-_onet_normalized_to_pair: dict[str, tuple[str, str]] | None = None
-
 
 def _load_onet_store(path: Path | None = None) -> dict[str, tuple[str, str]]:
     """Load O*NET Skills tab-delimited file; return normalized_name -> (element_id, element_name).
@@ -176,30 +176,30 @@ def _load_onet_store(path: Path | None = None) -> dict[str, tuple[str, str]]:
     return out
 
 
+@lru_cache(maxsize=1)
+def _get_onet_store_cached() -> dict[str, tuple[str, str]]:
+    """Return cached O*NET normalized_name -> (element_id, element_name)."""
+    return _load_onet_store()
+
+
 def _get_onet_store() -> dict[str, tuple[str, str]]:
-    """Return lazy-loaded O*NET normalized_name -> (element_id, element_name)."""
-    global _onet_normalized_to_pair
-    if _onet_normalized_to_pair is None:
-        _onet_normalized_to_pair = _load_onet_store()
-    return _onet_normalized_to_pair
+    """Public wrapper for O*NET store access."""
+    return _get_onet_store_cached()
 
 
-# Lazy-loaded singleton store state
-_esco_records: list[dict[str, Any]] | None = None
-_parent_label_to_uri: dict[str, str] | None = None
-_genai_skill_to_parent: dict[str, str] | None = None
-_genai_normalized_to_canonical: dict[str, str] | None = None
+@lru_cache(maxsize=1)
+def _get_store_cached() -> tuple[list[dict[str, Any]], dict[str, str], dict[str, str], dict[str, str]]:
+    """Load ESCO + GenAI config once and return cached store bundle."""
+    records = _load_esco_store()
+    parent_label_to_uri = _build_parent_label_to_uri(records) if records else {}
+    genai_skill_to_parent = _load_genai_extension()
+    genai_normalized_to_canonical = {_normalize_label(k): k for k in genai_skill_to_parent}
+    return records, parent_label_to_uri, genai_normalized_to_canonical, genai_skill_to_parent
 
 
 def _get_store():
-    """Load ESCO + GenAI config once; return (records, parent_label_to_uri, genai_normalized_to_canonical, genai_skill_to_parent)."""
-    global _esco_records, _parent_label_to_uri, _genai_skill_to_parent, _genai_normalized_to_canonical
-    if _esco_records is None:
-        _esco_records = _load_esco_store()
-        _parent_label_to_uri = _build_parent_label_to_uri(_esco_records) if _esco_records else {}
-        _genai_skill_to_parent = _load_genai_extension()
-        _genai_normalized_to_canonical = {_normalize_label(k): k for k in _genai_skill_to_parent}
-    return _esco_records, _parent_label_to_uri, _genai_normalized_to_canonical, _genai_skill_to_parent
+    """Public wrapper for cached ESCO + GenAI store bundle."""
+    return _get_store_cached()
 
 
 # ---------------------------------------------------------------------------
@@ -315,8 +315,8 @@ def _resolve_step3_normalized_esco(label: str) -> TaxonomyResult | None:
 # Step 4: Embedding cosine similarity (Azure OpenAI text-embedding-3-small)
 # ---------------------------------------------------------------------------
 
-_esco_embedding_meta: list[tuple[str, str]] | None = None  # (uri, preferred_label)
-_esco_normalized_matrix: np.ndarray | None = None  # (n_skills, dim) L2-normalized
+_esco_embedding_cache: tuple[list[tuple[str, str]], np.ndarray] | None = None
+_esco_embedding_cache_lock = threading.Lock()
 
 
 _EMBED_MAX_RETRIES = 5
@@ -609,24 +609,37 @@ def _get_esco_embeddings() -> tuple[list[tuple[str, str]], np.ndarray] | None:
     Meta is list of (skill_name, skill_name). Matrix is (n_skills, dim) L2-normalized
     so Step 4 only needs to normalize the query and run a dot product.
     """
-    global _esco_embedding_meta, _esco_normalized_matrix
+    global _esco_embedding_cache
 
-    # 1. In-memory cache
-    if _esco_embedding_meta is not None and _esco_normalized_matrix is not None:
-        return _esco_embedding_meta, _esco_normalized_matrix
+    # 1. In-memory cache (success-only cache; misses are not cached)
+    if _esco_embedding_cache is not None:
+        return _esco_embedding_cache
 
-    # 2. PostgreSQL
-    db_result = _load_embeddings_from_db()
-    if db_result is not None:
-        _esco_embedding_meta, _esco_normalized_matrix = db_result
-        log.info("esco_embeddings_loaded_from_db", skills=len(_esco_embedding_meta))
-        return _esco_embedding_meta, _esco_normalized_matrix
+    with _esco_embedding_cache_lock:
+        if _esco_embedding_cache is not None:
+            return _esco_embedding_cache
+
+        # 2. PostgreSQL
+        db_result = _load_embeddings_from_db()
+        if db_result is not None:
+            _esco_embedding_cache = db_result
+            log.info("esco_embeddings_loaded_from_db", skills=len(db_result[0]))
+            return _esco_embedding_cache
 
     log.warning(
         "esco_embeddings_not_available",
         reason="No embeddings in dbo.skills — run seed_esco_embeddings.py (admin only)",
     )
     return None
+
+
+def _clear_taxonomy_caches_for_tests() -> None:
+    """Clear cached taxonomy stores for deterministic tests."""
+    global _esco_embedding_cache
+    _get_store_cached.cache_clear()
+    _get_onet_store_cached.cache_clear()
+    with _esco_embedding_cache_lock:
+        _esco_embedding_cache = None
 
 
 def _resolve_step4_embedding_impl(label: str) -> TaxonomyResult | None:

--- a/tests/test_taxonomy_resolver.py
+++ b/tests/test_taxonomy_resolver.py
@@ -6,8 +6,13 @@ Azure API calls are made (avoids cost, latency, and flakiness in CI).
 
 from __future__ import annotations
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
 from common.types import TaxonomyResult
 from skills_extraction.extractors.taxonomy import (
+    _clear_taxonomy_caches_for_tests,
+    _get_esco_embeddings,
     _load_genai_extension,
     resolution_report,
     resolution_stats,
@@ -90,14 +95,7 @@ class TestResolveTaxonomy:
         fake_matrix = fake_vec / fake_norms
 
         # Clear in-memory cache so _get_esco_embeddings re-loads
-        monkeypatch.setattr(
-            "skills_extraction.extractors.taxonomy._esco_embedding_meta",
-            None,
-        )
-        monkeypatch.setattr(
-            "skills_extraction.extractors.taxonomy._esco_normalized_matrix",
-            None,
-        )
+        _clear_taxonomy_caches_for_tests()
         # Mock DB load to return our fake matrix
         monkeypatch.setattr(
             "skills_extraction.extractors.taxonomy._load_embeddings_from_db",
@@ -172,14 +170,7 @@ class TestResolveTaxonomyBatch:
 
     def test_step5_in_batch(self, monkeypatch) -> None:
         """Batch resolves a label at step 5 when O*NET store is patched and step 4 is skipped."""
-        monkeypatch.setattr(
-            "skills_extraction.extractors.taxonomy._esco_embedding_meta",
-            None,
-        )
-        monkeypatch.setattr(
-            "skills_extraction.extractors.taxonomy._esco_normalized_matrix",
-            None,
-        )
+        _clear_taxonomy_caches_for_tests()
         monkeypatch.setattr(
             "skills_extraction.extractors.taxonomy._load_embeddings_from_db",
             lambda: None,
@@ -235,14 +226,7 @@ class TestResolutionStats:
 
     def test_resolution_report_shape(self, monkeypatch) -> None:
         """Skip embedding + O*NET so one label is step 2 and one is step 6."""
-        monkeypatch.setattr(
-            "skills_extraction.extractors.taxonomy._esco_embedding_meta",
-            None,
-        )
-        monkeypatch.setattr(
-            "skills_extraction.extractors.taxonomy._esco_normalized_matrix",
-            None,
-        )
+        _clear_taxonomy_caches_for_tests()
         monkeypatch.setattr(
             "skills_extraction.extractors.taxonomy._get_onet_store",
             lambda: {},
@@ -254,3 +238,30 @@ class TestResolutionStats:
         assert rep["genai_extension_matches"] == 0
         assert "counts_by_step" in rep
         assert rep["avg_resolution_confidence"] == 1.0  # only step-2 hit, confidence 1.0
+
+
+def test_get_esco_embeddings_threadsafe_single_load(monkeypatch) -> None:
+    import numpy as np
+
+    _clear_taxonomy_caches_for_tests()
+
+    fake_meta = [("skill_a", "Skill A")]
+    fake_matrix = np.array([[1.0, 0.0]], dtype=np.float64)
+    call_count = {"n": 0}
+    lock = threading.Lock()
+
+    def _mock_db_load():
+        with lock:
+            call_count["n"] += 1
+        return fake_meta, fake_matrix
+
+    monkeypatch.setattr(
+        "skills_extraction.extractors.taxonomy._load_embeddings_from_db",
+        _mock_db_load,
+    )
+
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        results = list(pool.map(lambda _: _get_esco_embeddings(), range(5)))
+
+    assert all(result is not None for result in results)
+    assert call_count["n"] == 1


### PR DESCRIPTION
## Scope

This PR executes **Phase 1 Cleanup Pair A — P2**: make taxonomy cache initialization thread-safe in `skills_extraction/extractors/taxonomy.py` while preserving resolver behavior and keeping embedding-miss behavior unchanged (no miss caching).

## Why

The taxonomy resolver used mutable module-level singleton patterns with check-then-set initialization. Under concurrent calls, that can duplicate load work and risk inconsistent cache reads.

This refactor applies a KISS approach:
- thread-safe cached loaders for non-embedding stores
- lock-protected single-bundle embedding cache for successful loads
- no caching of embedding misses (`None`), so later calls can re-check DB

## Changes in this PR

- [x] Replaced mutable singleton initialization for non-embedding stores with cached loaders:
  - `@lru_cache(maxsize=1)` for cached ESCO/GenAI bundle
  - `@lru_cache(maxsize=1)` for cached O*NET store
  - kept `_get_store()` / `_get_onet_store()` as stable thin wrappers
- [x] Refactored embedding cache to thread-safe single-bundle storage:
  - introduced lock-protected success cache
  - removed split assignment risk from separate embedding globals
  - preserved **no miss caching** behavior (`None` is not cached)
- [x] Added cache reset helper for deterministic tests:
  - `_clear_taxonomy_caches_for_tests()`
- [x] Added concurrency regression test in `tests/test_taxonomy_resolver.py`:
  - `ThreadPoolExecutor(max_workers=5)`
  - mocked `_load_embeddings_from_db` with call counter
  - verifies valid concurrent results and single successful load initialization
- [x] Updated existing taxonomy tests to use new cache reset utility

## Out of Scope

- No retry/backoff changes (P6 already completed)
- No normalization consolidation changes (P4 handled separately)
- No enrichment classifier/agent refactors
- No event payload/schema changes

## Verification

- [x] `ruff check skills_extraction/extractors/taxonomy.py tests/test_taxonomy_resolver.py`
- [x] `pytest tests/test_taxonomy_resolver.py -v` *(17 passed, includes new concurrency test)*
- [ ] `pytest -x` *(blocked by unrelated pre-existing failure: `common/tests/test_config_loader.py::test_env_override_emits_warning_once`)*

## Risk / Rollback

Risk is low: resolver contracts, step order, and output shape remain unchanged.

Rollback plan: revert this PR to restore previous cache initialization logic.