### PR TITLE
refactor(skills-extraction): author ExtractorRunInfo model and migrate context.py to ExtractionMetadata (#411)

### DIFF
--- a/common/types/extraction_types.py
+++ b/common/types/extraction_types.py
@@ -1,14 +1,15 @@
 """Pydantic schemas for the Work Intelligence Agent extraction pipeline.
 
 These types define the structured output of the 6-dimension extraction model:
-Skills, Tools, Tasks, Responsibilities, Context — plus shared SpanRecord
-and ExtractionMetadata.
+Skills, Tools, Tasks, Responsibilities, Context — plus shared SpanRecord,
+ExtractionMetadata, and ExtractorRunInfo.
 
 Source of truth: ARCHITECTURE_DEEP.md § Work Intelligence Agent.
 
 Week 2: schemas defined, used by fixture data.
 Week 4: used by real extraction stubs (skills, tools, taxonomy).
 Week 5: TaskRecord, ResponsibilityRecord, ContextSignal live in extraction_schemas.py.
+Week 12: ExtractorRunInfo added per pydantic-jsonb-payloads.mdc §3.3.
 """
 
 from __future__ import annotations
@@ -119,3 +120,27 @@ class ExtractionMetadata(BaseModel):
     pass2_llm_dimensions: list[str] = Field(default_factory=list)
     pass2_llm_calls: int = Field(default=0, ge=0)
     extraction_warnings: list[str] = Field(default_factory=list)
+
+
+class ExtractorRunInfo(BaseModel):
+    """Per-call observability wrapper from an extractor invocation (LLM or pattern-matching).
+
+    Replaces the hand-rolled flat metadata dicts returned by extractors.
+    ``extraction_metadata`` carries the nested per-run detail (model, tokens, cost,
+    warnings); the outer fields capture the top-level success/failure signal used by
+    ``skills_extraction/agent.py`` when building the combined pass meta.
+
+    See: ``.cursor/rules/pydantic-jsonb-payloads.mdc §3.3``
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    tokens_used: int = 0
+    cost_usd: float = 0.0
+    latency_ms: int = 0
+    success: bool = True
+    extraction_failed: bool = False
+    error_reason: str | None = None
+    provider: str
+    model: str
+    extraction_metadata: ExtractionMetadata

--- a/skills_extraction/agent.py
+++ b/skills_extraction/agent.py
@@ -992,7 +992,8 @@ class SkillsExtractionAgent(BaseAgent):
         """
         job = item.job_record
         tools = extract_tools(job)
-        context_signals, ctx_meta = extract_context(job)
+        context_signals, ctx_run_info = extract_context(job)
+        ctx_meta = ctx_run_info.model_dump(mode="json")
 
         has_normalized_text = bool(
             (job.description or "").strip() or (job.requirements or "").strip() or (job.responsibilities or "").strip()
@@ -1027,7 +1028,8 @@ class SkillsExtractionAgent(BaseAgent):
         """Pass 1 sync + Pass 2 async gather for one work item (taxonomy deferred)."""
         job = item.job_record
         tools = extract_tools(job)
-        context_signals, ctx_meta = extract_context(job)
+        context_signals, ctx_run_info = extract_context(job)
+        ctx_meta = ctx_run_info.model_dump(mode="json")
 
         has_normalized_text = bool(
             (job.description or "").strip() or (job.requirements or "").strip() or (job.responsibilities or "").strip()

--- a/skills_extraction/extractors/context.py
+++ b/skills_extraction/extractors/context.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
-from typing import Any, cast
+from typing import cast
 
 import structlog
 
 from common.types import ContextSignal, JobRecord, SpanRecord
 from common.types.extraction_schemas import ContextSignalType
+from common.types.extraction_types import ExtractionMetadata, ExtractorRunInfo
 
 log = structlog.get_logger()
 
@@ -79,7 +80,7 @@ def _iter_job_fields(job_record: JobRecord) -> Iterable[tuple[str, str]]:
 
 def extract_context(
     job_record: JobRecord,
-) -> tuple[list[ContextSignal], dict[str, Any]]:
+) -> tuple[list[ContextSignal], ExtractorRunInfo]:
     """Extract context signals using Pass 1 regex patterns only (no LLM).
 
     Parameters
@@ -89,33 +90,11 @@ def extract_context(
 
     Returns
     -------
-    tuple[list[ContextSignal], dict]
-        Signals and metadata. ``tokens_used`` is always 0. On catastrophic
-        regex failure, returns ``[]`` and logs a warning (never raises).
+    tuple[list[ContextSignal], ExtractorRunInfo]
+        Signals and structured run metadata. ``tokens_used`` is always 0 (no LLM).
+        On catastrophic regex failure, returns ``[]`` and logs a warning (never raises).
     """
-    metadata: dict[str, Any] = {
-        "tokens_used": 0,
-        "cost_usd": 0.0,
-        "latency_ms": 0,
-        "success": True,
-        "extraction_failed": False,
-        "error_reason": None,
-        "provider": "pattern-matching",
-        "model": "none",
-        "extraction_metadata": {
-            "extraction_version": "week5-context-pass1",
-            "model_used": "none",
-            "model_tier": "none",
-            "tokens_used": 0,
-            "cost_usd": 0.0,
-            "extraction_duration_ms": 0,
-            "pass1_tool_count": 0,
-            "pass2_llm_dimensions": [],
-            "pass2_llm_calls": 0,
-            "extraction_warnings": [],
-        },
-    }
-
+    extraction_warnings: list[str] = []
     signals: list[ContextSignal] = []
 
     try:
@@ -148,21 +127,38 @@ def extract_context(
                             signal_type=signal_type,
                             field_source=field_source,
                         )
-                        metadata["extraction_metadata"]["extraction_warnings"].append(f"invalid_span:{signal_type}")
+                        extraction_warnings.append(f"invalid_span:{signal_type}")
 
         log.info(
             "context_extraction_complete",
             context_signal_count=len(signals),
             field_count=len(fields),
         )
-        return signals, metadata
+        return signals, ExtractorRunInfo(
+            provider="pattern-matching",
+            model="none",
+            extraction_metadata=ExtractionMetadata(
+                extraction_version="week5-context-pass1",
+                model_used="none",
+                model_tier="none",
+                extraction_warnings=extraction_warnings,
+            ),
+        )
     except Exception as e:
         log.warning("context_extraction_pattern_failure", error_type=type(e).__name__)
-        metadata["success"] = False
-        metadata["extraction_failed"] = True
-        metadata["error_reason"] = type(e).__name__
-        metadata["extraction_metadata"]["extraction_warnings"].append("pattern_failure")
-        return [], metadata
+        return [], ExtractorRunInfo(
+            success=False,
+            extraction_failed=True,
+            error_reason=type(e).__name__,
+            provider="pattern-matching",
+            model="none",
+            extraction_metadata=ExtractionMetadata(
+                extraction_version="week5-context-pass1",
+                model_used="none",
+                model_tier="none",
+                extraction_warnings=["pattern_failure"],
+            ),
+        )
 
 
 def _format_pass1_context_for_prompt(pass1_context: list[ContextSignal] | None) -> str:

--- a/skills_extraction/tests/test_extraction_integration.py
+++ b/skills_extraction/tests/test_extraction_integration.py
@@ -182,7 +182,7 @@ def test_extract_context_returns_empty_list() -> None:
     result, meta = extract_context(job)
     assert isinstance(result, list)
     assert len(result) == 0
-    assert meta.get("tokens_used") == 0
+    assert meta.tokens_used == 0
 
 
 @patch("skills_extraction.extractors.tasks.invoke_structured_extraction_llm")

--- a/skills_extraction/tests/test_extraction_stubs.py
+++ b/skills_extraction/tests/test_extraction_stubs.py
@@ -70,7 +70,7 @@ def test_context_signal_schema() -> None:
 def test_extract_context_empty_when_no_matches(dummy_job: JobRecord) -> None:
     """extract_context returns schema-valid list when no regex matches."""
     signals, meta = extract_context(dummy_job)
-    assert meta.get("tokens_used") == 0
+    assert meta.tokens_used == 0
     TypeAdapter(list[ContextSignal]).validate_python(signals)
 
 
@@ -84,7 +84,7 @@ def test_extract_context_finds_hybrid() -> None:
         description="We offer a hybrid schedule for this role.",
     )
     signals, meta = extract_context(job)
-    assert meta.get("tokens_used") == 0
+    assert meta.tokens_used == 0
     assert any(s.signal_type == "remote_policy" for s in signals)
 
 

--- a/tests/test_extraction_corpus.py
+++ b/tests/test_extraction_corpus.py
@@ -232,11 +232,10 @@ def test_extract_context_corpus_tokens_and_spans() -> None:
     adapter = TypeAdapter(list[ContextSignal])
     for job in all_corpus_jobs():
         signals, meta = extract_context(job)
-        assert meta.get("tokens_used") == 0
-        assert float(meta.get("cost_usd") or 0) == 0.0
-        inner = meta.get("extraction_metadata") or {}
-        assert inner.get("tokens_used") == 0
-        assert inner.get("pass2_llm_calls") == 0
+        assert meta.tokens_used == 0
+        assert meta.cost_usd == 0.0
+        assert meta.extraction_metadata.tokens_used == 0
+        assert meta.extraction_metadata.pass2_llm_calls == 0
         adapter.validate_python(signals)
         for sig in signals:
             _assert_span_anchors(job, sig.source_span)
@@ -261,7 +260,7 @@ def test_extract_context_ground_truth_file_has_signals() -> None:
     total = 0
     for job in jobs:
         signals, meta = extract_context(job)
-        assert meta.get("tokens_used") == 0
+        assert meta.tokens_used == 0
         for sig in signals:
             _assert_span_anchors(job, sig.source_span)
         total += len(signals)
@@ -387,7 +386,7 @@ def test_extraction_corpus_combined_pass1_and_mocked_pass2() -> None:
     ):
         for job in jobs:
             ctx, cmeta = extract_context(job)
-            assert cmeta.get("tokens_used") == 0
+            assert cmeta.tokens_used == 0
 
             tasks, tmeta = extract_tasks(job, pass1_context=ctx)
             assert tmeta.get("extraction_failed") is False

--- a/tests/test_extraction_job_postings_db.py
+++ b/tests/test_extraction_job_postings_db.py
@@ -92,11 +92,10 @@ def test_extract_context_db_job_postings_tokens_and_spans(unextracted_job_record
     adapter = TypeAdapter(list[ContextSignal])
     for job in unextracted_job_records:
         signals, meta = extract_context(job)
-        assert meta.get("tokens_used") == 0
-        assert float(meta.get("cost_usd") or 0) == 0.0
-        inner = meta.get("extraction_metadata") or {}
-        assert inner.get("tokens_used") == 0
-        assert inner.get("pass2_llm_calls") == 0
+        assert meta.tokens_used == 0
+        assert meta.cost_usd == 0.0
+        assert meta.extraction_metadata.tokens_used == 0
+        assert meta.extraction_metadata.pass2_llm_calls == 0
         adapter.validate_python(signals)
         for sig in signals:
             _assert_span_anchors(job, sig.source_span)
@@ -232,7 +231,7 @@ def test_extraction_db_job_postings_combined_pass1_and_mocked_pass2(unextracted_
     ):
         for job in jobs:
             ctx, cmeta = extract_context(job)
-            assert cmeta.get("tokens_used") == 0
+            assert cmeta.tokens_used == 0
             tasks, tmeta = extract_tasks(job, pass1_context=ctx)
             assert tmeta.get("extraction_failed") is False
             for t in tasks:

--- a/tests/test_skills_extraction_agent.py
+++ b/tests/test_skills_extraction_agent.py
@@ -57,12 +57,15 @@ def _patch_skills_extraction_pass2_llm(
     ):
         m_ctx.return_value = (
             [],
-            {
-                "tokens_used": 0,
-                "cost_usd": 0.0,
-                "extraction_failed": False,
-                "extraction_metadata": {},
-            },
+            ExtractorRunInfo(
+                provider="pattern-matching",
+                model="none",
+                extraction_metadata=ExtractionMetadata(
+                    extraction_version="week5-context-pass1",
+                    model_used="none",
+                    model_tier="none",
+                ),
+            ),
         )
         m_tasks.return_value = (
             [],
@@ -531,13 +534,15 @@ class TestSkillsExtractionAgent:
                 "skills_extraction.agent.extract_context",
                 return_value=(
                     [],
-                    {
-                        "tokens_used": 0,
-                        "cost_usd": 0.0,
-                        "latency_ms": 5,
-                        "extraction_failed": False,
-                        "extraction_metadata": {},
-                    },
+                    ExtractorRunInfo(
+                        provider="pattern-matching",
+                        model="none",
+                        extraction_metadata=ExtractionMetadata(
+                            extraction_version="week5-context-pass1",
+                            model_used="none",
+                            model_tier="none",
+                        ),
+                    ),
                 ),
             ),
             patch("skills_extraction.agent.extract_tasks_async", new=AsyncMock(side_effect=RuntimeError("tasks boom"))),
@@ -626,13 +631,16 @@ class TestSkillsExtractionAgent:
                 "skills_extraction.agent.extract_context",
                 return_value=(
                     [],
-                    {
-                        "tokens_used": 0,
-                        "cost_usd": 0.0,
-                        "latency_ms": 40,
-                        "extraction_failed": False,
-                        "extraction_metadata": {},
-                    },
+                    ExtractorRunInfo(
+                        latency_ms=40,
+                        provider="pattern-matching",
+                        model="none",
+                        extraction_metadata=ExtractionMetadata(
+                            extraction_version="week5-context-pass1",
+                            model_used="none",
+                            model_tier="none",
+                        ),
+                    ),
                 ),
             ),
             patch(
@@ -1205,15 +1213,15 @@ class TestSkillsExtractionAgent:
                 "skills_extraction.agent.extract_context",
                 return_value=(
                     [],
-                    {
-                        "tokens_used": 0,
-                        "cost_usd": 0.0,
-                        "latency_ms": 0,
-                        "extraction_failed": False,
-                        "provider": "pattern-matching",
-                        "model": "none",
-                        "extraction_metadata": {},
-                    },
+                    ExtractorRunInfo(
+                        provider="pattern-matching",
+                        model="none",
+                        extraction_metadata=ExtractionMetadata(
+                            extraction_version="week5-context-pass1",
+                            model_used="none",
+                            model_tier="none",
+                        ),
+                    ),
                 ),
             ),
             patch(

--- a/tests/test_skills_extraction_agent.py
+++ b/tests/test_skills_extraction_agent.py
@@ -17,6 +17,7 @@ from common.data_store.database import check_db_connection, get_engine, session_
 from common.data_store.models import ExtractedIntelligence, NormalizedJob
 from common.event_envelope import EventEnvelope
 from common.types import JobRecord
+from common.types.extraction_types import ExtractionMetadata, ExtractorRunInfo
 from skills_extraction.agent import ExtractionWorkItem, SkillsExtractionAgent
 
 
@@ -1092,15 +1093,15 @@ class TestSkillsExtractionAgent:
             is_genai_extension=False,
             resolution_step=2,
         )
-        ctx_meta = {
-            "tokens_used": 0,
-            "cost_usd": 0.0,
-            "latency_ms": 0,
-            "extraction_failed": False,
-            "provider": "pattern-matching",
-            "model": "none",
-            "extraction_metadata": {"context_signals": 0},
-        }
+        ctx_meta = ExtractorRunInfo(
+            provider="pattern-matching",
+            model="none",
+            extraction_metadata=ExtractionMetadata(
+                extraction_version="week5-context-pass1",
+                model_used="none",
+                model_tier="none",
+            ),
+        )
         tasks_meta = {
             "success": True,
             "extraction_failed": False,


### PR DESCRIPTION
## Summary

Closes #411

Addresses the missing `ExtractorRunInfo` model identified in the Pair B runbook audit. Two changes:

- Add `ExtractorRunInfo` to `common/types/extraction_types.py` per `pydantic-jsonb-payloads.mdc §3.3`
- Migrate `skills_extraction/extractors/context.py` to use `ExtractorRunInfo` + the existing `ExtractionMetadata` model instead of the hand-rolled metadata dict at lines 96–117

## What changed

- `common/types/extraction_types.py` — new `ExtractorRunInfo` Pydantic model (`ConfigDict(extra="forbid")`, nests `ExtractionMetadata`)
- `skills_extraction/extractors/context.py` — replace bare `metadata: dict[str, Any]` with `ExtractorRunInfo`; update return type of `extract_context` to `tuple[list[ContextSignal], ExtractorRunInfo]`
- Call sites updated to use `.model_dump(mode="json")` at the write boundary

## Out of scope

Migration of `skills.py`, `tools.py`, `tasks.py`, and `responsibilities.py` is a follow-up. This PR establishes the model and proves the pattern on `context.py` only.

## Test plan

- [ ] `pytest skills_extraction/tests/ -v`
- [ ] `pytest common/ -v`
- [ ] Verify `extract_context` return type is `ExtractorRunInfo` in all code paths (success + failure branches)
- [ ] Verify `.model_dump(mode="json")` output shape matches the previous hand-rolled dict shape
