### PR TITLE
fix(smoke): align LaborPulse default API URL

### DIFF
--- a/scripts/smoke/laborpulse/real_query.py
+++ b/scripts/smoke/laborpulse/real_query.py
@@ -5,7 +5,7 @@ Mirrors wfd-os → ``POST /analytics/query`` (LaborPulse headers, JIE #222).
 
 Requires JIE running, e.g.::
 
-    uvicorn analytics.api.app:app --host 127.0.0.1 --port 8020
+    python scripts/run_analytics_api.py
 
 Headers match ``scripts/smoke/api_smoke.py``. Set ``ANALYTICS_QUERY_X_API_KEY`` when
 ``JIE_API_KEYS`` is configured (see ``.env.example``).
@@ -13,7 +13,7 @@ Headers match ``scripts/smoke/api_smoke.py``. Set ``ANALYTICS_QUERY_X_API_KEY`` 
 Usage::
 
     python scripts/smoke/laborpulse/real_query.py
-    python scripts/smoke/laborpulse/real_query.py --base-url http://localhost:8020
+    python scripts/smoke/laborpulse/real_query.py --base-url http://localhost:8000
 
 Exit code 0 only if every question returns HTTP 200 with a non-empty answer.
 """
@@ -40,6 +40,8 @@ LOCKED_DEMO_QUESTIONS: tuple[str, ...] = (
     "What tools and practices do Borderplex employers expect from workflow automation engineers?",
     "What does an MLOps role look like in the Borderplex job market right now?",
 )
+
+DEFAULT_JIE_BASE_URL = "http://127.0.0.1:8000"
 
 
 def _headers(*, request_id: str | None = None) -> dict[str, str]:
@@ -89,12 +91,22 @@ def _likely_refusal(answer: str) -> bool:
     return any(a.startswith(p) for p in prefixes)
 
 
+def _default_base_url() -> str:
+    """Return the JIE API base URL used by the smoke script.
+
+    Mirrors ``scripts/run_analytics_api.py`` so the no-argument smoke command
+    targets the API port that local devs get by default, while still allowing
+    ``JIE_BASE_URL`` to override it for non-standard runs.
+    """
+    return os.environ.get("JIE_BASE_URL", DEFAULT_JIE_BASE_URL)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Smoke the five locked LaborPulse demo questions.")
     parser.add_argument(
         "--base-url",
-        default=os.environ.get("JIE_BASE_URL", "http://localhost:8020"),
-        help="JIE Analytics API base URL (default: http://localhost:8020 or JIE_BASE_URL).",
+        default=_default_base_url(),
+        help=f"JIE Analytics API base URL (default: {DEFAULT_JIE_BASE_URL} or JIE_BASE_URL).",
     )
     parser.add_argument(
         "--require-non-empty-sql",

--- a/scripts/tests/test_laborpulse_real_query.py
+++ b/scripts/tests/test_laborpulse_real_query.py
@@ -1,0 +1,26 @@
+"""Unit tests for the LaborPulse locked-question smoke script helpers."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+real_query = importlib.import_module("scripts.smoke.laborpulse.real_query")
+
+
+def test_default_base_url_matches_run_analytics_api(monkeypatch) -> None:
+    """No-arg smoke command should target scripts/run_analytics_api.py's default port."""
+    monkeypatch.delenv("JIE_BASE_URL", raising=False)
+
+    assert real_query._default_base_url() == "http://127.0.0.1:8000"
+
+
+def test_default_base_url_honors_jie_base_url(monkeypatch) -> None:
+    monkeypatch.setenv("JIE_BASE_URL", "http://localhost:8010")
+
+    assert real_query._default_base_url() == "http://localhost:8010"


### PR DESCRIPTION
## Summary
- Aligns `scripts/smoke/laborpulse/real_query.py` with `scripts/run_analytics_api.py` by defaulting to `http://127.0.0.1:8000` instead of the stale `8020` port.
- Keeps `JIE_BASE_URL` as the environment override for non-standard local runs.
- Adds a small unit test for the default URL and env override behavior.

## Tests
- `python -m pytest scripts/tests/test_laborpulse_real_query.py -q`
- `python -m ruff format --check scripts/smoke/laborpulse/real_query.py scripts/tests/test_laborpulse_real_query.py`
- `python -m ruff check scripts/smoke/laborpulse/real_query.py scripts/tests/test_laborpulse_real_query.py`

## Risk
Low. This only changes the no-argument default for a smoke script and preserves explicit `--base-url` plus `JIE_BASE_URL` override behavior.

## Reviewer Notes
Please sanity-check that the smoke script should follow `scripts/run_analytics_api.py`'s default port. I kept the change scoped to the LaborPulse smoke helper and a pure unit test, with no live API calls in tests.
