### PR TITLE
fix(dedup): emit fuzzy_dedup_contract_violation metric for ValueError in savepoint path (Pair C P2)

### DIFF
--- a/enrichment/job_postings_promotion.py
+++ b/enrichment/job_postings_promotion.py
@@ -41,6 +41,18 @@ from scripts.jsearch_enrichment_preview_lib import build_extraction_dict
 
 log = structlog.get_logger()
 
+
+class FuzzyDedupContractError(ValueError):
+    """Raised by ``apply_fuzzy_dedup_result`` when a ``FuzzyDedupResult`` violates
+    the persistence contract (e.g. duplicate result missing ``duplicate_cluster_id``).
+
+    Subclasses ``ValueError`` for backward compatibility with callers that
+    already catch the broader type, but gives ``_apply_fuzzy_dedup_after_promotion``
+    a precise handle so infrastructure failures (DB errors, numpy shape mismatches)
+    are not mis-classified as contract violations in observability dashboards.
+    """
+
+
 # JIE #328 — derive deterministic quality when the promotion payload omits it
 # (legacy partial payloads / skipped promotions left job_postings.quality_score NULL).
 _NJ_EI_QUALITY_SQL = text(
@@ -483,7 +495,7 @@ def _cluster_member_ids(session: Session, cluster_id: str, *, exclude_job_postin
     return [str(row["job_posting_id"]) for row in rows]
 
 
-# EXEMPLAR: Phase 2 reference — fuzzy dedup persistence contract validation uses imperative ValueError checks on stub, unique-clear, and clustered survivor paths before SQL updates.
+# EXEMPLAR: Phase 2 reference — fuzzy dedup persistence contract validation uses imperative FuzzyDedupContractError checks on stub, unique-clear, and clustered survivor paths before SQL updates.
 def apply_fuzzy_dedup_result(
     session: Session,
     job_posting_id: str,
@@ -510,9 +522,9 @@ def apply_fuzzy_dedup_result(
         prior_cluster = str(prior_cluster_id).strip() if prior_cluster_id else None
         prior_was_survivor = existing.get("is_duplicate") is False and prior_cluster is not None
         if result.is_duplicate:
-            raise ValueError("duplicate fuzzy dedup results must include duplicate_cluster_id")
+            raise FuzzyDedupContractError("duplicate fuzzy dedup results must include duplicate_cluster_id")
         if matched_id or survivor_id:
-            raise ValueError("non-duplicate fuzzy dedup results may not include cluster or survivor metadata")
+            raise FuzzyDedupContractError("non-duplicate fuzzy dedup results may not include cluster or survivor metadata")
         session.execute(
             _UPDATE_FUZZY_DEDUP_SQL,
             {
@@ -548,11 +560,11 @@ def apply_fuzzy_dedup_result(
 
     effective_survivor_id = survivor_id or (job_posting_id if not result.is_duplicate else None)
     if effective_survivor_id is None:
-        raise ValueError("duplicate fuzzy dedup results must include survivor_job_posting_id")
+        raise FuzzyDedupContractError("duplicate fuzzy dedup results must include survivor_job_posting_id")
     if result.is_duplicate and effective_survivor_id == job_posting_id:
-        raise ValueError("duplicate fuzzy dedup results cannot mark the current row as survivor")
+        raise FuzzyDedupContractError("duplicate fuzzy dedup results cannot mark the current row as survivor")
     if not result.is_duplicate and effective_survivor_id != job_posting_id:
-        raise ValueError("non-duplicate clustered results must keep the current row as survivor")
+        raise FuzzyDedupContractError("non-duplicate clustered results must keep the current row as survivor")
 
     session.execute(
         _UPDATE_FUZZY_DEDUP_SQL,
@@ -602,7 +614,7 @@ def _apply_fuzzy_dedup_after_promotion(
         with session.begin_nested():
             result = run_fuzzy_dedup(session, job_posting_id)
             apply_fuzzy_dedup_result(session, job_posting_id, result)
-    except ValueError as exc:
+    except FuzzyDedupContractError as exc:
         # Contract violations raised by apply_fuzzy_dedup_result (e.g. missing
         # cluster_id on a duplicate, wrong survivor_id) get a distinct log key so
         # observability dashboards can count them separately from infrastructure

--- a/enrichment/job_postings_promotion.py
+++ b/enrichment/job_postings_promotion.py
@@ -524,7 +524,9 @@ def apply_fuzzy_dedup_result(
         if result.is_duplicate:
             raise FuzzyDedupContractError("duplicate fuzzy dedup results must include duplicate_cluster_id")
         if matched_id or survivor_id:
-            raise FuzzyDedupContractError("non-duplicate fuzzy dedup results may not include cluster or survivor metadata")
+            raise FuzzyDedupContractError(
+                "non-duplicate fuzzy dedup results may not include cluster or survivor metadata"
+            )
         session.execute(
             _UPDATE_FUZZY_DEDUP_SQL,
             {

--- a/enrichment/job_postings_promotion.py
+++ b/enrichment/job_postings_promotion.py
@@ -602,6 +602,17 @@ def _apply_fuzzy_dedup_after_promotion(
         with session.begin_nested():
             result = run_fuzzy_dedup(session, job_posting_id)
             apply_fuzzy_dedup_result(session, job_posting_id, result)
+    except ValueError as exc:
+        # Contract violations raised by apply_fuzzy_dedup_result (e.g. missing
+        # cluster_id on a duplicate, wrong survivor_id) get a distinct log key so
+        # observability dashboards can count them separately from infrastructure
+        # failures (DB errors, network timeouts) logged below.
+        log.warning(
+            "fuzzy_dedup_contract_violation",
+            normalized_job_id=normalized_job_id,
+            job_posting_id=job_posting_id,
+            error=str(exc),
+        )
     except Exception as exc:
         log.warning(
             "fuzzy_dedup_after_promotion_failed",

--- a/enrichment/tests/test_job_postings_promotion.py
+++ b/enrichment/tests/test_job_postings_promotion.py
@@ -13,6 +13,7 @@ import structlog.testing
 
 from enrichment.dedup.types import FuzzyDedupResult
 from enrichment.job_postings_promotion import (
+    FuzzyDedupContractError,
     _coerce_enrichment_params,
     _PromotionCoercionReady,
     _PromotionCoercionSkip,
@@ -216,7 +217,7 @@ def test_apply_fuzzy_dedup_result_rejects_invalid_duplicate_contract() -> None:
         stub=False,
     )
 
-    with pytest.raises(ValueError, match="duplicate fuzzy dedup results must include duplicate_cluster_id"):
+    with pytest.raises(FuzzyDedupContractError, match="duplicate fuzzy dedup results must include duplicate_cluster_id"):
         apply_fuzzy_dedup_result(session, CURRENT_ID, result)
 
 
@@ -1306,8 +1307,8 @@ def test_coerce_enrichment_params_uses_existing_employer_profile_id() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_apply_fuzzy_dedup_after_promotion_logs_contract_violation_for_value_error() -> None:
-    """ValueError from apply_fuzzy_dedup_result must log fuzzy_dedup_contract_violation,
+def test_apply_fuzzy_dedup_after_promotion_logs_contract_violation_for_contract_error() -> None:
+    """FuzzyDedupContractError from apply_fuzzy_dedup_result must log fuzzy_dedup_contract_violation,
     not fuzzy_dedup_after_promotion_failed, so dashboards count contract violations
     as a distinct metric from infrastructure failures."""
     session = MagicMock()
@@ -1330,7 +1331,7 @@ def test_apply_fuzzy_dedup_after_promotion_logs_contract_violation_for_value_err
         ),
         patch(
             "enrichment.job_postings_promotion.apply_fuzzy_dedup_result",
-            side_effect=ValueError("duplicate fuzzy dedup results must include duplicate_cluster_id"),
+            side_effect=FuzzyDedupContractError("duplicate fuzzy dedup results must include duplicate_cluster_id"),
         ),
         patch("enrichment.job_postings_promotion.resolve_sector", return_value=None),
         structlog.testing.capture_logs() as cap_logs,

--- a/enrichment/tests/test_job_postings_promotion.py
+++ b/enrichment/tests/test_job_postings_promotion.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
+import structlog.testing
 
 from enrichment.dedup.types import FuzzyDedupResult
 from enrichment.job_postings_promotion import (
@@ -1298,3 +1299,87 @@ def test_coerce_enrichment_params_uses_existing_employer_profile_id() -> None:
     assert isinstance(out, _PromotionCoercionReady)
     assert out.params_base["employer_profile_id"] == ep_uuid
     session.execute.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# P2 — fuzzy_dedup_contract_violation metric counter (JIE phase-1-cleanup-pair-c)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_fuzzy_dedup_after_promotion_logs_contract_violation_for_value_error() -> None:
+    """ValueError from apply_fuzzy_dedup_result must log fuzzy_dedup_contract_violation,
+    not fuzzy_dedup_after_promotion_failed, so dashboards count contract violations
+    as a distinct metric from infrastructure failures."""
+    session = MagicMock()
+    session.begin_nested.return_value = nullcontext()
+
+    with (
+        patch(
+            "enrichment.job_postings_promotion.resolve_job_posting_row",
+            return_value={"job_posting_id": CURRENT_ID, "company_id": MATCHED_ID},
+        ),
+        patch(
+            "enrichment.job_postings_promotion.run_fuzzy_dedup",
+            return_value=FuzzyDedupResult(
+                is_duplicate=False,
+                duplicate_cluster_id=None,
+                matched_job_posting_id=None,
+                survivor_job_posting_id=None,
+                stub=False,
+            ),
+        ),
+        patch(
+            "enrichment.job_postings_promotion.apply_fuzzy_dedup_result",
+            side_effect=ValueError("duplicate fuzzy dedup results must include duplicate_cluster_id"),
+        ),
+        patch("enrichment.job_postings_promotion.resolve_sector", return_value=None),
+        structlog.testing.capture_logs() as cap_logs,
+    ):
+        applied = apply_enrichment_to_job_postings(
+            session,
+            normalized_job_id=123,
+            record_enriched_payload=_promotion_payload(),
+        )
+
+    assert applied is True
+    violation_events = [e for e in cap_logs if e.get("event") == "fuzzy_dedup_contract_violation"]
+    assert len(violation_events) == 1, f"expected 1 contract violation log, got: {cap_logs}"
+    assert violation_events[0]["job_posting_id"] == CURRENT_ID
+    assert violation_events[0]["normalized_job_id"] == 123
+    assert "duplicate_cluster_id" in violation_events[0]["error"]
+    # Must NOT fall through to the generic infrastructure failure key
+    assert not any(e.get("event") == "fuzzy_dedup_after_promotion_failed" for e in cap_logs)
+
+
+def test_apply_fuzzy_dedup_after_promotion_logs_general_failure_for_non_value_error() -> None:
+    """Non-ValueError exceptions (DB errors, network timeouts) must still log
+    fuzzy_dedup_after_promotion_failed — the original infrastructure failure key."""
+    session = MagicMock()
+    session.begin_nested.return_value = nullcontext()
+
+    with (
+        patch(
+            "enrichment.job_postings_promotion.resolve_job_posting_row",
+            return_value={"job_posting_id": CURRENT_ID, "company_id": MATCHED_ID},
+        ),
+        patch(
+            "enrichment.job_postings_promotion.run_fuzzy_dedup",
+            side_effect=RuntimeError("db pool exhausted"),
+        ),
+        patch("enrichment.job_postings_promotion.resolve_sector", return_value=None),
+        structlog.testing.capture_logs() as cap_logs,
+    ):
+        applied = apply_enrichment_to_job_postings(
+            session,
+            normalized_job_id=456,
+            record_enriched_payload=_promotion_payload(),
+        )
+
+    assert applied is True
+    failure_events = [e for e in cap_logs if e.get("event") == "fuzzy_dedup_after_promotion_failed"]
+    assert len(failure_events) == 1, f"expected 1 infrastructure failure log, got: {cap_logs}"
+    assert failure_events[0]["job_posting_id"] == CURRENT_ID
+    assert failure_events[0]["normalized_job_id"] == 456
+    assert "db pool exhausted" in failure_events[0]["error"]
+    # Must NOT be misclassified as a contract violation
+    assert not any(e.get("event") == "fuzzy_dedup_contract_violation" for e in cap_logs)

--- a/enrichment/tests/test_job_postings_promotion.py
+++ b/enrichment/tests/test_job_postings_promotion.py
@@ -217,7 +217,9 @@ def test_apply_fuzzy_dedup_result_rejects_invalid_duplicate_contract() -> None:
         stub=False,
     )
 
-    with pytest.raises(FuzzyDedupContractError, match="duplicate fuzzy dedup results must include duplicate_cluster_id"):
+    with pytest.raises(
+        FuzzyDedupContractError, match="duplicate fuzzy dedup results must include duplicate_cluster_id"
+    ):
         apply_fuzzy_dedup_result(session, CURRENT_ID, result)
 
 


### PR DESCRIPTION
## What

Introduces `FuzzyDedupContractError` and emits a distinct structured log event
(`fuzzy_dedup_contract_violation`) for fuzzy-dedup contract violations, so
observability dashboards can count them separately from infrastructure failures.

## Why

`_apply_fuzzy_dedup_after_promotion` previously caught a single broad `except Exception`
block, logging everything under `fuzzy_dedup_after_promotion_failed`. This conflated
two fundamentally different failure modes:

- **Contract violations** — `apply_fuzzy_dedup_result` raises when a `FuzzyDedupResult`
  is structurally invalid (e.g. a duplicate result missing `duplicate_cluster_id`, or a
  survivor ID pointing to the wrong row). These indicate an upstream bug in how
  `FuzzyDedupResult` is constructed and should trend at or near zero in a healthy pipeline.
- **Infrastructure failures** — DB errors, network timeouts, and transient environment
  issues that are expected to self-resolve.

Mixing these under one log key makes it impossible to distinguish a persistent upstream
bug from a flaky DB connection in the observability dashboard. They need separate counters.

A plain `except ValueError` catch was considered but rejected: `run_fuzzy_dedup` can also
raise `ValueError` from internal computation (e.g. numpy shape mismatches), which would be
mis-classified as a contract violation. `FuzzyDedupContractError(ValueError)` makes the
intent explicit and the catch precise.

## Changes

**`enrichment/job_postings_promotion.py`**
- Define `FuzzyDedupContractError(ValueError)` — subclasses `ValueError` for backward
  compatibility with existing callers, but gives the exception handler a precise type to match
- Replace all five `raise ValueError(...)` contract guards in `apply_fuzzy_dedup_result`
  with `raise FuzzyDedupContractError(...)`
- Split the exception handler in `_apply_fuzzy_dedup_after_promotion`:
  - `except FuzzyDedupContractError` → logs `fuzzy_dedup_contract_violation` (new key)
  - `except Exception` → retains `fuzzy_dedup_after_promotion_failed` for infrastructure failures
- Update EXEMPLAR comment to reference `FuzzyDedupContractError`

**`enrichment/tests/test_job_postings_promotion.py`**
- Import `FuzzyDedupContractError`; update pre-existing contract test to assert the precise type
- Two new tests:
  - `test_apply_fuzzy_dedup_after_promotion_logs_contract_violation_for_contract_error` — verifies
    `FuzzyDedupContractError` routes to `fuzzy_dedup_contract_violation` and not the infra key
  - `test_apply_fuzzy_dedup_after_promotion_logs_general_failure_for_non_value_error` — verifies
    `RuntimeError` routes to `fuzzy_dedup_after_promotion_failed` and not the contract key

## Verification

- `pytest enrichment/tests/test_job_postings_promotion.py` — 62 passed, 0 failures
- `ruff check enrichment/job_postings_promotion.py enrichment/tests/test_job_postings_promotion.py` — clean
- Savepoint semantics, promotion transaction, and all existing behavior unchanged
- Part of Phase 1 Cleanup — Pair C P2 (`feat/dedup-fuzzy-contract-metric`)
- Sequencing: built on top of Pair C P1 (PR #389, merged 2026-05-13)