### PR TITLE
fix(router): ignore workflow role-context phrases

### DIFF
--- a/analytics/query_engine/router.py
+++ b/analytics/query_engine/router.py
@@ -166,6 +166,49 @@ _ROLE_TOKEN_STOPWORDS: frozenset[str] = frozenset(
     {"and", "or", "the", "of", "for", "with", "at", "in", "to", "a", "an", "any", "all"}
 )
 
+_ROLE_CONTEXT_SUFFIXES: frozenset[str] = frozenset(
+    {
+        "employer",
+        "employers",
+        "candidate",
+        "candidates",
+        "hire",
+        "hires",
+        "recruit",
+        "recruits",
+        "professional",
+        "professionals",
+    }
+)
+
+_ROLE_CONTEXT_SCOPE_PREFIXES: frozenset[str] = frozenset(
+    {
+        "borderplex",
+        "regional",
+        "local",
+        "current",
+        "active",
+    }
+)
+
+_ROLE_OCCUPATION_HEADS: frozenset[str] = frozenset(
+    {
+        "administrator",
+        "analyst",
+        "architect",
+        "consultant",
+        "developer",
+        "engineer",
+        "manager",
+        "operator",
+        "programmer",
+        "researcher",
+        "scientist",
+        "specialist",
+        "technician",
+    }
+)
+
 
 def _tokenize_role_name(role: str) -> list[str]:
     """Split a free-text role name into ILIKE-friendly tokens.
@@ -182,6 +225,38 @@ def _tokenize_role_name(role: str) -> list[str]:
         return []
     raw_tokens = re.split(r"[\s/,\-_]+", role.strip())
     return [t.strip() for t in raw_tokens if len(t.strip()) >= 2 and t.strip().lower() not in _ROLE_TOKEN_STOPWORDS]
+
+
+def _clean_workflow_role_names(role_names: list[str]) -> list[str]:
+    """Drop workflow role-context phrases that are not actual occupation names.
+
+    LLM entity extraction can return phrases such as ``"Borderplex IT employers"``
+    as role names. Those phrases describe the employer/candidate population, not
+    a role family, and hard-filtering workflow queries on them can produce empty
+    evidence. If a phrase ends in a context suffix but still contains an
+    occupation head (for example ``"software developer candidates"``), keep the
+    role portion.
+    """
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for raw in role_names:
+        value = str(raw or "").strip()
+        if not value:
+            continue
+        tokens = _tokenize_role_name(value)
+        if tokens and tokens[-1].lower() in _ROLE_CONTEXT_SUFFIXES:
+            role_tokens = tokens[:-1]
+            while role_tokens and role_tokens[0].lower() in _ROLE_CONTEXT_SCOPE_PREFIXES:
+                role_tokens = role_tokens[1:]
+            if not any(t.lower() in _ROLE_OCCUPATION_HEADS for t in role_tokens):
+                continue
+            value = " ".join(role_tokens)
+        key = value.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        cleaned.append(value)
+    return cleaned
 
 
 # US state-code lookup for the small set we expect in Borderplex / Puget queries.
@@ -1180,6 +1255,7 @@ class QueryRouter:
         """workflow → ``canonical_roles`` (top_skills, top_tools) for day-to-day tasks."""
         if not tenant.can_query_borderplex_skill_tables:
             return self._no_borderplex_market_aggregates(intent, confidence)
+        role_names = _clean_workflow_role_names(role_names)
         cr = CanonicalRole
         stmt = select(
             cr.role_id,

--- a/analytics/tests/test_router.py
+++ b/analytics/tests/test_router.py
@@ -40,6 +40,7 @@ from analytics.query_engine.constants import (
 from analytics.query_engine.router import (
     ALLOWED_TABLES,
     QueryRouter,
+    _clean_workflow_role_names,
     _is_list_style,
     _parse_weeks_back,
     _resolve_geo_terms,
@@ -467,6 +468,54 @@ class TestEdgeCases:
 class TestRoleEmbeddingResolution:
     """Embedding path vs ILIKE fallback; _embed_texts_azure is always mocked."""
 
+    def test_workflow_drops_role_context_phrase_before_resolution(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """JIE #357: ``IT employers`` is context, not a role filter."""
+
+        def _unexpected_embed(*args: Any, **kwargs: Any) -> None:
+            raise AssertionError("role context phrases should be removed before role resolution")
+
+        monkeypatch.setattr("analytics.query_engine.router._embed_texts_azure", _unexpected_embed)
+
+        session = _make_session()
+        cls = _mk_classification("workflow", role_names=["Borderplex IT employers"])
+        result = QueryRouter().route(cls, session)
+
+        assert result.routed is True
+        assert result.query_label == "role workflow — skills and tools"
+        sql = _compiled_sql(session)
+        assert "ILIKE" not in sql.upper()
+        assert "IT employers" not in sql
+
+    def test_workflow_keeps_valid_role_before_resolution(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Valid role names must still reach the workflow role resolver."""
+
+        def _fake_embed(texts: list[str], audit_agent_name: str = "") -> list[list[float]]:
+            assert texts == ["software developer"]
+            return [[0.1] * 1536]
+
+        monkeypatch.setattr("analytics.query_engine.router._embed_texts_azure", _fake_embed)
+
+        resolve_result = MagicMock()
+        resolve_result.fetchall.return_value = [("resolved-role-id-aa",)]
+
+        select_result = MagicMock()
+        select_result.__iter__ = MagicMock(return_value=iter([]))
+
+        session = MagicMock(spec=Session)
+        session.execute.side_effect = [resolve_result, select_result]
+
+        cls = _mk_classification("workflow", role_names=["software developer"])
+        result = QueryRouter().route(cls, session)
+
+        assert result.routed is True
+        assert session.execute.call_count == 2
+
     def test_workflow_embedding_resolved_role_ids_use_pgvector_then_in_filter(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -595,6 +644,28 @@ class TestRoleEmbeddingResolution:
 
 
 class TestHelpers:
+    @pytest.mark.parametrize(
+        ("role_names", "expected"),
+        [
+            (["IT employers"], []),
+            (["Borderplex IT employers"], []),
+            (["AI candidates"], []),
+            (["cybersecurity hires"], []),
+            (["software professionals"], []),
+            (["tech recruits"], []),
+            (["healthcare-IT employers"], []),
+            (["software developer candidates"], ["software developer"]),
+            (["data engineer", "AI agent developer"], ["data engineer", "AI agent developer"]),
+            (["unicorn wranglers"], ["unicorn wranglers"]),
+        ],
+    )
+    def test_clean_workflow_role_names_removes_context_phrases(
+        self,
+        role_names: list[str],
+        expected: list[str],
+    ) -> None:
+        assert _clean_workflow_role_names(role_names) == expected
+
     def test_parse_weeks_back_named_periods(self) -> None:
         assert _parse_weeks_back(["last week"]) == 1
         assert _parse_weeks_back(["last month"]) == 4


### PR DESCRIPTION
## Summary
- Fixes #357 by dropping workflow role-context phrases like `Borderplex IT employers` before role resolution
- Keeps valid role names like `software developer` and `AI agent developer`
- Adds router regression tests for context phrases, valid roles, and unresolvable role phrases

## Tests
- `pytest analytics/tests/test_router.py -q`
- `pytest analytics/query_engine/tests/test_intent_classification.py analytics/tests/test_router.py -q`
- `ruff format --check analytics/query_engine/router.py analytics/tests/test_router.py`
- `ruff check analytics/query_engine/router.py analytics/tests/test_router.py`