### PR TITLE
fix: role_family grouping for job-count-by-domain Q&A (#362)

### DIFF
--- a/analytics/canonical_roles/persist.py
+++ b/analytics/canonical_roles/persist.py
@@ -13,6 +13,7 @@ import structlog
 from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 
+from analytics.canonical_roles.role_family import classify_canonical_role
 from analytics.clustering.types import ClusteringResult, RankedSkill, RankedTool
 from common.data_store.models import CanonicalRole
 
@@ -113,6 +114,8 @@ def persist_clustering_result(
 
     now = datetime.now(timezone.utc)
     roles_inserted = 0
+    role_family_assigned = 0
+    role_family_unmapped = 0
 
     for cluster in result.clusters:
         role_id = cluster_id_to_role_id[cluster.cluster_id]
@@ -132,8 +135,24 @@ def persist_clustering_result(
         row.is_llm_generated = cluster.is_llm_generated_label
         row.computed_at = now
         row.updated_at = now
+        family = classify_canonical_role(
+            row.label,
+            representative_titles=list(row.representative_titles or []),
+            top_skills=row.top_skills if isinstance(row.top_skills, list) else None,
+        )
+        row.role_family = family
+        if family:
+            role_family_assigned += 1
+        else:
+            role_family_unmapped += 1
 
     session.flush()
+    log.info(
+        "clustering_role_family_assigned",
+        correlation_id=correlation_id,
+        assigned=role_family_assigned,
+        unmapped=role_family_unmapped,
+    )
 
     label_embeddings_synced = 0
     for cluster in result.clusters:

--- a/analytics/canonical_roles/role_family.py
+++ b/analytics/canonical_roles/role_family.py
@@ -1,0 +1,257 @@
+"""Role-family taxonomy: config load, NL resolution, and cluster classification (JIE #362).
+
+Backfill approach: rule-based token/alias scoring on ``label`` (+ optional
+``representative_titles`` / ``top_skills``); optional LLM batch for unmapped labels
+via ``--use-llm`` in ``scripts/backfill_role_family.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+
+import structlog
+
+from common.config_loader import load_yaml
+
+log = structlog.get_logger()
+
+# Minimum alias match length (chars) to avoid spurious single-token hits.
+_MIN_ALIAS_LEN = 4
+
+# Rule classifier: minimum score to assign without LLM.
+_MIN_RULE_SCORE = 2
+
+_JOB_COUNT_SIGNAL_RE = re.compile(
+    r"\b("
+    r"how many|number of|count of|how many job|job postings?|jobs posted|"
+    r"roles posted|posting count|compare.*postings?|postings? for .+ roles?"
+    r")\b",
+    re.IGNORECASE,
+)
+
+_SKILL_MENTION_COMPARISON_RE = re.compile(
+    r"\bskills?\b.{0,40}\b(vs\.?|versus|compared to|compare)\b|"
+    r"\b(vs\.?|versus|compared to|compare)\b.{0,40}\bskills?\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class RoleFamilyEntry:
+    slug: str
+    aliases: tuple[str, ...]
+
+
+def load_role_family_config() -> list[RoleFamilyEntry]:
+    """Load families from ``config/role_families.yaml`` via ``load_yaml("role_families")``."""
+    data = load_yaml("role_families")
+    raw = data.get("role_families") or {}
+    families = raw.get("families") if isinstance(raw, dict) else None
+    if not isinstance(families, list):
+        return []
+    out: list[RoleFamilyEntry] = []
+    for item in families:
+        if not isinstance(item, dict):
+            continue
+        slug = str(item.get("slug") or "").strip()
+        if not slug:
+            continue
+        aliases_raw = item.get("aliases") or []
+        aliases = tuple(str(a).strip().lower() for a in aliases_raw if str(a).strip())
+        out.append(RoleFamilyEntry(slug=slug, aliases=aliases))
+    return out
+
+
+def _normalized_phrases(*phrases: str) -> str:
+    parts: list[str] = []
+    for p in phrases:
+        s = str(p or "").strip().lower()
+        if not s:
+            continue
+        s = re.sub(r"[-_/]+", " ", s)
+        parts.append(s)
+    return " ".join(parts)
+
+
+def resolve_role_families_from_text(*phrases: str) -> list[str]:
+    """Map free text to unique family slugs (longest alias match wins per span)."""
+    haystack = _normalized_phrases(*phrases)
+    if not haystack:
+        return []
+
+    families = load_role_family_config()
+    # (alias_len, slug, alias) — prefer longer aliases first
+    candidates: list[tuple[int, str, str]] = []
+    for entry in families:
+        for alias in entry.aliases:
+            if len(alias) >= _MIN_ALIAS_LEN and alias in haystack:
+                candidates.append((len(alias), entry.slug, alias))
+
+    candidates.sort(key=lambda t: (-t[0], t[1]))
+    matched_slugs: list[str] = []
+    seen: set[str] = set()
+    used_spans: list[tuple[int, int]] = []
+
+    for _alen, slug, alias in candidates:
+        if slug in seen:
+            continue
+        start = haystack.find(alias)
+        if start < 0:
+            continue
+        end = start + len(alias)
+        overlap = any(not (end <= s or start >= e) for s, e in used_spans)
+        if overlap:
+            continue
+        used_spans.append((start, end))
+        seen.add(slug)
+        matched_slugs.append(slug)
+
+    return matched_slugs
+
+
+def question_signals_job_posting_count(question: str) -> bool:
+    """True when the question asks for job/posting counts (not skill-mention demand)."""
+    return bool(_JOB_COUNT_SIGNAL_RE.search(question or ""))
+
+
+def question_signals_skill_mention_comparison(question: str) -> bool:
+    """True when the question frames a skill-vs-skill comparison."""
+    return bool(_SKILL_MENTION_COMPARISON_RE.search(question or ""))
+
+
+def comparison_should_use_role_family_count(
+    question: str,
+    role_names: list[str],
+    skill_names: list[str],
+) -> bool:
+    """True when comparison should aggregate ``job_postings`` by ``role_family``.
+
+    Requires at least two resolved families and a job-count phrasing signal.
+    Single-family resolution falls through to skill_demand_weekly / sector paths.
+    """
+    if not question_signals_job_posting_count(question):
+        return False
+    if question_signals_skill_mention_comparison(question) and not question_signals_job_posting_count(question):
+        return False
+    families = resolve_role_families_from_text(question, *role_names, *skill_names)
+    return len(families) >= 2
+
+
+def comparison_resolved_role_families(
+    question: str,
+    role_names: list[str],
+    skill_names: list[str],
+) -> list[str]:
+    """Family slugs for the role-family comparison path, or ``[]`` if not applicable."""
+    if not comparison_should_use_role_family_count(question, role_names, skill_names):
+        return []
+    return resolve_role_families_from_text(question, *role_names, *skill_names)
+
+
+def _collect_classifier_text(
+    label: str,
+    *,
+    representative_titles: list[str] | None,
+    top_skills: list | None,
+) -> str:
+    parts = [label or ""]
+    for t in representative_titles or []:
+        if isinstance(t, str) and t.strip():
+            parts.append(t)
+    for sk in top_skills or []:
+        if isinstance(sk, dict):
+            name = sk.get("skill_name") or sk.get("label") or ""
+            if name:
+                parts.append(str(name))
+        elif isinstance(sk, str):
+            parts.append(sk)
+    return " ".join(parts).lower()
+
+
+# EXEMPLAR: Phase 2 reference — rule-based role_family assignment for canonical_roles.
+def classify_canonical_role(
+    label: str,
+    *,
+    representative_titles: list[str] | None = None,
+    top_skills: list | None = None,
+) -> str | None:
+    """Assign a role_family slug from cluster metadata (rule-based; deterministic)."""
+    text = _collect_classifier_text(
+        label,
+        representative_titles=representative_titles,
+        top_skills=top_skills,
+    )
+    if not text.strip():
+        return None
+
+    # Score each family by alias hits in the full classifier text (longer alias = higher weight).
+    best_slug: str | None = None
+    best_score = 0
+    for entry in load_role_family_config():
+        score = 0
+        for alias in entry.aliases:
+            if len(alias) >= 3 and alias in text:
+                score += len(alias) * max(1, len(alias.split()))
+        if entry.slug == "cloud_engineering" and "cloud" in text:
+            score += 15
+        if score > best_score:
+            best_score = score
+            best_slug = entry.slug
+
+    if best_score >= _MIN_RULE_SCORE:
+        return best_slug
+    return None
+
+
+def classify_canonical_role_llm_batch(
+    items: list[tuple[str, str]],
+    *,
+    agent_name: str = "analytics-role-family-backfill",
+) -> dict[str, str]:
+    """LLM batch classify unmapped labels. *items* = ``(role_id, label)`` pairs."""
+    if not items:
+        return {}
+
+    from common.llm_adapter import complete
+
+    slugs = [e.slug for e in load_role_family_config()]
+    slug_list = ", ".join(slugs)
+    lines = "\n".join(f'- role_id="{rid}" label="{lbl}"' for rid, lbl in items[:50])
+    prompt = (
+        "Assign each canonical role label to exactly one role_family slug from this list:\n"
+        f"{slug_list}\n\n"
+        'Respond with JSON only: {"assignments": [{"role_id": "...", "role_family": "..."}, ...]}\n'
+        "Use null role_family only if no family fits.\n\n"
+        f"Roles:\n{lines}"
+    )
+    try:
+        raw = complete(
+            prompt=prompt,
+            agent_name=agent_name,
+            role="classification",
+        )
+        text = raw if isinstance(raw, str) else str(raw)
+        start = text.find("{")
+        end = text.rfind("}") + 1
+        if start < 0 or end <= start:
+            return {}
+        parsed = json.loads(text[start:end])
+        out: dict[str, str] = {}
+        for row in parsed.get("assignments") or []:
+            if not isinstance(row, dict):
+                continue
+            rid = str(row.get("role_id") or "").strip()
+            fam = row.get("role_family")
+            if rid and fam and str(fam).strip() in slugs:
+                out[rid] = str(fam).strip()
+        return out
+    except Exception as exc:
+        log.warning(
+            "role_family_llm_batch_failed",
+            error_type=type(exc).__name__,
+            error=str(exc),
+            batch_size=len(items),
+        )
+        return {}

--- a/analytics/canonical_roles/tests/test_role_family.py
+++ b/analytics/canonical_roles/tests/test_role_family.py
@@ -1,0 +1,67 @@
+"""Unit tests for analytics.canonical_roles.role_family (JIE #362)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from analytics.canonical_roles.role_family import (
+    classify_canonical_role,
+    comparison_should_use_role_family_count,
+    load_role_family_config,
+    question_signals_job_posting_count,
+    resolve_role_families_from_text,
+)
+
+
+def test_load_role_family_config_has_expected_slugs() -> None:
+    families = load_role_family_config()
+    slugs = {f.slug for f in families}
+    assert "cybersecurity" in slugs
+    assert "cloud_engineering" in slugs
+    assert len(slugs) >= 10
+
+
+def test_resolve_cloud_and_cyber_from_text() -> None:
+    got = resolve_role_families_from_text(
+        "cloud-engineering roles compared to cybersecurity roles",
+    )
+    assert "cloud_engineering" in got
+    assert "cybersecurity" in got
+
+
+def test_resolve_cloud_computing_alias() -> None:
+    got = resolve_role_families_from_text("Cloud Computing", "Cybersecurity")
+    assert "cloud_engineering" in got
+    assert "cybersecurity" in got
+
+
+def test_classify_cloud_infrastructure_label() -> None:
+    fam = classify_canonical_role("Senior Cloud Infrastructure Engineer")
+    assert fam == "cloud_engineering"
+
+
+def test_comparison_requires_two_families() -> None:
+    q = "How many Borderplex job postings are for cybersecurity roles?"
+    assert question_signals_job_posting_count(q)
+    assert not comparison_should_use_role_family_count(q, [], ["Cybersecurity"])
+
+
+def test_comparison_two_families_and_job_count() -> None:
+    q = (
+        "How many Borderplex job postings are for cloud-engineering roles "
+        "compared to cybersecurity roles in recent weeks?"
+    )
+    assert comparison_should_use_role_family_count(
+        q,
+        ["cloud engineering", "cybersecurity"],
+        [],
+    )
+
+
+def test_classify_llm_batch_mocked() -> None:
+    from analytics.canonical_roles.role_family import classify_canonical_role_llm_batch
+
+    payload = '{"assignments": [{"role_id": "r1", "role_family": "cybersecurity"}]}'
+    with patch("common.llm_adapter.complete", return_value=payload):
+        out = classify_canonical_role_llm_batch([("r1", "Security Analyst")])
+    assert out.get("r1") == "cybersecurity"

--- a/analytics/query_engine/intent.py
+++ b/analytics/query_engine/intent.py
@@ -317,6 +317,14 @@ Q: "Compare AI engineering hiring in El Paso vs Las Cruces over the last 6 month
 A: {"intent":"comparison","confidence":0.88,...}
    ← Two locations being compared side-by-side.
 
+Q: "How many Borderplex job postings are for cloud-engineering roles compared to cybersecurity roles in recent weeks?"
+A: {"intent":"comparison","confidence":0.88,"extracted_entities":{"geographic_terms":["Borderplex"],"role_names":["cloud engineering","cybersecurity"],"skill_names":[],"time_references":["recent weeks"]}}
+   ← Job posting counts by role family (not skill-mention weekly aggregates).
+
+Q: "Compare Borderplex demand for DevOps skills versus Data Engineering skills — which is the stronger hiring signal?"
+A: {"intent":"comparison","confidence":0.85,"extracted_entities":{"geographic_terms":["Borderplex"],"role_names":[],"skill_names":["DevOps","Data Engineering"],"time_references":[]}}
+   ← Skill-mention comparison → skill_demand_weekly, not role-family job counts.
+
 Q: "What should a training program for a cybersecurity analyst in El Paso look like in the next 2 years?"
 A: {"intent":"curriculum","confidence":0.91,...}
    ← Program/curriculum design for a role; the city is context, not a posting filter.

--- a/analytics/query_engine/router.py
+++ b/analytics/query_engine/router.py
@@ -38,6 +38,10 @@ import structlog
 from sqlalchemy import Text, cast, func, or_, select, text
 from sqlalchemy.orm import Session
 
+from analytics.canonical_roles.role_family import (
+    comparison_resolved_role_families,
+    comparison_should_use_role_family_count,
+)
 from analytics.query_engine.constants import (
     NO_DATA_GEO_SKILL_SCOPE_REFUSAL,
     NO_DATA_SKILL_TAXONOMY_REFUSAL,
@@ -378,6 +382,7 @@ class RouteResult:
     error: str | None = None
     confidence: float = 0.0
     empty_rows_refusal_reason: str | None = None
+    distinct_posting_count: int | None = None
 
 
 # JIE #330 — intents that read skill-scoped aggregates; every extracted skill_name must
@@ -668,9 +673,13 @@ class QueryRouter:
             geo_terms=geo_terms[:3],
         )
 
-        blocked = _apply_skill_taxonomy_and_geo_scope_gates(session, intent, confidence, skill_names, question)
-        if blocked is not None:
-            return blocked
+        skip_taxonomy_gate = intent == "comparison" and comparison_should_use_role_family_count(
+            question, role_names, skill_names
+        )
+        if not skip_taxonomy_gate:
+            blocked = _apply_skill_taxonomy_and_geo_scope_gates(session, intent, confidence, skill_names, question)
+            if blocked is not None:
+                return blocked
 
         handler: Callable[..., RouteResult] | None = _INTENT_HANDLERS.get(intent)
         if handler is None:
@@ -1706,6 +1715,112 @@ class QueryRouter:
                 confidence=confidence,
             )
 
+    def _route_role_family_count(
+        self,
+        *,
+        intent: str,
+        confidence: float,
+        families: list[str],
+        week_floor: date,
+        session: Session,
+        tenant: TenantAccess,
+        question: str = "",
+    ) -> RouteResult:
+        """comparison (job-count) → ``job_postings`` joined to ``canonical_roles.role_family``."""
+        if not tenant.can_query_borderplex_skill_tables:
+            return self._no_borderplex_market_aggregates(intent, confidence)
+
+        if not families:
+            return RouteResult(
+                intent=intent,
+                tables_used=[],
+                query_label="role family posting count — no families resolved",
+                rows=[],
+                row_count=0,
+                routed=True,
+                confidence=confidence,
+                empty_rows_refusal_reason=(
+                    "Could not resolve at least two role families for a domain job-count comparison."
+                ),
+            )
+
+        allowed_subregions = list(tenant.allowed_subregions)
+        params: dict[str, Any] = {
+            "families": families,
+            "week_floor": week_floor,
+            "subregions": allowed_subregions,
+        }
+        where_parts: list[str] = [
+            "cr.role_family = ANY(:families)",
+            "jp.is_spam = FALSE",
+            "jp.canonical_role_id IS NOT NULL",
+            "jp.date_posted >= :week_floor",
+        ]
+        if allowed_subregions:
+            where_parts.append("jp.borderplex_subregion = ANY(:subregions)")
+
+        sql = text(
+            f"""
+            SELECT
+                cr.role_family,
+                COUNT(DISTINCT jp.job_posting_id) AS posting_count
+            FROM dbo.job_postings AS jp
+            INNER JOIN dbo.canonical_roles AS cr ON cr.role_id = jp.canonical_role_id
+            WHERE {" AND ".join(where_parts)}
+            GROUP BY cr.role_family
+            ORDER BY posting_count DESC
+            LIMIT {_QUERY_LIMIT}
+            """
+        )
+
+        family_label = " vs ".join(families[:5])
+        label = f"role family posting count (since {week_floor.isoformat()}) — {family_label}"
+
+        try:
+            result = session.execute(
+                sql,
+                params,
+                execution_options={"timeout": _QUERY_TIMEOUT_SECONDS},
+            )
+            rows = [dict(row._mapping) for row in result]
+            is_partial = len(rows) >= _QUERY_LIMIT
+            distinct_total = sum(int(r.get("posting_count") or 0) for r in rows)
+            log.info(
+                "query_router_result",
+                intent=intent,
+                query_label=label,
+                row_count=len(rows),
+                is_partial=is_partial,
+                tables_used=["job_postings", "canonical_roles"],
+                distinct_posting_count=distinct_total,
+            )
+            return RouteResult(
+                intent=intent,
+                tables_used=["job_postings", "canonical_roles"],
+                query_label=label,
+                rows=rows,
+                row_count=len(rows),
+                is_partial=is_partial,
+                confidence=confidence,
+                distinct_posting_count=distinct_total,
+            )
+        except Exception as exc:
+            log.error(
+                "query_router_execute_error",
+                intent=intent,
+                query_label=label,
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+            return RouteResult(
+                intent=intent,
+                tables_used=["job_postings", "canonical_roles"],
+                query_label=label,
+                routed=False,
+                error=str(exc),
+                confidence=confidence,
+            )
+
     def _route_comparison(
         self,
         *,
@@ -1719,9 +1834,22 @@ class QueryRouter:
         tenant: TenantAccess,
         question: str = "",
     ) -> RouteResult:
-        """comparison → ``skill_demand_weekly`` for skill vs skill; ``sector_summary_weekly`` otherwise."""
+        """comparison → role-family job counts, ``skill_demand_weekly``, or ``sector_summary_weekly``."""
         if not tenant.can_query_borderplex_skill_tables:
             return self._no_borderplex_market_aggregates(intent, confidence)
+
+        families = comparison_resolved_role_families(question, role_names, skill_names)
+        if families:
+            return self._route_role_family_count(
+                intent=intent,
+                confidence=confidence,
+                families=families,
+                week_floor=week_floor,
+                session=session,
+                tenant=tenant,
+                question=question,
+            )
+
         if skill_names:
             t = SkillDemandWeekly
             skill_filter = self._ilike_or(t.skill_label, skill_names)

--- a/analytics/query_engine/routing.py
+++ b/analytics/query_engine/routing.py
@@ -847,6 +847,7 @@ def run_analytics_qna(
             correlation_id=cid,
             role_suggestion_hint=role_hint,
             no_data_refusal_override=no_data_override,
+            distinct_posting_count=getattr(route_result, "distinct_posting_count", None),
         )
 
         syn = qna.run_analytics_qna(q_payload, cost_ledger=ledger)

--- a/analytics/tests/test_router.py
+++ b/analytics/tests/test_router.py
@@ -33,11 +33,11 @@ import pytest
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Session
 
+from analytics.canonical_roles.role_family import comparison_should_use_role_family_count
 from analytics.query_engine.constants import (
     NO_DATA_GEO_SKILL_SCOPE_REFUSAL,
     NO_DATA_SKILL_TAXONOMY_REFUSAL,
 )
-from analytics.canonical_roles.role_family import comparison_should_use_role_family_count
 from analytics.query_engine.router import (
     _AI_TOOL_RESOLUTION_ALIASES,
     _AI_TOOL_SUPPLEMENTAL_TERMS,
@@ -414,7 +414,7 @@ class TestIntentRouting:
         )
         q = "How many Borderplex job postings are for cybersecurity roles?"
         cls = _mk_classification("comparison", skill_names=["Cybersecurity"])
-        result = QueryRouter().route(cls, session, question=q)
+        QueryRouter().route(cls, session, question=q)
         sql = _last_execute_sql(session).lower()
         assert "role_family" not in sql
         assert "skill_demand_weekly" in sql

--- a/analytics/tests/test_router.py
+++ b/analytics/tests/test_router.py
@@ -37,6 +37,7 @@ from analytics.query_engine.constants import (
     NO_DATA_GEO_SKILL_SCOPE_REFUSAL,
     NO_DATA_SKILL_TAXONOMY_REFUSAL,
 )
+from analytics.canonical_roles.role_family import comparison_should_use_role_family_count
 from analytics.query_engine.router import (
     _AI_TOOL_RESOLUTION_ALIASES,
     _AI_TOOL_SUPPLEMENTAL_TERMS,
@@ -137,6 +138,17 @@ def _compiled_sql(session: MagicMock) -> str:
             compile_kwargs={"literal_binds": True},
         )
     )
+
+
+def _last_execute_sql(session: MagicMock) -> str:
+    """Return SQL text from the last ``session.execute()`` (ORM or ``text()``)."""
+    calls = session.execute.call_args_list
+    if not calls:
+        raise AssertionError("session.execute was never called")
+    stmt = calls[-1][0][0]
+    if hasattr(stmt, "text"):
+        return str(stmt.text)
+    return _compiled_sql(session)
 
 
 def _assert_sql_guardrails(sql: str) -> None:
@@ -319,7 +331,11 @@ class TestIntentRouting:
     def test_route_comparison_with_skills(self) -> None:
         session = _make_session(taxonomy_lower_matches=("python", "r"))
         cls = _mk_classification("comparison", skill_names=["Python", "R"])
-        result = QueryRouter().route(cls, session)
+        result = QueryRouter().route(
+            cls,
+            session,
+            question="Compare Python skills vs R skills in Borderplex demand",
+        )
 
         assert result.intent == "comparison"
         assert result.routed is True
@@ -329,6 +345,126 @@ class TestIntentRouting:
         sql = _compiled_sql(session)
         _assert_sql_guardrails(sql)
         assert "skill_demand_weekly" in sql.lower()
+
+    def test_comparison_role_family_job_count(self) -> None:
+        session = _make_session(
+            rows=[
+                _make_mock_row(role_family="cloud_engineering", posting_count=84),
+                _make_mock_row(role_family="cybersecurity", posting_count=31),
+            ],
+        )
+        q = (
+            "How many Borderplex job postings are for cloud-engineering roles "
+            "compared to cybersecurity roles in recent weeks?"
+        )
+        cls = _mk_classification(
+            "comparison",
+            role_names=["cloud engineering", "cybersecurity"],
+            time_refs=["recent weeks"],
+        )
+        result = QueryRouter().route(cls, session, question=q)
+
+        assert result.routed is True
+        assert result.tables_used == ["job_postings", "canonical_roles"]
+        assert result.empty_rows_refusal_reason is None
+        sql = _last_execute_sql(session).lower()
+        _assert_sql_guardrails(sql)
+        assert "role_family" in sql
+        assert "job_postings" in sql
+        assert "canonical_roles" in sql
+        assert "count(distinct" in sql
+        assert "date_posted" in sql
+
+    def test_comparison_role_family_distinct_posting_count(self) -> None:
+        session = _make_session(
+            rows=[
+                _make_mock_row(role_family="cloud_engineering", posting_count=84),
+                _make_mock_row(role_family="cybersecurity", posting_count=31),
+            ],
+        )
+        q = (
+            "How many job postings are for cloud engineering roles compared to "
+            "cybersecurity roles?"
+        )
+        cls = _mk_classification("comparison", role_names=["cloud engineering", "cybersecurity"])
+        result = QueryRouter().route(cls, session, question=q)
+        assert result.distinct_posting_count == 115
+
+    def test_comparison_job_count_skips_taxonomy_gate(self) -> None:
+        session = _make_session(
+            rows=[_make_mock_row(role_family="cloud_engineering", posting_count=10)],
+        )
+        q = (
+            "How many Borderplex job postings are for cloud-engineering roles "
+            "compared to cybersecurity roles?"
+        )
+        cls = _mk_classification(
+            "comparison",
+            skill_names=["Cloud Computing", "Cybersecurity"],
+        )
+        result = QueryRouter().route(cls, session, question=q)
+        assert result.empty_rows_refusal_reason is None
+        assert "canonical_roles" in result.tables_used
+        assert session.execute.call_count == 1
+
+    def test_comparison_single_family_not_role_family_sql(self) -> None:
+        session = _make_session(
+            taxonomy_lower_matches=("cybersecurity",),
+            rows=[_make_mock_row(skill_label="Cybersecurity", posting_count=31)],
+        )
+        q = "How many Borderplex job postings are for cybersecurity roles?"
+        cls = _mk_classification("comparison", skill_names=["Cybersecurity"])
+        result = QueryRouter().route(cls, session, question=q)
+        sql = _last_execute_sql(session).lower()
+        assert "role_family" not in sql
+        assert "skill_demand_weekly" in sql
+
+    def test_comparison_devops_skills_vs_data_engineering(self) -> None:
+        session = _make_session(taxonomy_lower_matches=("devops", "data engineering"))
+        q = (
+            "Compare Borderplex demand for DevOps skills versus Data Engineering skills "
+            "— which is the stronger hiring signal?"
+        )
+        cls = _mk_classification("comparison", skill_names=["DevOps", "Data Engineering"])
+        result = QueryRouter().route(cls, session, question=q)
+        assert result.tables_used == ["skill_demand_weekly"]
+        sql = _compiled_sql(session).lower()
+        assert "role_family" not in sql
+
+    @pytest.mark.parametrize(
+        "question,role_names,skill_names,expected",
+        [
+            (
+                "How many job postings for cloud engineering vs cybersecurity roles?",
+                [],
+                [],
+                True,
+            ),
+            (
+                "How many cybersecurity job postings?",
+                [],
+                ["Cybersecurity"],
+                False,
+            ),
+            (
+                "Compare Python skills vs R skills",
+                [],
+                ["Python", "R"],
+                False,
+            ),
+        ],
+    )
+    def test_comparison_should_use_role_family_count_predicate(
+        self,
+        question: str,
+        role_names: list[str],
+        skill_names: list[str],
+        expected: bool,
+    ) -> None:
+        assert (
+            comparison_should_use_role_family_count(question, role_names, skill_names)
+            is expected
+        )
 
     def test_route_other(self) -> None:
         session = _make_session()

--- a/analytics/tests/test_router.py
+++ b/analytics/tests/test_router.py
@@ -382,10 +382,7 @@ class TestIntentRouting:
                 _make_mock_row(role_family="cybersecurity", posting_count=31),
             ],
         )
-        q = (
-            "How many job postings are for cloud engineering roles compared to "
-            "cybersecurity roles?"
-        )
+        q = "How many job postings are for cloud engineering roles compared to cybersecurity roles?"
         cls = _mk_classification("comparison", role_names=["cloud engineering", "cybersecurity"])
         result = QueryRouter().route(cls, session, question=q)
         assert result.distinct_posting_count == 115
@@ -394,10 +391,7 @@ class TestIntentRouting:
         session = _make_session(
             rows=[_make_mock_row(role_family="cloud_engineering", posting_count=10)],
         )
-        q = (
-            "How many Borderplex job postings are for cloud-engineering roles "
-            "compared to cybersecurity roles?"
-        )
+        q = "How many Borderplex job postings are for cloud-engineering roles compared to cybersecurity roles?"
         cls = _mk_classification(
             "comparison",
             skill_names=["Cloud Computing", "Cybersecurity"],
@@ -461,10 +455,7 @@ class TestIntentRouting:
         skill_names: list[str],
         expected: bool,
     ) -> None:
-        assert (
-            comparison_should_use_role_family_count(question, role_names, skill_names)
-            is expected
-        )
+        assert comparison_should_use_role_family_count(question, role_names, skill_names) is expected
 
     def test_route_other(self) -> None:
         session = _make_session()

--- a/common/data_store/migrations.py
+++ b/common/data_store/migrations.py
@@ -351,6 +351,8 @@ _SKILL_DEMAND_WEEKLY_ALTER_STATEMENTS = [
 # Not ORM-mapped — follows the same unmapped-vector pattern as dedup_embedding on job_postings.
 _CANONICAL_ROLES_ALTER_STATEMENTS = [
     "ALTER TABLE dbo.canonical_roles ADD COLUMN IF NOT EXISTS label_embedding vector(1536)",
+    "ALTER TABLE dbo.canonical_roles ADD COLUMN IF NOT EXISTS role_family TEXT",
+    "CREATE INDEX IF NOT EXISTS ix_canonical_roles_role_family ON dbo.canonical_roles (role_family)",
 ]
 
 # Issue #157: JSearch Pro-plan monthly budget counter — one column on job_ingestion_runs

--- a/common/data_store/models.py
+++ b/common/data_store/models.py
@@ -399,12 +399,14 @@ class CanonicalRole(Base):
     __tablename__ = "canonical_roles"
     __table_args__ = (
         Index("ix_canonical_roles_computed_at", "computed_at"),
+        Index("ix_canonical_roles_role_family", "role_family"),
         {"schema": "dbo"},
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     role_id: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
     label: Mapped[str] = mapped_column(Text, nullable=False)
+    role_family: Mapped[str | None] = mapped_column(String(64), nullable=True)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     posting_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     cluster_centroid: Mapped[list[float] | None] = mapped_column(JSONB, nullable=True)

--- a/config/role_families.yaml
+++ b/config/role_families.yaml
@@ -1,0 +1,93 @@
+# config/role_families.yaml — role-family taxonomy for canonical_roles.role_family (JIE #362).
+# Loaded via load_yaml("role_families") → data["role_families"]["families"].
+
+role_families:
+  families:
+    - slug: cybersecurity
+      aliases:
+        - cyber security
+        - cybersecurity
+        - cyber-security
+        - infosec
+        - information security
+        - security engineer
+        - network security
+    - slug: cloud_engineering
+      aliases:
+        - cloud computing
+        - cloud engineer
+        - cloud engineering
+        - cloud infrastructure
+        - cloud architect
+        - cloud operations
+    - slug: data_engineering
+      aliases:
+        - data engineer
+        - data engineering
+        - etl engineer
+        - data pipeline
+    - slug: ai_ml
+      aliases:
+        - ai engineer
+        - machine learning
+        - ml engineer
+        - artificial intelligence
+        - deep learning
+    - slug: devops_sre
+      aliases:
+        - devops
+        - site reliability
+        - sre
+        - platform engineer
+        - infrastructure engineer
+    - slug: software_engineering
+      aliases:
+        - software engineer
+        - software developer
+        - application developer
+        - full stack
+        - fullstack
+    - slug: frontend
+      aliases:
+        - front end
+        - frontend
+        - front-end developer
+        - ui developer
+    - slug: backend
+      aliases:
+        - back end
+        - backend
+        - back-end developer
+        - api developer
+    - slug: mobile
+      aliases:
+        - mobile developer
+        - ios developer
+        - android developer
+    - slug: qa_test
+      aliases:
+        - qa engineer
+        - quality assurance
+        - test engineer
+        - software tester
+        - automation tester
+    - slug: it_ops
+      aliases:
+        - it operations
+        - systems administrator
+        - sysadmin
+        - network administrator
+        - it support
+    - slug: product_design
+      aliases:
+        - product manager
+        - product design
+        - ux designer
+        - ui designer
+        - product owner
+    - slug: analytics_bi
+      aliases:
+        - data analyst
+        - business intelligence
+        - bi analyst
+        - analytics engineer

--- a/docs/planning/QA_DATA_CONTRACT.md
+++ b/docs/planning/QA_DATA_CONTRACT.md
@@ -712,7 +712,7 @@ pipeline startup and treated as agent-owned reference data.
 
 | Table | PK | Key query columns | Notes |
 |-------|----|-------------------|-------|
-| `canonical_roles` | `role_id VARCHAR(64)` | `label, description, posting_count, top_skills, top_tools` | Cluster-level role definitions; use `role_id` as FK target |
+| `canonical_roles` | `role_id VARCHAR(64)` | `label, role_family, description, posting_count, top_skills, top_tools` | Cluster-level role definitions; `role_family` groups ~200 labels into domain buckets (JIE #362). Job-count-by-domain: `JOIN job_postings ON canonical_role_id = role_id` + `GROUP BY role_family` (non-null `canonical_role_id` only; see #363). |
 | `companies` | `company_id TEXT` | `company_name, size, city, state, industry_sector_id` | Cast `job_postings.company_id` to `TEXT` when joining |
 | `industry_sectors` | `industry_sector_id TEXT` | `sector_title` | Join via `job_postings.sector_id` or `sector_summary_weekly.sector` |
 | `employer_profiles` | `id UUID` | `company_size, ai_maturity_signal, sector, is_known_employer` | Join via `job_postings.employer_profile_id` |

--- a/eval/qa_golden_questions.json
+++ b/eval/qa_golden_questions.json
@@ -1691,15 +1691,16 @@
   },
   {
     "id": "gq-052",
-    "question": "How does Borderplex demand for Cloud Computing skills compare to Cybersecurity skills \u2014 which domain has more job postings?",
+    "question": "How many Borderplex job postings are for cloud-engineering roles compared to cybersecurity roles in recent weeks?",
     "intent": "comparison",
-    "context": "Workforce director choosing between launching a cloud computing or cybersecurity certification track for the next fiscal year. Budget only supports one new track. Needs a clear demand comparison to justify the investment to funders.",
-    "ideal_answer_summary": "Should compare posting counts for Cloud Computing (approx 84 postings for core label plus variants) versus Cybersecurity (approx 31 postings for core label). Cloud Computing should clearly dominate with roughly 2.5x to 3x more postings. Should cite specific counts for each domain. Should name related skill variants found (e.g., Cloud Certifications, Cloud AI Services for cloud; Cybersecurity Certification, CISSP for security). Should recommend the cloud track as the higher-demand option while noting cybersecurity still shows solid demand and may have less competition among training providers.",
+    "context": "Workforce director choosing between launching a cloud computing or cybersecurity certification track for the next fiscal year. Budget only supports one new track. Needs a clear demand comparison of open role-domain postings (not skill-mention counts).",
+    "ideal_answer_summary": "Should compare distinct job posting counts by role_family (cloud_engineering vs cybersecurity) from job_postings joined to canonical_roles, scoped to Borderplex and recent weeks via date_posted. Should cite posting_count per family and state which domain has more open roles. Should note coverage caveat: only postings with non-null canonical_role_id are included (#363). Should recommend the higher-volume track while acknowledging cybersecurity demand if lower.",
     "must_include": [
-      "cloud_computing_posting_count_stated",
+      "cloud_engineering_posting_count_stated",
       "cybersecurity_posting_count_stated",
-      "cloud_computing_identified_as_higher_demand",
+      "cloud_engineering_identified_as_higher_demand_when_data_supports",
       "both_domains_compared_numerically",
+      "canonical_role_id_coverage_caveat_or_equivalent",
       "recommendation_for_track_priority"
     ],
     "must_not_include": [

--- a/scripts/backfill_role_family.py
+++ b/scripts/backfill_role_family.py
@@ -1,0 +1,175 @@
+# ruff: noqa: T201
+"""Backfill dbo.canonical_roles.role_family from cluster labels (JIE #362).
+
+Rule-based classification runs first (``analytics.canonical_roles.role_family``);
+optional ``--use-llm`` batch for rows still unmapped.
+
+Idempotent: only rows with ``role_family IS NULL`` are updated unless ``--force``.
+
+Exit behavior:
+  - Default: print stats and warnings; exit 0 (partial dev DBs stay unblocked).
+  - ``--strict``: exit 1 when unmapped rate exceeds ``UNMAPPED_THRESHOLD`` (10%).
+
+Prerequisites:
+    python scripts/db_check.py migrate
+
+Usage (from repo root, venv activated):
+
+    python scripts/backfill_role_family.py
+    python scripts/backfill_role_family.py --use-llm
+    python scripts/backfill_role_family.py --strict
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import text  # noqa: E402
+
+from analytics.canonical_roles.role_family import (  # noqa: E402
+    classify_canonical_role,
+    classify_canonical_role_llm_batch,
+)
+from common.data_store.database import get_engine  # noqa: E402
+from common.env import load_repo_root_dotenv  # noqa: E402
+
+load_repo_root_dotenv()
+
+UNMAPPED_THRESHOLD = 0.10
+
+_COLUMN_CHECK = """
+SELECT 1
+FROM information_schema.columns
+WHERE table_schema = 'dbo'
+  AND table_name = 'canonical_roles'
+  AND column_name = 'role_family'
+LIMIT 1
+"""
+
+_SELECT_ROWS = """
+SELECT role_id, label, representative_titles, top_skills
+FROM dbo.canonical_roles
+WHERE (:force OR role_family IS NULL)
+ORDER BY role_id
+"""
+
+_STATS = """
+SELECT
+    COUNT(*) AS total,
+    COUNT(role_family) AS with_family,
+    COUNT(*) FILTER (WHERE role_family IS NULL) AS still_unmapped
+FROM dbo.canonical_roles
+"""
+
+_FAMILY_DIST = """
+SELECT role_family, COUNT(*) AS n
+FROM dbo.canonical_roles
+WHERE role_family IS NOT NULL
+GROUP BY role_family
+ORDER BY n DESC
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Backfill canonical_roles.role_family")
+    parser.add_argument("--force", action="store_true", help="Reclassify rows that already have role_family")
+    parser.add_argument("--use-llm", action="store_true", help="LLM batch for labels still unmapped after rules")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=f"Exit 1 when unmapped rate > {UNMAPPED_THRESHOLD:.0%} (CI/smoke)",
+    )
+    args = parser.parse_args()
+
+    engine = get_engine()
+    with engine.connect() as conn:
+        if not conn.execute(text(_COLUMN_CHECK)).scalar():
+            print(
+                "ERROR: dbo.canonical_roles.role_family does not exist.\nRun: python scripts/db_check.py migrate",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    mapped = 0
+    unmapped_after_rules = 0
+    llm_mapped = 0
+
+    with engine.begin() as conn:
+        rows = conn.execute(
+            text(_SELECT_ROWS),
+            {"force": args.force},
+        ).fetchall()
+
+        pending_llm: list[tuple[str, str]] = []
+        for row in rows:
+            role_id = str(row.role_id)
+            label = str(row.label or "")
+            rep = row.representative_titles
+            skills = row.top_skills
+            rep_list = list(rep) if isinstance(rep, list) else []
+            skills_list = list(skills) if isinstance(skills, list) else None
+            family = classify_canonical_role(
+                label,
+                representative_titles=rep_list,
+                top_skills=skills_list,
+            )
+            if family:
+                conn.execute(
+                    text("UPDATE dbo.canonical_roles SET role_family = :fam WHERE role_id = :rid"),
+                    {"fam": family, "rid": role_id},
+                )
+                mapped += 1
+            else:
+                pending_llm.append((role_id, label))
+                unmapped_after_rules += 1
+
+        if args.use_llm and pending_llm:
+            batch_size = 25
+            for i in range(0, len(pending_llm), batch_size):
+                chunk = pending_llm[i : i + batch_size]
+                assignments = classify_canonical_role_llm_batch(chunk)
+                for rid, fam in assignments.items():
+                    conn.execute(
+                        text("UPDATE dbo.canonical_roles SET role_family = :fam WHERE role_id = :rid"),
+                        {"fam": fam, "rid": rid},
+                    )
+                    llm_mapped += 1
+
+    with engine.connect() as conn:
+        stats = conn.execute(text(_STATS)).one()
+        total = int(stats.total or 0)
+        with_family = int(stats.with_family or 0)
+        still_unmapped = int(stats.still_unmapped or 0)
+        dist = conn.execute(text(_FAMILY_DIST)).fetchall()
+
+    print("backfill_role_family complete")
+    print(f"  rows considered: {len(rows)}")
+    print(f"  rule-mapped this run: {mapped}")
+    print(f"  unmapped after rules: {unmapped_after_rules}")
+    print(f"  llm-mapped this run: {llm_mapped}")
+    print(f"  total canonical_roles: {total}")
+    print(f"  with role_family: {with_family}")
+    print(f"  still unmapped: {still_unmapped}")
+    print("  per-family distribution:")
+    for row in dist:
+        print(f"    {row.role_family}: {row.n}")
+
+    if total > 0:
+        unmapped_rate = still_unmapped / total
+        if unmapped_rate > UNMAPPED_THRESHOLD:
+            msg = (
+                f"WARNING: unmapped rate {unmapped_rate:.1%} exceeds threshold "
+                f"{UNMAPPED_THRESHOLD:.0%} ({still_unmapped}/{total})"
+            )
+            print(msg, file=sys.stderr)
+            if args.strict:
+                sys.exit(1)
+    print("  exit: 0 (use --strict for non-zero exit on high unmapped rate)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/golden-questions-form/golden_questions.json
+++ b/tools/golden-questions-form/golden_questions.json
@@ -1113,26 +1113,26 @@
   },
   {
     "id": "gq-052",
-    "question": "Which IT skills are required in El Paso, TX postings but rarely mentioned in Las Cruces, NM postings, and vice versa?",
+    "question": "How many Borderplex job postings are for cloud-engineering roles compared to cybersecurity roles in recent weeks?",
     "source": "wfd_archetype",
     "intent": "comparison",
-    "context": "Contrast which skills appear frequently in one subregion vs rare in the other (set-difference / ratio style).",
-    "ideal_answer_summary": "Use dbo.job_postings filtered by borderplex_subregion (el_paso vs las_cruces), join normalized_jobs on source/external_id, then join extracted_intelligence on normalized_job_id and unnest skills JSONB . Report top skills unique / over-represented in each metro with counts or shares [to be filled from data]; caveat sparse skills / confidence threshold  if used. If extraction coverage is low, state refusal / partial.",
+    "context": "Workforce director comparing open role-domain postings (cloud engineering vs cybersecurity), not skill-mention weekly aggregates.",
+    "ideal_answer_summary": "Compare distinct job posting counts by role_family (cloud_engineering vs cybersecurity) from job_postings joined to canonical_roles, Borderplex-scoped and filtered by date_posted for recent weeks. Cite posting_count per family; note only postings with non-null canonical_role_id are counted (#363).",
     "must_include": [
-      "extracted_intelligence",
-      "skills OR skill_label",
-      "borderplex_subregion",
-      "el_paso",
-      "las_cruces",
-      "Both directions (“El Paso vs Las Cruces” / “vice versa”)",
-      "Numeric results as [to be filled from data] or caveat"
+      "role_family OR cloud_engineering",
+      "cybersecurity",
+      "job_postings",
+      "canonical_roles",
+      "posting_count",
+      "both_domains_compared_numerically",
+      "canonical_role_id coverage caveat or equivalent"
     ],
     "must_not_include": [
-      "Claiming skill_demand_weekly answers metro-specific asymmetry without job_postings geo/subregion path",
-      "Fabricated employer names",
-      "Single-city-only answer"
+      "skill_demand_weekly as sole evidence for domain job totals",
+      "national statistics substituted",
+      "fabricated_employer_names"
     ],
-    "difficulty": "hard"
+    "difficulty": "easy"
   },
   {
     "id": "gq-053",


### PR DESCRIPTION
## Summary

Fixes #362 — adds `role_family` to `dbo.canonical_roles` and a comparison-router path that counts **distinct job postings** by role family (e.g. cybersecurity vs cloud engineering), instead of skill-mention counts from `skill_demand_weekly`.

## What changed

- **Schema:** `canonical_roles.role_family` + index (`common/data_store/models.py`, `migrations.py`)
- **Taxonomy:** `config/role_families.yaml` (13 families + NL aliases) + `analytics/canonical_roles/role_family.py`
- **Data:** `scripts/backfill_role_family.py` (idempotent; `--strict` for CI); persist hook on clustering
- **Q&A:** `_route_role_family_count` — `job_postings` ⋈ `canonical_roles`, `date_posted >= week_floor` (default 12 weeks)
- **Routing:** Comparison intent branches to role-family SQL when ≥2 families resolve + job-count phrasing; taxonomy gate skipped for that path; single-family questions fall through to skill/sector paths
- **Synthesis:** `distinct_posting_count` wired router → `QueryResultPayload`
- **Golden:** `gq-052` reframed to job-centric comparison (eval + tools JSON)
- **Docs:** `QA_DATA_CONTRACT.md` appendix

## Why

Workforce directors ask "how many cybersecurity jobs vs cloud jobs?" Skill-demand weekly answers "how many postings mention skill X," which is easy to misread as job counts. Role families group ~202 canonical cluster labels under domain slugs for an honest job-posting metric.

## Coverage caveat

Aggregates only include postings with **non-null `canonical_role_id`**. ~48% of postings are unassigned today — tracked in #363.

## Comparison routing rules

- Role-family path: job-count phrasing **and** ≥2 resolved families
- One domain only → existing `skill_demand_weekly` / sector comparison (no regression on gq-053-style skill comparisons)

## Test plan

- [x] `pytest analytics/tests/test_router.py analytics/canonical_roles/tests/ -v`
- [x] ruff on touched paths
- [ ] `python scripts/db_check.py migrate && python scripts/backfill_role_family.py` (reviewer local)
- [ ] Smoke gq-052 / cyber vs cloud job-count phrasing in Ask the Data
- [ ] Confirm gq-053-style skill comparison still uses `skill_demand_weekly`

## Post-merge (not blocking)

- Admin: backfill + optional fixture export for `role_family`
- `seed_agent_data.py` UPSERT column when fixtures updated
