### PR TITLE
docs(exemplar): add Phase 2 EXEMPLAR markers to enrichment/dedup modules (Pair C)

### DIFF
--- a/enrichment/dedup/completeness.py
+++ b/enrichment/dedup/completeness.py
@@ -1,4 +1,10 @@
-"""Field completeness counting for fuzzy dedup survivor arbitration."""
+"""Field completeness counting for fuzzy dedup survivor arbitration.
+
+# EXEMPLAR: Phase 2 reference — single-responsibility pure functions; defensive
+# _has_value guard handles None/empty/non-string uniformly; no side effects or
+# global mutable state; entire module is 43 lines and exhaustively testable
+# without a DB connection or LLM call.
+"""
 
 from __future__ import annotations
 

--- a/enrichment/dedup/fuzzy_dedup.py
+++ b/enrichment/dedup/fuzzy_dedup.py
@@ -215,6 +215,12 @@ def run_fuzzy_dedup(
 
     Persists ``dedup_text_hash`` and ``dedup_embedding`` on success; duplicate flags are
     applied by ``job_postings_promotion.apply_fuzzy_dedup_result``.
+
+    # EXEMPLAR: Phase 2 reference — layered load→validate→embed→compare→arbitrate
+    # pipeline; every error path is structured-logged with a distinct key; safe
+    # defaults (_unique_result) on any failure so the caller never receives a
+    # partially-constructed result; threshold and window are config-driven with no
+    # hardcoded values; embedding cache avoids redundant Azure calls within a batch.
     """
     effective_threshold = dedup_cosine_threshold() if threshold is None else threshold
     jid = (job_posting_id or "").strip()

--- a/enrichment/dedup/fuzzy_dedup.py
+++ b/enrichment/dedup/fuzzy_dedup.py
@@ -213,14 +213,14 @@ def run_fuzzy_dedup(
     """
     Compare one posting's embedding against same-company survivors in the rolling window.
 
-    Persists ``dedup_text_hash`` and ``dedup_embedding`` on success; duplicate flags are
-    applied by ``job_postings_promotion.apply_fuzzy_dedup_result``.
-
     # EXEMPLAR: Phase 2 reference — layered load→validate→embed→compare→arbitrate
     # pipeline; every error path is structured-logged with a distinct key; safe
     # defaults (_unique_result) on any failure so the caller never receives a
     # partially-constructed result; threshold and window are config-driven with no
     # hardcoded values; embedding cache avoids redundant Azure calls within a batch.
+
+    Persists ``dedup_text_hash`` and ``dedup_embedding`` on success; duplicate flags are
+    applied by ``job_postings_promotion.apply_fuzzy_dedup_result``.
     """
     effective_threshold = dedup_cosine_threshold() if threshold is None else threshold
     jid = (job_posting_id or "").strip()

--- a/enrichment/dedup/text.py
+++ b/enrichment/dedup/text.py
@@ -1,4 +1,10 @@
-"""Build normalized dedup text for fuzzy near-duplicate detection (IMP-018)."""
+"""Build normalized dedup text for fuzzy near-duplicate detection (IMP-018).
+
+# EXEMPLAR: Phase 2 reference — normalize/hash decoupled into pure functions;
+# immutable string ops with no side effects; extend hash logic or normalization
+# independently without touching the other; each function is unit-testable in
+# isolation with no DB or LLM dependency.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## What

Adds `# EXEMPLAR: Phase 2 reference — <reason>` comments to the three dedup modules listed in Pair C exemplar-marker task:

- **`enrichment/dedup/text.py`** (entire file) — normalize/hash decoupled into pure functions; immutable string ops; independently extensible without touching hash logic; unit-testable with no DB or LLM dependency
- **`enrichment/dedup/completeness.py`** (entire file) — single-responsibility pure functions; defensive `_has_value` guard; no side effects or global mutable state; 43-line, exhaustively testable
- **`enrichment/dedup/fuzzy_dedup.py` — `run_fuzzy_dedup`** — layered load→validate→embed→compare→arbitrate pipeline; every error path structured-logged with a distinct key; safe defaults on failure; threshold and window are config-driven; embedding cache avoids redundant Azure calls

## Why

These modules are called out as Phase 2 reference implementations for the dedup stream. The markers make the intent visible to future pairs building on this code.

## Verification

- No logic changes — marker comments only
- `ruff check enrichment/dedup/text.py enrichment/dedup/completeness.py enrichment/dedup/fuzzy_dedup.py` — clean
- Sequencing: built on `development` after #401 (Pair C P2) merged

## Files

`enrichment/dedup/text.py`, `enrichment/dedup/completeness.py`, `enrichment/dedup/fuzzy_dedup.py` — 3 files, docstring additions only