### PR TITLE
feat(router): AI-tool taxonomy supplement — unblocks disruption eval slice (#349)

### DIFF
--- a/analytics/query_engine/router.py
+++ b/analytics/query_engine/router.py
@@ -386,14 +386,83 @@ _SKILL_AGG_INTENTS_REQUIRING_TAXONOMY: frozenset[str] = frozenset(
     {"trend", "disruption", "emergence", "comparison", "curriculum"},
 )
 
+# JIE #349 — AI-tool / AI-adjacent canonical terms accepted by the taxonomy gate
+# even before they are seeded to dbo.skills.  All values are lowercase; the gate
+# normalises incoming skill_names to lowercase before checking.
+#
+# To permanently surface these terms across all analytics dimensions (skill demand,
+# velocity, co-occurrence), run:  python scripts/seed_ai_taxonomy_terms.py
+_AI_TOOL_SUPPLEMENTAL_TERMS: frozenset[str] = frozenset(
+    {
+        # AI coding assistants
+        "copilot",
+        "github copilot",
+        "cursor",
+        "cursor ide",
+        "claude",
+        "claude.ai",
+        "chatgpt",
+        "gpt-4",
+        "gpt4",
+        # AI skill categories
+        "prompt engineering",
+        "rag",
+        "vector search",
+        "llm engineering",
+        "ai-adjacent",
+        "ai-native",
+        "ai-augmented",
+        "ai-assisted testing",
+        "aiops",
+        "llm-driven incident triage",
+        "copilot for infra-as-code",
+        "ai-assistant tools",
+        "ai assistant tools",
+        # Automation / RPA
+        "automation",
+        "rpa",
+        "robotic process automation",
+        "workflow automation",
+        "process automation",
+        # RPA and AI tool brands
+        "uipath",
+        "blue prism",
+        "automation anywhere",
+        "testim",
+        "mabl",
+        "applitools",
+        "langchain",
+    }
+)
+
+# Resolution aliases: variant spelling → canonical form (always lowercase).
+# Applied after lowercasing and before the supplemental / DB lookup so that
+# "GitHub Copilot" and "Copilot" resolve to the same canonical term.
+_AI_TOOL_RESOLUTION_ALIASES: dict[str, str] = {
+    "github copilot": "copilot",
+    "ms copilot": "copilot",
+    "microsoft copilot": "copilot",
+    "openai chatgpt": "chatgpt",
+    "gpt4": "gpt-4",
+    "cursor ide": "cursor",
+    "claude.ai": "claude",
+    "robotic process automation": "rpa",
+    "ai assistant tools": "ai-assistant tools",
+    "llm incident triage": "llm-driven incident triage",
+}
+
 
 def _skill_terms_all_in_dbo_skills(session: Session, skill_names: list[str], *, max_terms: int = 5) -> bool:
-    """True iff each distinct extracted skill term matches ``dbo.skills.skill_name`` (ci exact).
+    """True iff each distinct extracted skill term matches ``dbo.skills.skill_name`` (ci exact)
+    or belongs to the AI-tool supplemental allowlist (JIE #349).
 
     Matching uses **case-insensitive equality on the full stored skill_name** only.
     Substring or ``ILIKE '%term%'`` is intentionally avoided: short tokens and
     ambiguous fragments would otherwise match unrelated taxonomy rows and let
     broad aggregates pass the gate (the RT-007 failure mode).
+
+    AI-tool terms in ``_AI_TOOL_SUPPLEMENTAL_TERMS`` bypass the DB lookup: they are
+    semantically valid skill references whose taxonomy entries are seeded separately.
     """
     lowered: list[str] = []
     for raw in skill_names[:max_terms]:
@@ -403,9 +472,15 @@ def _skill_terms_all_in_dbo_skills(session: Session, skill_names: list[str], *, 
     if not lowered:
         return True
     distinct = list(dict.fromkeys(lowered))
-    stmt = select(func.lower(Skill.skill_name)).where(func.lower(Skill.skill_name).in_(distinct))
+    # Resolve aliases before checking (e.g. "GitHub Copilot" → "copilot").
+    resolved = [_AI_TOOL_RESOLUTION_ALIASES.get(t, t) for t in distinct]
+    # Terms in the supplemental AI-tool list are accepted without a DB round-trip.
+    db_terms = [t for t in resolved if t not in _AI_TOOL_SUPPLEMENTAL_TERMS]
+    if not db_terms:
+        return True
+    stmt = select(func.lower(Skill.skill_name)).where(func.lower(Skill.skill_name).in_(db_terms))
     matched = set(session.execute(stmt).scalars().all())
-    return all(term in matched for term in distinct)
+    return all(term in matched for term in db_terms)
 
 
 def _skill_taxonomy_block_result(

--- a/analytics/query_engine/router.py
+++ b/analytics/query_engine/router.py
@@ -390,20 +390,24 @@ _SKILL_AGG_INTENTS_REQUIRING_TAXONOMY: frozenset[str] = frozenset(
 # even before they are seeded to dbo.skills.  All values are lowercase; the gate
 # normalises incoming skill_names to lowercase before checking.
 #
+# Rules for this set:
+#   1. Canonical forms only — variant spellings belong in _AI_TOOL_RESOLUTION_ALIASES.
+#      Alias resolution always runs first, so a term that is also an alias key can
+#      never reach this frozenset check; such entries are unreachable dead code.
+#   2. No generic single-word fragments (e.g. "automation", "rpa").  Short tokens can
+#      match unrelated taxonomy rows and re-open the RT-007 broad-aggregate failure
+#      mode.  Specific brand names and multi-word phrases are safe.
+#
 # To permanently surface these terms across all analytics dimensions (skill demand,
 # velocity, co-occurrence), run:  python scripts/seed_ai_taxonomy_terms.py
 _AI_TOOL_SUPPLEMENTAL_TERMS: frozenset[str] = frozenset(
     {
-        # AI coding assistants
+        # AI coding assistants (canonical forms; aliases map variants → these)
         "copilot",
-        "github copilot",
         "cursor",
-        "cursor ide",
         "claude",
-        "claude.ai",
         "chatgpt",
         "gpt-4",
-        "gpt4",
         # AI skill categories
         "prompt engineering",
         "rag",
@@ -417,14 +421,10 @@ _AI_TOOL_SUPPLEMENTAL_TERMS: frozenset[str] = frozenset(
         "llm-driven incident triage",
         "copilot for infra-as-code",
         "ai-assistant tools",
-        "ai assistant tools",
-        # Automation / RPA
-        "automation",
-        "rpa",
-        "robotic process automation",
+        # Automation / RPA — specific brands and multi-word phrases only.
+        # "automation" and "rpa" are excluded (RT-007 risk: too short/generic).
         "workflow automation",
         "process automation",
-        # RPA and AI tool brands
         "uipath",
         "blue prism",
         "automation anywhere",
@@ -437,7 +437,9 @@ _AI_TOOL_SUPPLEMENTAL_TERMS: frozenset[str] = frozenset(
 
 # Resolution aliases: variant spelling → canonical form (always lowercase).
 # Applied after lowercasing and before the supplemental / DB lookup so that
-# "GitHub Copilot" and "Copilot" resolve to the same canonical term.
+# e.g. "GitHub Copilot" and "Copilot" resolve to the same canonical term.
+# Every alias target must be present in _AI_TOOL_SUPPLEMENTAL_TERMS so that
+# the alias short-circuits the DB lookup for the canonical form as well.
 _AI_TOOL_RESOLUTION_ALIASES: dict[str, str] = {
     "github copilot": "copilot",
     "ms copilot": "copilot",
@@ -446,7 +448,6 @@ _AI_TOOL_RESOLUTION_ALIASES: dict[str, str] = {
     "gpt4": "gpt-4",
     "cursor ide": "cursor",
     "claude.ai": "claude",
-    "robotic process automation": "rpa",
     "ai assistant tools": "ai-assistant tools",
     "llm incident triage": "llm-driven incident triage",
 }

--- a/analytics/tests/test_router.py
+++ b/analytics/tests/test_router.py
@@ -38,12 +38,15 @@ from analytics.query_engine.constants import (
     NO_DATA_SKILL_TAXONOMY_REFUSAL,
 )
 from analytics.query_engine.router import (
+    _AI_TOOL_RESOLUTION_ALIASES,
+    _AI_TOOL_SUPPLEMENTAL_TERMS,
     ALLOWED_TABLES,
     QueryRouter,
     _clean_workflow_role_names,
     _is_list_style,
     _parse_weeks_back,
     _resolve_geo_terms,
+    _skill_terms_all_in_dbo_skills,
     _split_geo_term,
     _tokenize_role_name,
     _week_floor,
@@ -458,6 +461,76 @@ class TestEdgeCases:
         assert result.row_count == 0
         assert result.tables_used == []
         session.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AI-tool taxonomy supplement (JIE #349)
+# ---------------------------------------------------------------------------
+
+
+class TestAIToolTaxonomySupplement:
+    """Validate that AI-tool / AI-adjacent terms bypass the DB taxonomy gate."""
+
+    def test_supplemental_terms_frozenset_is_non_empty(self) -> None:
+        assert len(_AI_TOOL_SUPPLEMENTAL_TERMS) > 0
+
+    def test_resolution_aliases_values_are_in_supplemental_set(self) -> None:
+        """Every alias target must resolve to a term in the supplemental set."""
+        for alias, canonical in _AI_TOOL_RESOLUTION_ALIASES.items():
+            assert canonical in _AI_TOOL_SUPPLEMENTAL_TERMS, (
+                f"alias {alias!r} → {canonical!r} is not in _AI_TOOL_SUPPLEMENTAL_TERMS"
+            )
+
+    def test_ai_tool_terms_bypass_db_lookup(self) -> None:
+        """copilot, chatgpt, prompt engineering etc. must not issue a DB query."""
+        session = MagicMock(spec=Session)
+        result = _skill_terms_all_in_dbo_skills(session, ["Copilot", "ChatGPT", "Prompt Engineering"])
+        assert result is True
+        session.execute.assert_not_called()
+
+    def test_rpa_terms_bypass_db_lookup(self) -> None:
+        """Automation / RPA terms must not issue a DB query."""
+        session = MagicMock(spec=Session)
+        result = _skill_terms_all_in_dbo_skills(session, ["RPA", "UiPath", "automation"])
+        assert result is True
+        session.execute.assert_not_called()
+
+    def test_alias_resolution_github_copilot_bypasses_db(self) -> None:
+        """'GitHub Copilot' aliases to 'copilot' and must bypass the DB gate."""
+        session = MagicMock(spec=Session)
+        result = _skill_terms_all_in_dbo_skills(session, ["GitHub Copilot"])
+        assert result is True
+        session.execute.assert_not_called()
+
+    def test_mixed_ai_and_db_terms_still_queries_db_for_non_supplemental(self) -> None:
+        """If a question contains one AI-tool term and one unknown term, the DB
+        is still queried for the unknown term only."""
+        tax_mock = MagicMock()
+        tax_mock.scalars.return_value.all.return_value = ["python"]
+        session = MagicMock(spec=Session)
+        session.execute.return_value = tax_mock
+        # "Copilot" → supplemental (no DB); "Python" → DB query
+        result = _skill_terms_all_in_dbo_skills(session, ["Copilot", "Python"])
+        assert result is True
+        session.execute.assert_called_once()
+
+    def test_disruption_intent_with_ai_tools_routes_through_gate(self) -> None:
+        """Disruption question whose extracted skills are all AI-tool terms must not
+        be blocked — it should reach the disruption handler (JIE #349)."""
+        session = _make_session(rows=[_make_mock_row(temporal_period="agentic_era", posting_count=42)])
+        cls = _mk_classification("disruption", skill_names=["Copilot", "ChatGPT"])
+        result = QueryRouter().route(cls, session)
+        assert result.routed is True
+        assert result.empty_rows_refusal_reason is None or result.row_count > 0
+
+    def test_trend_intent_with_langchain_routes_without_db_gate(self) -> None:
+        """LangChain is in the supplemental set — trend query must not query skills table first."""
+        session = _make_session(rows=[_make_mock_row(skill_label="LangChain", posting_count=10)])
+        cls = _mk_classification("trend", skill_names=["LangChain"])
+        result = QueryRouter().route(cls, session)
+        assert result.routed is True
+        # Only the trend aggregate query executes; no separate taxonomy probe call.
+        assert session.execute.call_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/analytics/tests/test_router.py
+++ b/analytics/tests/test_router.py
@@ -488,10 +488,12 @@ class TestAIToolTaxonomySupplement:
         assert result is True
         session.execute.assert_not_called()
 
-    def test_rpa_terms_bypass_db_lookup(self) -> None:
-        """Automation / RPA terms must not issue a DB query."""
+    def test_automation_brands_bypass_db_lookup(self) -> None:
+        """Specific automation brand names must not issue a DB query.
+        Note: bare "automation" and "rpa" are intentionally excluded from the
+        supplemental set (RT-007 risk) and will fall through to the DB lookup."""
         session = MagicMock(spec=Session)
-        result = _skill_terms_all_in_dbo_skills(session, ["RPA", "UiPath", "automation"])
+        result = _skill_terms_all_in_dbo_skills(session, ["UiPath", "Blue Prism", "Workflow Automation"])
         assert result is True
         session.execute.assert_not_called()
 
@@ -516,12 +518,15 @@ class TestAIToolTaxonomySupplement:
 
     def test_disruption_intent_with_ai_tools_routes_through_gate(self) -> None:
         """Disruption question whose extracted skills are all AI-tool terms must not
-        be blocked — it should reach the disruption handler (JIE #349)."""
+        be blocked by the taxonomy gate — it should reach the disruption handler (JIE #349)."""
         session = _make_session(rows=[_make_mock_row(temporal_period="agentic_era", posting_count=42)])
         cls = _mk_classification("disruption", skill_names=["Copilot", "ChatGPT"])
         result = QueryRouter().route(cls, session)
         assert result.routed is True
-        assert result.empty_rows_refusal_reason is None or result.row_count > 0
+        assert result.empty_rows_refusal_reason is None, (
+            f"taxonomy gate must not have blocked: {result.empty_rows_refusal_reason}"
+        )
+        assert result.row_count > 0
 
     def test_trend_intent_with_langchain_routes_without_db_gate(self) -> None:
         """LangChain is in the supplemental set — trend query must not query skills table first."""

--- a/scripts/seed_ai_taxonomy_terms.py
+++ b/scripts/seed_ai_taxonomy_terms.py
@@ -46,7 +46,7 @@ from common.data_store.models import Skill  # noqa: E402
 log = structlog.get_logger()
 
 # Subcategory IDs from dbo.skill_subcategories (fixture-seeded)
-_AIML_SUBCATEGORY_ID = "F6CD1DF0-8352-4B4E-BE9B-E5291BC95702"   # AI/ML
+_AIML_SUBCATEGORY_ID = "F6CD1DF0-8352-4B4E-BE9B-E5291BC95702"  # AI/ML
 _AUTOMATION_SUBCATEGORY_ID = "344DEF26-88C4-430F-A7D2-0195A6EFF498"  # IT Automation
 
 # Terms that belong under the Automation subcategory; everything else → AI/ML.
@@ -74,9 +74,22 @@ def _subcategory_for(term: str) -> str:
 def _skill_type_for(term: str) -> str:
     """Rough type assignment; "tool" for named products, "knowledge" for concepts."""
     tools = {
-        "copilot", "github copilot", "cursor", "cursor ide", "claude", "claude.ai",
-        "chatgpt", "gpt-4", "gpt4", "uipath", "blue prism", "automation anywhere",
-        "testim", "mabl", "applitools", "langchain",
+        "copilot",
+        "github copilot",
+        "cursor",
+        "cursor ide",
+        "claude",
+        "claude.ai",
+        "chatgpt",
+        "gpt-4",
+        "gpt4",
+        "uipath",
+        "blue prism",
+        "automation anywhere",
+        "testim",
+        "mabl",
+        "applitools",
+        "langchain",
     }
     return "tool" if term in tools else "knowledge"
 
@@ -95,7 +108,9 @@ def run(*, dry_run: bool) -> None:
                 select(func.lower(Skill.skill_name)).where(
                     func.lower(Skill.skill_name).in_([t.lower() for t in canonical_terms])
                 )
-            ).scalars().all()
+            )
+            .scalars()
+            .all()
         )
 
         to_insert = [t for t in canonical_terms if t.lower() not in existing]

--- a/scripts/seed_ai_taxonomy_terms.py
+++ b/scripts/seed_ai_taxonomy_terms.py
@@ -50,11 +50,9 @@ _AIML_SUBCATEGORY_ID = "F6CD1DF0-8352-4B4E-BE9B-E5291BC95702"  # AI/ML
 _AUTOMATION_SUBCATEGORY_ID = "344DEF26-88C4-430F-A7D2-0195A6EFF498"  # IT Automation
 
 # Terms that belong under the Automation subcategory; everything else → AI/ML.
+# Mirrors the automation brands / multi-word phrases retained in the supplemental set.
 _AUTOMATION_TERMS: frozenset[str] = frozenset(
     {
-        "automation",
-        "rpa",
-        "robotic process automation",
         "workflow automation",
         "process automation",
         "uipath",
@@ -66,6 +64,43 @@ _AUTOMATION_TERMS: frozenset[str] = frozenset(
     }
 )
 
+# Display-ready casing for each canonical term.  The supplemental set stores
+# lowercase keys for gate matching; dbo.skills should store human-readable names
+# so they surface correctly in dashboards and velocity/demand exports.
+_DISPLAY_NAMES: dict[str, str] = {
+    "copilot": "Copilot",
+    "cursor": "Cursor",
+    "claude": "Claude",
+    "chatgpt": "ChatGPT",
+    "gpt-4": "GPT-4",
+    "prompt engineering": "Prompt Engineering",
+    "rag": "RAG",
+    "vector search": "Vector Search",
+    "llm engineering": "LLM Engineering",
+    "ai-adjacent": "AI-Adjacent",
+    "ai-native": "AI-Native",
+    "ai-augmented": "AI-Augmented",
+    "ai-assisted testing": "AI-Assisted Testing",
+    "aiops": "AIOps",
+    "llm-driven incident triage": "LLM-Driven Incident Triage",
+    "copilot for infra-as-code": "Copilot for Infra-as-Code",
+    "ai-assistant tools": "AI-Assistant Tools",
+    "workflow automation": "Workflow Automation",
+    "process automation": "Process Automation",
+    "uipath": "UiPath",
+    "blue prism": "Blue Prism",
+    "automation anywhere": "Automation Anywhere",
+    "testim": "Testim",
+    "mabl": "Mabl",
+    "applitools": "Applitools",
+    "langchain": "LangChain",
+}
+
+
+def _display_name_for(term: str) -> str:
+    """Return display-ready casing; fall back to title-case for unknown terms."""
+    return _DISPLAY_NAMES.get(term, term.title())
+
 
 def _subcategory_for(term: str) -> str:
     return _AUTOMATION_SUBCATEGORY_ID if term in _AUTOMATION_TERMS else _AIML_SUBCATEGORY_ID
@@ -75,14 +110,10 @@ def _skill_type_for(term: str) -> str:
     """Rough type assignment; "tool" for named products, "knowledge" for concepts."""
     tools = {
         "copilot",
-        "github copilot",
         "cursor",
-        "cursor ide",
         "claude",
-        "claude.ai",
         "chatgpt",
         "gpt-4",
-        "gpt4",
         "uipath",
         "blue prism",
         "automation anywhere",
@@ -129,7 +160,11 @@ def run(*, dry_run: bool) -> None:
 
         if dry_run:
             for term in to_insert:
-                log.info("seed_ai_taxonomy_terms_would_insert", term=term)
+                log.info(
+                    "seed_ai_taxonomy_terms_would_insert",
+                    term=term,
+                    display_name=_display_name_for(term),
+                )
             return
 
         inserted = 0
@@ -137,7 +172,7 @@ def run(*, dry_run: bool) -> None:
             skill = Skill(
                 skill_id=str(uuid.uuid4()).upper(),
                 skill_subcategory_id=_subcategory_for(term),
-                skill_name=term,
+                skill_name=_display_name_for(term),
                 skill_info_url="",
                 skill_type=_skill_type_for(term),
                 createdat=now,

--- a/scripts/seed_ai_taxonomy_terms.py
+++ b/scripts/seed_ai_taxonomy_terms.py
@@ -1,0 +1,154 @@
+"""One-shot seed: insert AI-tool / AI-adjacent terms into dbo.skills.
+
+JIE #349 — The skill taxonomy gate in ``analytics/query_engine/router.py``
+blocks disruption questions when extracted skill names (e.g. "Copilot",
+"ChatGPT", "RPA") are absent from ``dbo.skills``.  This script permanently
+adds those terms so they surface in all analytics dimensions (skill demand,
+velocity, co-occurrence) once embeddings are backfilled.
+
+Until this script is run, the router's ``_AI_TOOL_SUPPLEMENTAL_TERMS``
+frozenset acts as a stop-gap so the gate does not block valid AI-intent
+questions.
+
+Usage (repo root, venv, ``PYTHON_DATABASE_URL`` set)::
+
+    python scripts/seed_ai_taxonomy_terms.py --dry-run
+    python scripts/seed_ai_taxonomy_terms.py
+
+Refs: #349
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(_REPO / ".env")
+
+import structlog  # noqa: E402
+from sqlalchemy import func, select  # noqa: E402
+
+from analytics.query_engine.router import (  # noqa: E402
+    _AI_TOOL_SUPPLEMENTAL_TERMS,
+)
+from common.data_store.database import session_scope  # noqa: E402
+from common.data_store.models import Skill  # noqa: E402
+
+log = structlog.get_logger()
+
+# Subcategory IDs from dbo.skill_subcategories (fixture-seeded)
+_AIML_SUBCATEGORY_ID = "F6CD1DF0-8352-4B4E-BE9B-E5291BC95702"   # AI/ML
+_AUTOMATION_SUBCATEGORY_ID = "344DEF26-88C4-430F-A7D2-0195A6EFF498"  # IT Automation
+
+# Terms that belong under the Automation subcategory; everything else → AI/ML.
+_AUTOMATION_TERMS: frozenset[str] = frozenset(
+    {
+        "automation",
+        "rpa",
+        "robotic process automation",
+        "workflow automation",
+        "process automation",
+        "uipath",
+        "blue prism",
+        "automation anywhere",
+        "testim",
+        "mabl",
+        "applitools",
+    }
+)
+
+
+def _subcategory_for(term: str) -> str:
+    return _AUTOMATION_SUBCATEGORY_ID if term in _AUTOMATION_TERMS else _AIML_SUBCATEGORY_ID
+
+
+def _skill_type_for(term: str) -> str:
+    """Rough type assignment; "tool" for named products, "knowledge" for concepts."""
+    tools = {
+        "copilot", "github copilot", "cursor", "cursor ide", "claude", "claude.ai",
+        "chatgpt", "gpt-4", "gpt4", "uipath", "blue prism", "automation anywhere",
+        "testim", "mabl", "applitools", "langchain",
+    }
+    return "tool" if term in tools else "knowledge"
+
+
+def run(*, dry_run: bool) -> None:
+    now = datetime.now(timezone.utc)
+
+    # Seed every term in the supplemental set.  Alias targets (canonical forms)
+    # are already members of the set by construction, so no special casing needed.
+    canonical_terms = sorted(_AI_TOOL_SUPPLEMENTAL_TERMS)
+
+    with session_scope() as session:
+        # Find which terms already exist (case-insensitive).
+        existing: set[str] = set(
+            session.execute(
+                select(func.lower(Skill.skill_name)).where(
+                    func.lower(Skill.skill_name).in_([t.lower() for t in canonical_terms])
+                )
+            ).scalars().all()
+        )
+
+        to_insert = [t for t in canonical_terms if t.lower() not in existing]
+
+        log.info(
+            "seed_ai_taxonomy_terms_plan",
+            total_terms=len(canonical_terms),
+            already_present=len(existing),
+            to_insert=len(to_insert),
+            dry_run=dry_run,
+        )
+
+        if not to_insert:
+            log.info("seed_ai_taxonomy_terms_noop", reason="all_terms_already_present")
+            return
+
+        if dry_run:
+            for term in to_insert:
+                log.info("seed_ai_taxonomy_terms_would_insert", term=term)
+            return
+
+        inserted = 0
+        for term in to_insert:
+            skill = Skill(
+                skill_id=str(uuid.uuid4()).upper(),
+                skill_subcategory_id=_subcategory_for(term),
+                skill_name=term,
+                skill_info_url="",
+                skill_type=_skill_type_for(term),
+                createdat=now,
+                updatedat=now,
+            )
+            session.add(skill)
+            inserted += 1
+
+        session.flush()
+        log.info("seed_ai_taxonomy_terms_done", inserted=inserted)
+
+    log.info("seed_ai_taxonomy_terms_committed", inserted=inserted)
+    print(f"Inserted {inserted} AI-tool taxonomy terms into dbo.skills.")
+    print("Run  python scripts/seed_esco_embeddings.py  to backfill embeddings for the new rows.")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the terms that would be inserted without committing.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    run(dry_run=args.dry_run)


### PR DESCRIPTION
## Merge plan

This PR is part of a 3-PR stack landing the disruption / geographic / comparison eval fixes:

| Order | PR | Branch | Touches | Conflicts |
|---|---|---|---|---|
| 1 | #407 | `docs/124-findings-citation-calibration-cost` | findings doc only | None |
| **2 (this PR)** | #405 | `feat/349-ai-taxonomy-supplement` | `router.py`, `test_router.py`, `scripts/seed_ai_taxonomy_terms.py` | conflicts with #406 |
| 3 | #406 | `feat/340-geo-comp-prompt-iterations` | `router.py`, `synthesis.py`, `test_router.py`, eval log + findings | conflicts with #405; **rebase required** |

### Why this PR merges before #406

Both this PR and #406 add a frozenset right after `_SKILL_AGG_INTENTS_REQUIRING_TAXONOMY` and modify the body of `_skill_terms_all_in_dbo_skills` / its imports in `test_router.py`. A textual merge conflict is unavoidable. #406's author already anticipated this in a code comment: "When #349 lands, replace this line with: `_TAXONOMY_SUPPLEMENT = _COMPARISON_SKILL_SUPPLEMENT | _AI_TOOL_SUPPLEMENT`".

This PR is the broader, more foundational change (introduces `_AI_TOOL_SUPPLEMENTAL_TERMS`, alias resolution, and the operational seed script), so it lands first and #406 rebases onto it.

A throw-away merge of the two branches was verified locally:
- Hand-resolved conflicts (union the two frozensets, alias-resolve first, then filter)
- `pytest analytics/tests/` → **288 passed, 3 skipped, 0 failures**
- `ruff check` + `ruff format --check` → clean

### Post-merge operational steps (run against the SoT DB)

```bash
# 1. Confirm what will be inserted
python scripts/seed_ai_taxonomy_terms.py --dry-run

# 2. Insert the 26 AI-tool / AI-adjacent terms into dbo.skills
python scripts/seed_ai_taxonomy_terms.py

# 3. Backfill embeddings so the new rows are reachable by cosine-similarity linking
python scripts/seed_esco_embeddings.py
```

Until step 2 runs, the router's `_AI_TOOL_SUPPLEMENTAL_TERMS` frozenset is the stop-gap that keeps the taxonomy gate from blocking AI-tool queries.

### After #406 rebases on this PR

The owner of #406 must apply the union the comment in this PR anticipates — full instructions are in #406's "Merge plan" section.

---

## What

Adds `_AI_TOOL_SUPPLEMENTAL_TERMS` (28 canonical AI-tool / AI-adjacent terms) and `_AI_TOOL_RESOLUTION_ALIASES` (variant-spelling map) to `analytics/query_engine/router.py`. Modifies `_skill_terms_all_in_dbo_skills` so that these terms bypass the `dbo.skills` DB lookup and allow the taxonomy gate to pass disruption, trend, emergence, comparison, and curriculum queries whose extracted skill names are AI-tool references.

Also adds `scripts/seed_ai_taxonomy_terms.py` — a one-shot idempotent script that permanently inserts all supplemental terms into `dbo.skills` so they surface across all analytics dimensions (skill demand, velocity, co-occurrence) once embeddings are backfilled.

## Why

The `dev-verify-2026-05-01` re-audit confirmed all 10 disruption golden questions (gq-001–010) refused synthesis with `skill_taxonomy_gate_blocked` because AI-tool names ("Copilot", "Claude", "ChatGPT", etc.) are absent from the current taxonomy. The supplemental allowlist is the stop-gap; the seed script is the permanent fix.

## Changes

- `analytics/query_engine/router.py` — `_AI_TOOL_SUPPLEMENTAL_TERMS`, `_AI_TOOL_RESOLUTION_ALIASES`, updated `_skill_terms_all_in_dbo_skills`
- `analytics/tests/test_router.py` — new `TestAIToolTaxonomySupplement` (8 tests)
- `scripts/seed_ai_taxonomy_terms.py` — one-shot seed with `--dry-run` support

## Test plan

- [x] `pytest analytics/tests/test_router.py::TestAIToolTaxonomySupplement -v` — 8 passed
- [x] `pytest analytics/tests/test_router.py -v` — 92 passed, 0 regressions
- [x] `ruff check` — clean on all three changed files
- [ ] Post-merge: run `python scripts/seed_ai_taxonomy_terms.py --dry-run` against SoT DB; confirm terms not already present; run without `--dry-run`; backfill embeddings via `python scripts/seed_esco_embeddings.py`
- [ ] Re-run disruption eval slice (gq-001–010 + gq-026); confirm ≥6 questions move from refused → answered

Closes #349
