### PR TITLE
feat(clustering): Phase 2 UMAP tuning — dry-run, gate metrics, findings template (#327)

### DIFF
--- a/eval/runs/findingsv2.phase2-clustering-template.md
+++ b/eval/runs/findingsv2.phase2-clustering-template.md
@@ -1,0 +1,79 @@
+# Phase 2 Clustering Findings — [DATE] — Tier [N]
+
+**Issue:** [#327](https://github.com/Building-With-Agents/job-intelligence-engine/issues/327)
+**Discipline:** ONE variable changed vs prior run.
+
+---
+
+## Run parameters (full snapshot)
+
+| Parameter | Prior value | This run | Changed? |
+|-----------|-------------|----------|----------|
+| `min_cluster_size` | 3 | X | |
+| `min_samples` | 3 | X | |
+| `cluster_selection_method` | leaf | X | |
+| `umap_n_components` | 15 | X | |
+| `umap_n_neighbors` | 10 | X | |
+| `umap_min_dist` | 0.0 | X | |
+| `umap_metric` | cosine | X | |
+
+**Changed this run:** `param_name` from `old` → `new`
+
+**Command used:**
+```bash
+CLUSTER_PARAM=VALUE python scripts/run_clustering.py --dry-run --findings-output eval/runs/findingsv2.X-clustering-tierN.md
+```
+
+---
+
+## Results
+
+| Metric | Value | Target | Gate |
+|--------|-------|--------|------|
+| eligible_posting_count | X | — | — |
+| cluster_count | X | ≥ 20 | ✗/✓ |
+| noise_rate | X% | < 30% | ✗/✓ |
+| mega_cluster_share | X% | < 10% | ✗/✓ |
+
+**Phase 2 gate:** PASS / FAIL
+
+---
+
+## Top clusters (qualitative review — sample 5 postings per cluster)
+
+| # | Label | Posts | Share | Top skills |
+|---|-------|-------|-------|-----------|
+| 1 | | | % | |
+| 2 | | | % | |
+| 3 | | | % | |
+
+**Semantic coherence check:** Are the top 3 clusters semantically distinct roles, or are similar roles merged?
+
+---
+
+## Decision
+
+- [ ] Gate passed (cluster_count ≥ 20, mega_cluster_share < 10%, noise_rate < 30%)
+- [ ] Cluster labels are semantically coherent (checked 5 sample postings per top cluster)
+- [ ] No regression on previously identified clusters (SRE, Data Engineering still distinct)
+
+**Decision:**
+- [ ] Ship this config to `config/clustering.yaml` + advance to Phase 3
+- [ ] Advance to Phase 2 priority 2 (next tuning lever)
+- [ ] Revisit this lever (explain why)
+
+**Next step:** <!-- priority 2: min_cluster_size sweep / priority 3: n_components sweep / etc. -->
+
+---
+
+## UMAP convergence diagnostics (fill from stdout)
+
+- Embedding shape after UMAP: `(N_samples, N_components)`
+- Any UMAP warnings: none / list warnings
+- Run time: approx X minutes
+
+---
+
+## Notes
+
+<!-- Any qualitative observations, surprises, or follow-up questions -->

--- a/scripts/run_clustering.py
+++ b/scripts/run_clustering.py
@@ -4,6 +4,18 @@
 Usage:
     python scripts/run_clustering.py
     python scripts/run_clustering.py --min-postings 100
+
+Phase 2 tuning (JIE #327) — one variable per run discipline:
+    python scripts/run_clustering.py --dry-run --findings-output eval/runs/findingsv2.X-clustering-tierN.md
+    # Set a single param via env override, e.g.:
+    CLUSTER_MIN_SAMPLES=2 python scripts/run_clustering.py --dry-run --findings-output eval/runs/...
+    CLUSTER_DIM_REDUCTION_N_COMPONENTS=10 python scripts/run_clustering.py --dry-run ...
+
+Tuning matrix (execute in priority order per #327 Phase 2 discipline):
+    Priority 1: CLUSTER_MIN_SAMPLES 3 → try 2, 5
+    Priority 2: CLUSTER_MIN_CLUSTER_SIZE 3 → try 2, 5
+    Priority 3: CLUSTER_DIM_REDUCTION_N_COMPONENTS 15 → try 10, 20
+    Priority 4: CLUSTER_UMAP_N_NEIGHBORS 10 → try 5, 15
 """
 
 from __future__ import annotations
@@ -37,13 +49,86 @@ def _iso_week_monday(today: date) -> date:
     return today - timedelta(days=today.weekday())
 
 
+def _write_findings_md(path: Path, findings: dict, config_snapshot: dict) -> None:
+    """Write a Phase 2 tuning findings note in Markdown (JIE #327)."""
+    mega = findings["mega_cluster_share_pct"]
+    noise = findings["noise_rate"]
+    n_clusters = findings["clusters_found"]
+    gate = (
+        "PASS" if n_clusters >= 20 and mega < 10.0 and findings["noise_count"] / max(findings["eligible_posting_count"], 1) < 0.30 else "FAIL"
+    )
+    lines = [
+        f"# Phase 2 Clustering Findings — {findings['run_date']}",
+        "",
+        f"**Gate:** {gate}  (target: clusters ≥ 20, mega-cluster < 10%, noise < 30%)",
+        "",
+        "## Run parameters",
+        "",
+        "| Parameter | Value |",
+        "|-----------|-------|",
+    ]
+    for k, v in config_snapshot.items():
+        lines.append(f"| `{k}` | `{v}` |")
+    lines += [
+        "",
+        "## Results",
+        "",
+        "| Metric | Value | Target |",
+        "|--------|-------|--------|",
+        f"| eligible_posting_count | {findings['eligible_posting_count']} | — |",
+        f"| cluster_count | {n_clusters} | ≥ 20 |",
+        f"| noise_rate | {noise} | < 30% |",
+        f"| mega_cluster_share | {mega:.1f}% | < 10% |",
+        f"| emergence_candidates | {findings['emergence_candidates']} | — |",
+        "",
+        "## Top clusters (qualitative label review)",
+        "",
+        "| # | Label | Posts | Top skills |",
+        "|---|-------|-------|-----------|",
+    ]
+    for i, cl in enumerate(findings.get("top_clusters", [])[:20], 1):
+        skills = ", ".join(cl["top_skills"][:4])
+        lines.append(f"| {i} | {cl['label']} | {cl['posting_count']} | {skills} |")
+    lines += [
+        "",
+        "## Decision",
+        "",
+        "<!-- Fill in after reviewing qualitative labels -->",
+        "",
+        f"- [ ] cluster_count ≥ 20 → {'✓' if n_clusters >= 20 else '✗'}",
+        f"- [ ] mega_cluster_share < 10% → {'✓' if mega < 10.0 else '✗'}",
+        f"- [ ] noise < 30% → {'✓' if findings['noise_count'] / max(findings['eligible_posting_count'], 1) < 0.30 else '✗'}",
+        "",
+        "**Next step:** <!-- advance to next Phase 2 lever / ship / revisit UMAP params -->",
+        "",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+    print(f"\nFindings Markdown written to: {path}")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--min-postings", type=int, default=None)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip DB persistence (clustering + findings only; no canonical_roles or snapshots updated)",
+    )
+    parser.add_argument(
+        "--findings-output",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Write Phase 2 findings Markdown to this path (e.g. eval/runs/findingsv2.1-clustering-tier3.md)",
+    )
     args = parser.parse_args()
 
     if args.min_postings is not None:
         os.environ["CLUSTER_MIN_TOTAL_POSTINGS"] = str(args.min_postings)
+
+    dry_run: bool = args.dry_run
+    findings_output: str | None = args.findings_output
 
     if not check_db_connection():
         print("ERROR: DB not reachable")
@@ -84,16 +169,24 @@ def main() -> None:
             print(f"SKIP: {result.skip_reason}")
             return
 
+        n_clusters = len(result.clusters)
+        noise_rate = 100 * result.noise_posting_count / result.eligible_posting_count
+        sorted_clusters = sorted(result.clusters, key=lambda c: c.member_count, reverse=True)
+        mega_cluster_count = sorted_clusters[0].member_count if sorted_clusters else 0
+        mega_cluster_share = 100 * mega_cluster_count / result.eligible_posting_count if result.eligible_posting_count else 0
+
         print("\nClustering results:")
         print(f"  Total input:        {result.total_input_postings}")
         print(f"  Eligible:           {result.eligible_posting_count}")
-        print(f"  Clusters found:     {len(result.clusters)}")
+        print(f"  Clusters found:     {n_clusters}  (target: ≥ 20)")
         print(f"  Noise postings:     {result.noise_posting_count}")
-        print(f"  Noise rate:         {100 * result.noise_posting_count / result.eligible_posting_count:.1f}%")
+        print(f"  Noise rate:         {noise_rate:.1f}%  (target: < 30%)")
+        print(f"  Mega-cluster share: {mega_cluster_share:.1f}%  (target: < 10%)")
         print(f"  Emergence cands:    {len(result.emergence_candidates)}")
+        gate_pass = n_clusters >= 20 and mega_cluster_share < 10.0 and noise_rate < 30.0
+        print(f"\n  Phase 2 gate: {'PASS' if gate_pass else 'FAIL'}  (clusters≥20, mega<10%, noise<30%)")
 
         print("\n--- Top clusters ---")
-        sorted_clusters = sorted(result.clusters, key=lambda c: c.member_count, reverse=True)
         for i, cl in enumerate(sorted_clusters[:20], 1):
             skills_str = ", ".join(s.skill_name for s in cl.top_skills[:5])
             tools_str = ", ".join(t.tool_name for t in cl.top_tools[:3])
@@ -110,31 +203,60 @@ def main() -> None:
                 print(f"    Novel skills: {[s.skill_name for s in ec.top_skills[:5]]}")
                 print(f"    Reason: {ec.filter_reason}")
 
-        print("\n--- Persisting to DB ---")
-        persist_info = persist_clustering_result(session, result, correlation_id="week7-clustering-run")
-        print(f"  Roles inserted:    {persist_info.get('roles_inserted')}")
-        print(f"  Postings updated:  {persist_info.get('postings_updated')}")
+        if dry_run:
+            print("\n--- dry-run: skipping DB persistence ---")
+            persist_info: dict = {"roles_inserted": 0, "postings_updated": 0}
+            snapshot_rows = 0
+        else:
+            print("\n--- Persisting to DB ---")
+            persist_info = persist_clustering_result(session, result, correlation_id="week7-clustering-run")
+            print(f"  Roles inserted:    {persist_info.get('roles_inserted')}")
+            print(f"  Postings updated:  {persist_info.get('postings_updated')}")
 
-        week_start = _iso_week_monday(date.today())
-        print(f"\n--- Role snapshot weekly (week_start={week_start}) ---")
-        snapshot_rows = refresh_role_snapshot_weekly(session, week_start=week_start)
-        print(f"  Snapshot rows:     {snapshot_rows}")
+            week_start = _iso_week_monday(date.today())
+            print(f"\n--- Role snapshot weekly (week_start={week_start}) ---")
+            snapshot_rows = refresh_role_snapshot_weekly(session, week_start=week_start)
+            print(f"  Snapshot rows:     {snapshot_rows}")
 
-        orphans = cleanup_orphan_canonical_roles(session)
-        print(f"  Orphans cleaned:   {orphans}")
+            orphans = cleanup_orphan_canonical_roles(session)
+            print(f"  Orphans cleaned:   {orphans}")
 
         print("\n" + "=" * 70)
         print("DONE — query canonical_roles and role_snapshot_weekly for findings")
         print("=" * 70)
 
+        from analytics.clustering.config import (
+            cluster_dim_reduction_n_components,
+            cluster_min_cluster_size,
+            cluster_min_samples,
+            cluster_selection_method,
+            cluster_umap_metric,
+            cluster_umap_min_dist,
+            cluster_umap_n_neighbors,
+        )
+
+        config_snapshot = {
+            "min_cluster_size": cluster_min_cluster_size(),
+            "min_samples": cluster_min_samples(),
+            "cluster_selection_method": cluster_selection_method(),
+            "umap_n_components": cluster_dim_reduction_n_components(),
+            "umap_n_neighbors": cluster_umap_n_neighbors(),
+            "umap_min_dist": cluster_umap_min_dist(),
+            "umap_metric": cluster_umap_metric(),
+        }
+
         findings = {
             "run_date": date.today().isoformat(),
+            "config_snapshot": config_snapshot,
             "features_loaded": len(features),
+            "eligible_posting_count": result.eligible_posting_count,
             "skills_coverage": f"{100 * with_skills / len(features):.1f}%",
             "tools_coverage": f"{100 * with_tools / len(features):.1f}%",
-            "clusters_found": len(result.clusters),
+            "clusters_found": n_clusters,
             "noise_count": result.noise_posting_count,
-            "noise_rate": f"{100 * result.noise_posting_count / result.eligible_posting_count:.1f}%",
+            "noise_rate": f"{noise_rate:.1f}%",
+            "mega_cluster_share_pct": mega_cluster_share,
+            "phase2_gate_pass": gate_pass,
             "emergence_candidates": len(result.emergence_candidates),
             "roles_persisted": persist_info.get("roles_inserted"),
             "snapshot_rows": snapshot_rows,
@@ -163,6 +285,9 @@ def main() -> None:
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(json.dumps(findings, indent=2, default=str), encoding="utf-8")
         print(f"\nFindings JSON saved to: {out_path}")
+
+        if findings_output:
+            _write_findings_md(Path(findings_output), findings, config_snapshot)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Phase 2 of JIE #327 — adds the tooling to execute the one-variable-at-a-time UMAP tuning sweep safely (no prod DB writes) and generate structured Markdown findings notes automatically.

Contributes to #327 (Phase 2 tooling; actual tuning runs + findings docs are committed as the sweep progresses).

## Changes

### `scripts/run_clustering.py`

| Addition | Purpose |
|----------|---------|
| `--dry-run` flag | Skips DB persistence — safe to run tuning iterations without touching `canonical_roles` or `role_snapshot_weekly` |
| `--findings-output PATH` | Writes a Markdown findings doc with config snapshot, gate verdict, and top-cluster table |
| Mega-cluster share calculation | `mega_cluster_share = top_cluster.member_count / eligible_posting_count` — required for Phase 2 gate |
| Phase 2 gate inline verdict | Prints PASS/FAIL against `clusters≥20, mega<10%, noise<30%` on every run |
| `config_snapshot` in findings JSON | Captures the exact 7 HDBSCAN+UMAP params for reproducibility |
| Module-level docstring | Documents the Phase 2 tuning matrix (priority 1–4) with env-override commands |

### `eval/runs/findingsv2.phase2-clustering-template.md`

Template for each Phase 2 tuning iteration's findings note, covering:
- Full parameter snapshot (what changed vs prior run)
- Gate table with pass/fail per metric
- Qualitative cluster-label review prompt (5 sample postings per cluster)
- Semantic coherence check + decision section

## How to run Phase 2 (one variable at a time)

```bash
# Priority 1: min_samples sweep (current = 3; try 2 and 5)
CLUSTER_MIN_SAMPLES=2 python scripts/run_clustering.py \
    --dry-run \
    --findings-output eval/runs/findingsv2.1-clustering-tier3-min-samples-2.md

CLUSTER_MIN_SAMPLES=5 python scripts/run_clustering.py \
    --dry-run \
    --findings-output eval/runs/findingsv2.1-clustering-tier3-min-samples-5.md

# Priority 2: min_cluster_size sweep (try 2 and 5)
CLUSTER_MIN_CLUSTER_SIZE=2 python scripts/run_clustering.py --dry-run ...
```

After each run: fill in the findings template, update `config/clustering.yaml` with the winner.

## Test plan

- [ ] `python scripts/run_clustering.py --help` shows `--dry-run` and `--findings-output`
- [ ] `--dry-run` run completes without DB write (verify `canonical_roles` count unchanged)
- [ ] `--findings-output` produces a valid Markdown file with gate verdict and cluster table
- [ ] Phase 2 priority 1: run `CLUSTER_MIN_SAMPLES=2` and `CLUSTER_MIN_SAMPLES=5`; fill findings docs; commit winner config

## Phase 2 tuning matrix (from #327)

| Priority | Knob | Current → Try | Goal |
|----------|------|---------------|------|
| 1 | `min_samples` | 3 → 2, 5 | More clusters survive |
| 2 | `min_cluster_size` | 3 → 2, 5 | More candidate clusters |
| 3 | UMAP `n_components` | 15 → 10, 20 | More semantic separation |
| 4 | UMAP `n_neighbors` | 10 → 5, 15 | Fine-tune cluster locality |


Made with [Cursor](https://cursor.com)