### PR TITLE
fix(synthesis): #361 comparison_clause enforces totals-first on comparison-intent questions

### DIFF
--- a/analytics/query_engine/synthesis.py
+++ b/analytics/query_engine/synthesis.py
@@ -131,14 +131,23 @@ def _build_main_prompt(
         )
     comparison_clause = ""
     if intent_label == "comparison":
-        comparison_clause = (
-            "- This question is a comparison: when citeable_facts_json includes counts for "
-            "two or more skills, sectors, or temporal periods, state the magnitude difference "
-            "(e.g. 'X has 3× more postings than Y') and identify the leader. "
-            "If only one side has data, be explicit about which side is absent and why "
-            "(e.g. 'no demand data found for Y in the current aggregate window'). "
-            "Do not refuse or hedge when the data is thin — use it with appropriate caveats.\n"
-        )
+        comparison_clause = """
+COMPARISON INSTRUCTIONS (required when comparing two or more terms):
+1. Before writing your conclusion, compute the total supporting_count for each
+   compared term by summing across ALL cited facts for that term.
+2. State the totals explicitly: e.g. "Python total: 44 postings; ML total: 53 postings"
+3. Your directional conclusion MUST match the totals — never contradict them. Never conclude Term A is higher
+   if Term B has a higher total; identify the leader from the summed totals.
+4. State the magnitude of the difference (e.g. "ML has 3× more postings than Python" or "ML leads by 9 postings").
+5. If per-period patterns conflict with totals (e.g. Term A leads in one week but
+   trails overall), name that conflict explicitly.
+6. If only one side has data, be explicit about which side is absent and why
+   (e.g. 'no demand data found for Y in the current aggregate window').
+   Do not refuse or hedge when the data is thin — use cited counts with appropriate caveats.
+7. If you cannot compute a clean comparison from the cited facts, state that and
+   set confidence to medium or low — never confidence: high when the answer contradicts
+   the totals you computed from supporting_count.
+"""
     instructions = (
         "You are an analytics assistant. Write a concise, professional answer for workforce stakeholders.\n"
         "Rules:\n"

--- a/analytics/query_engine/tests/test_synthesis.py
+++ b/analytics/query_engine/tests/test_synthesis.py
@@ -1,0 +1,67 @@
+"""Unit tests for analytics.query_engine.synthesis (prompt construction, JIE #361)."""
+
+from __future__ import annotations
+
+from analytics.query_engine.schemas import DataSufficiency, EvidenceBundle, EvidenceCitation
+from analytics.query_engine.synthesis import _build_main_prompt
+
+
+def test_comparison_prompt_requires_total_supporting_counts_across_facts() -> None:
+    """JIE #361 — comparison synthesis must sum supporting_count per term before concluding.
+
+    Facts: Python 38 + 6 = 44 vs ML 49 + 4 = 53 (ML higher overall). The main prompt must
+    instruct the model to total supporting_count first; a draft claiming Python is higher
+    would contradict item 3 (conclusion must match totals).
+    """
+    bundle = EvidenceBundle(
+        facts=[
+            EvidenceCitation(
+                citation_id="py_w1",
+                summary="Python posting_count 38 in week 1.",
+                source_table="skill_demand_weekly",
+                supporting_count=38,
+                time_period="2025-W01",
+            ),
+            EvidenceCitation(
+                citation_id="py_w2",
+                summary="Python posting_count 6 in week 2.",
+                source_table="skill_demand_weekly",
+                supporting_count=6,
+                time_period="2025-W02",
+            ),
+            EvidenceCitation(
+                citation_id="ml_w1",
+                summary="ML posting_count 49 in week 1 (single-week peak).",
+                source_table="skill_demand_weekly",
+                supporting_count=49,
+                time_period="2025-W01",
+            ),
+            EvidenceCitation(
+                citation_id="ml_w2",
+                summary="ML posting_count 4 in week 2.",
+                source_table="skill_demand_weekly",
+                supporting_count=4,
+                time_period="2025-W02",
+            ),
+        ],
+        period_coverage="2025-W01 to 2025-W02",
+        volume_posting_count=97,
+        sufficiency=DataSufficiency.ADEQUATE,
+        blended_confidence=0.82,
+        confidence_explanation="Adequate evidence for comparison.",
+        refuse_synthesis=False,
+    )
+    prompt = _build_main_prompt(
+        "How does Python demand compare to ML?",
+        "comparison",
+        bundle,
+    )
+    assert "total supporting_count" in prompt
+    assert "COMPARISON INSTRUCTIONS" in prompt
+    assert "MUST match the totals" in prompt
+    assert "Never conclude Term A is higher" in prompt
+    assert "higher total" in prompt
+    assert "magnitude of the difference" in prompt
+    assert "never confidence: high" in prompt.lower()
+    # Facts sum to Python 44 vs ML 53; claiming "Python is higher overall" would violate
+    # the clause requiring the directional conclusion to match summed supporting_count.

--- a/analytics/tests/test_qna_synthesis.py
+++ b/analytics/tests/test_qna_synthesis.py
@@ -190,22 +190,25 @@ def test_periods_and_citations_echo() -> None:
 # Comparison-intent prompt clause (JIE #340 cycle 3)
 # ---------------------------------------------------------------------------
 
-# Stable substring of the comparison clause added in _build_main_prompt for
-# intent_label == "comparison".  Pinning it here lets refactors of the clause
-# wording still trip the test if the magnitude-difference instruction is dropped.
-_COMPARISON_CLAUSE_MARKER = "magnitude difference"
+# Stable substrings of the merged comparison clause (#361 totals-first + #406 magnitude).
+_COMPARISON_TOTALS_MARKER = "total supporting_count"
+_COMPARISON_MAGNITUDE_MARKER = "magnitude of the difference"
 
 
 def test_comparison_clause_present_for_comparison_intent() -> None:
-    """When intent_label == 'comparison', _build_main_prompt must include the
-    magnitude-difference instruction so the synthesis LLM does not over-hedge
-    on thin comparison data (JIE #340 cycle 3)."""
+    """When intent_label == 'comparison', _build_main_prompt must include totals-first
+    and magnitude-difference instructions (#361 + #406 merged clause)."""
     bundle = sample_evidence_bundle_adequate()
     prompt = _build_main_prompt("Compare X vs Y", "comparison", bundle)
-    assert _COMPARISON_CLAUSE_MARKER in prompt, (
+    assert _COMPARISON_TOTALS_MARKER in prompt, (
+        "comparison_clause must require summing total supporting_count per term; "
+        "see analytics/query_engine/synthesis.py:_build_main_prompt"
+    )
+    assert _COMPARISON_MAGNITUDE_MARKER in prompt, (
         "comparison_clause must include the magnitude-difference instruction; "
         "see analytics/query_engine/synthesis.py:_build_main_prompt"
     )
+    assert "COMPARISON INSTRUCTIONS" in prompt
     # The carve-out for the general thin-data rule must also be present so
     # the LLM does not receive a "be cautious" signal that contradicts the
     # comparison clause's "do not refuse on thin data" instruction.
@@ -219,7 +222,11 @@ def test_comparison_clause_absent_for_non_comparison_intents() -> None:
     bundle = sample_evidence_bundle_adequate()
     for intent_label in ("aggregate_salary", "trend", "role_evolution", "geographic"):
         prompt = _build_main_prompt("q", intent_label, bundle)
-        assert _COMPARISON_CLAUSE_MARKER not in prompt, (
+        assert _COMPARISON_TOTALS_MARKER not in prompt, (
+            f"comparison clause leaked into intent_label={intent_label!r}; "
+            "the clause must be gated on intent_label == 'comparison'"
+        )
+        assert _COMPARISON_MAGNITUDE_MARKER not in prompt, (
             f"comparison clause leaked into intent_label={intent_label!r}; "
             "the clause must be gated on intent_label == 'comparison'"
         )


### PR DESCRIPTION
## What

JIE#361 — synthesis LLM was contradicting its own cited numbers on comparison
questions. gq-051 (Python vs ML): LLM cited Python=44 total, ML=53 total but
concluded Python is higher. 3/3 runs wrong. confidence: high on wrong answer.

## Fix

Added comparison_clause to _build_main_prompt() for intent_label == 'comparison',
parallel to existing trend_clause.

Instructs LLM to:
1. Sum supporting_count across ALL cited facts per term before concluding
2. State totals explicitly (e.g. 'Python total: 44; ML total: 53')
3. Match directional conclusion to totals — never contradict
4. Name per-period vs total conflicts explicitly
5. Refuse with medium/low confidence if totals are unclear — never confidence: high on contradicting answer

_build_main_prompt_retry() builds on _build_main_prompt() so retries get the same instructions.

## Tests

New test: Python 38+6 vs ML 49+4 bundle, asserts:
- 'total supporting_count' in prompt
- Guardrail wording present: MUST match the totals, Never conclude Term A is higher, never confidence: high

pytest analytics/query_engine/tests/ → 155 passed
pytest analytics/ -q → 446 passed, 3 skipped ✅

## Verify against live

Re-run gq-051 — expect 3/3 to correctly state ML > Python (53 vs 44)
or refuse with calibrated confidence. No regression on gq-052.

## Closes

Closes #361

## Note

gq-051 was already off the May 6 demo set due to this bug.
Fix lands before demo set re-expands beyond gq-052 in comparison-intent slot.