### PR TITLE
docs(eval): v2 harness documentation — README + ADR-009 closure (#272)

### DIFF
--- a/docs/adr/ADR-009-week-10-eval-scoring-strategy.md
+++ b/docs/adr/ADR-009-week-10-eval-scoring-strategy.md
@@ -4,8 +4,9 @@
 |---|---|
 | **Owner** | Gary (lead instructor); Pair C (implementation) |
 | **Experiment** | #264 (Langfuse LLM-as-a-Judge side-by-side comparison) |
-| **Status** | **Proposed** (awaiting empirical evidence from #264) |
-| **Date** | Week 9 → Week 10 |
+| **Status** | **Accepted** — Option D (Hybrid): custom scorer fixed + Langfuse judge enabled |
+| **Decided** | Week 11 (all sub-issues closed; empirical evidence gathered in #264) |
+| **Original date** | Week 9 → Week 10 |
 
 ## Context
 
@@ -102,18 +103,37 @@ Reasoning:
 - **Judge rubric authorship is a new skill.** Prompt-engineering for judges is subtly different from prompt-engineering for the pipeline. Mitigation: Pair C owns initial rubric drafts; cross-pair review in Week 10.
 - **The Langfuse native judge is less battle-tested than RAGAs.** It is newer, less documented, used by fewer teams. Mitigation: if the Langfuse judge is insufficient at Week 11, revisit RAGAs with the comparison data already in hand — we will not have wasted the exercise.
 
-## Data / Evidence
+## Decision outcome (Week 11)
 
-This ADR is **proposed, not accepted.** Evidence to collect during Week 10 from issue #264:
+**Option D accepted.** Evidence collected during Week 10 via issues #260–#271 and #264:
 
-- [ ] Custom scorer scores (with #260, #261, #263, #265 fixes applied) for v1-baseline
-- [ ] Langfuse LLM-as-a-Judge scores (faithfulness + optionally answer_relevance) for the same v1-baseline traces
-- [ ] Human Layer 2 scores (`correctness`, `decision_relevance`, `followup_quality`) — already in plan for Week 10 manual annotation
-- [ ] Cost: dollar amount of judge calls
-- [ ] Runtime: time to judge 90 items
-- [ ] Variance: per-item judge score delta on a second run
+- [x] Custom scorer fixed: #260 (refusal redesign), #261 (binary intent), #263 (None-for-infra),
+      #265 (component scores), #267 (confidence redesign), #268 (sub-composites), #269
+      (answerability + correct_refusal), #270 (latency tail aggregates), #271 (Layer 2 ECE)
+- [x] Langfuse LLM-as-a-Judge enabled per #264 (Gary); side-by-side data gathered on v1-baseline
+- [x] Human Layer 2 scores (`correctness`, `decision_relevance`, `followup_quality`) scored in
+      Langfuse UI; IRR report generated via `scripts/compute_layer2_irr.py`
+- [x] Divergence report `eval/qa_divergence_report.md` produced by
+      `scripts/compute_automated_human_divergence.py`; high-auto-low-human items prioritised for
+      Week 11 prompt iteration
+- [x] Cost within bounds: judge cost confirmed acceptable per #264
 
-Once gathered, review this ADR at the Week 11 start and update its Status to Accepted, Amended, or Superseded.
+**No migration to RAGAs required.** The fixed custom scorer + Langfuse LLM-as-a-Judge meets the
+Week 10–11 iteration bar. RAGAs remains an option if the judge proves insufficient at Week 12 or
+beyond.
+
+**Custom scorer is the offline fallback.** When Langfuse / Azure OpenAI is unavailable, the
+deterministic custom scorer (`eval/qa_scoring.py`) runs without LLM calls and produces
+reproducible results.
+
+## Data / Evidence (collected)
+
+- Custom scorer scores with all fixes applied: `eval/runs/qa-v2-scorer-redesign.json`
+- v1-baseline re-scored under v2 semantics: `eval/runs/qa-v1-baseline.json`
+- IRR report: `eval/qa_irr_report.md` (generated post Week 10 Layer 2 annotation)
+- Divergence report: `eval/qa_divergence_report.md`
+- Langfuse dataset runs: `qa-golden-v1-baseline`, `qa-golden-v2-scorer-redesign` on
+  `langfuse.watechcoalition.org`
 
 ## Adjacent and Prior Work
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -76,7 +76,8 @@ python -m eval.qa_eval --prompt-version v1-baseline --use-http --analytics-base-
 
 | Variable | Role |
 |----------|------|
-| `QA_EVAL_LATENCY_SLA_SECONDS` | Latency SLA for `latency_sla` score (default 45). |
+| `QA_EVAL_LATENCY_SLA_SECONDS` | Latency SLA for `latency_sla` score (default **15**; JIE #270 tightened from 45s). Catastrophic latencies > SLA × 10 return `None` (excluded). |
+| `QA_EVAL_ANSWERABILITY_GATE_THRESHOLD` | Float 0–1. When `mean_answerability` falls below this on a run, `overall_composite_status = "limited"` is emitted (default 0.40; JIE #268). |
 | `ANALYTICS_QUERY_BASE_URL` | Base URL when `--use-http` (default `http://127.0.0.1:8000`). |
 | `ANALYTICS_QUERY_X_TENANT_ID` | `X-Tenant-Id` for `POST /analytics/query` (default `borderplex`). Same as `scripts/smoke/smoke_issue197.py`. |
 | `ANALYTICS_QUERY_X_USER_EMAIL` | `X-User-Email` (default `smoke@thewaifinder.com`). |
@@ -88,6 +89,130 @@ Per-item `X-Request-Id` is the harness `correlation_id` (not env-configured).
 
 - `--output-json path.json` writes per-item scores (and trace IDs when Langfuse is used).
 - `--json` prints the same run summary as JSON to **stdout** and skips the human-readable console report (use for piping, `Tee-Object`, or redirecting to a file). Combine with `--output-json` to write the file and still emit JSON on stdout; file-write notices go to stderr so stdout stays valid JSON.
+
+---
+
+## v2 scorer architecture (JIE #260–#271)
+
+All scoring changes were landed for the Week 10 harness redesign. The sections below describe the current behaviour.
+
+### None semantics — infrastructure vs quality failures (JIE #263)
+
+Content metrics (`intent_accuracy`, `evidence_citation`, `confidence_self_consistency`) return `None`
+rather than `0.0` for infrastructure failures. Zeroing them conflates two orthogonal axes — pipeline
+health vs answer quality — which would prevent pairs from distinguishing "fix the prompt" from "fix
+the infrastructure."
+
+| Failure class | Score | Rationale |
+|---|---|---|
+| `pipeline_error` / timeout / Azure 500 | `None` | Infrastructure failure; not gradable |
+| `sql_execution_error_detail` set | `None` | Infrastructure failure on evidence path |
+| Empty answer (contract violation) | `None` | Pipeline output contract broken |
+| Committed answer with no evidence | `0.0` | Real quality failure; keeps signal |
+| `latency_sla` catastrophic (> SLA × 10) | `None` | Infrastructure event, not quality signal |
+| `latency_sla` all other | float 0–1 | Always computable from wall-clock time |
+
+Run-level means are computed over the **scorable pool** (non-`None` values only). Per-metric
+`n_scored` and `n_excluded` appear in every run summary and Langfuse mean comment.
+
+### Binary intent accuracy (JIE #261)
+
+`intent_accuracy` is a binary exact-match: 1.0 if `classified_intent == expected_intent`
+(case/whitespace normalised), 0.0 otherwise. The old `0.5` partial-credit ladder backed by
+`RELATED_INTENTS` is retired; `RELATED_INTENTS_OFFLINE` remains for confusion-matrix analysis only.
+
+### Refusal scoring redesign (JIE #260)
+
+`score_evidence_citation` now evaluates the rubric (`must_include`, `must_not_include`) against
+refusal text rather than bypassing it. Refusals are further penalised when the expected intent is
+data-backed (the pipeline should have committed a SQL-backed answer):
+
+| Case | Score formula |
+|---|---|
+| Intent-only refusal | `rubric_score` (must_include coverage − penalty) |
+| Data-backed refusal | `rubric_score × 0.35` (strong penalty for wrongful refusal) |
+
+The `len(ans) > 40` length floor is removed. The `refused-with-evidence → 0.85` shortcut is removed.
+
+### Component scores (JIE #265 phase 1)
+
+`score_evidence_citation` returns four values: `(combined, comment, must_include_recall, evidence_overlap)`.
+The last two are emitted as separate Langfuse `Evaluation` entries (`must_include_recall`,
+`evidence_overlap`) and included in the durable JSON `scores` block. When `combined` is `None`
+(infrastructure exclusion), both components are `None`.
+
+### correct_refusal metric (JIE #269)
+
+A sixth automated score, `correct_refusal` (1.0 / 0.0, or `None`), applies to intent-only
+(non–data-backed) items. It measures whether the pipeline made the right commit-vs-refuse decision.
+
+| Item type | `correct_refusal` |
+|---|---|
+| Data-backed expected intent | `None` (use `answerability` + `evidence_citation` instead) |
+| Infrastructure failure (no response) | `None` (excluded) |
+| Intent-only, refused | 0.0 by default; 1.0 if `refusal_appropriate: true` in golden |
+| Intent-only, committed answer | 1.0 by default; 0.0 if `refusal_appropriate: false` in golden |
+
+Optional golden fields: `data_backed` (bool), `expected_min_rows` (int), `zero_rows_is_correct` (bool),
+`refusal_appropriate` (bool).
+
+`answerability` (data-backed items) and `correct_refusal` (intent-only) together cover all 90
+golden items. Run output includes `refusal_correctness_summary`.
+
+### Sub-composites and geometric mean (JIE #268)
+
+`run_subcomposites_and_gates` computes four sub-composites and an overall geometric mean:
+
+| Sub-composite | Drives | Proxy until |
+|---|---|---|
+| `prompt_quality_composite` | `evidence_citation` mean | #265 full decomposition |
+| `classification_composite` | `intent_accuracy` mean | — |
+| `pipeline_health_composite` | `answerability`, `latency_sla`, `correct_refusal` (weighted) | — |
+| `safety_composite` | `confidence_self_consistency`, `confidence_in_expected_range` | Layer 2 `no_hallucination_rate` |
+| `overall_geometric_composite` | geometric mean of the four sub-composites | — |
+
+The geometric mean penalises any single tanked axis. An arithmetic mean would paper it over.
+
+When `mean_answerability < QA_EVAL_ANSWERABILITY_GATE_THRESHOLD`, the run emits
+`gated: true` and `gate_message` to force reader awareness of coverage gaps.
+
+### Per-stage Langfuse observations (JIE #258)
+
+Each pipeline LLM call produces its own `@observe(as_type="generation")` child observation in
+Langfuse, allowing per-stage drill-down in the trace tree:
+
+| Observation name | Stage | LLM tier |
+|---|---|---|
+| `intent_classification` | Intent routing | `LLM_DEFAULT` (Haiku-class) |
+| `sql_generation` | Text-to-SQL | `LLM_SYNTHESIS` (Sonnet-class) |
+| `synthesis` | Answer synthesis | `LLM_SYNTHESIS` |
+| `follow_up_generation` | Follow-up questions | `LLM_DEFAULT` |
+
+Token usage and model name propagate via `report_langfuse_usage` in
+`analytics/query_engine/langfuse_utils.py`. Cost attribution requires model registry population
+in Langfuse (admin task, JIE #259).
+
+### Per-intent score breakdown (JIE #256)
+
+```powershell
+python scripts/compute_per_intent_means.py
+python scripts/compute_per_intent_means.py eval/runs/qa-v2-scorer-redesign.json
+```
+
+Prints a table of per-intent means (n + 6 score columns) from a durable run JSON. Flat trace
+metadata (`intent`, `difficulty`, `gq_id`) is also set on every Langfuse trace so the Experiment
+detail view supports per-intent filtering.
+
+### Latency tail aggregates (JIE #270)
+
+The Langfuse run-level evaluators emit five latency statistics alongside `mean_latency_sla`:
+
+- `mean_latency_seconds`, `p50_latency_seconds`, `p95_latency_seconds`, `p99_latency_seconds` — raw wall-clock seconds
+- `p95_latency_sla_score` — `min(1, SLA / p95)` for iteration signal at the tail
+
+`catastrophic_excluded` in each comment counts items excluded from `latency_sla` scoring.
+
+---
 
 ### Extraction eval
 


### PR DESCRIPTION
## Summary

Closes the documentation gap remaining after all 15 sub-issues of the #272 eval harness redesign epic were merged into `development`. The implementation (scorer redesign, Layer 2 scripts, per-stage Langfuse observations, HTTP headers fix) is already live; this PR brings the reference documentation up to date and formally closes ADR-009.

- **`eval/README.md`** — Fix stale default SLA (45s → 15s per JIE #270), add missing `QA_EVAL_ANSWERABILITY_GATE_THRESHOLD` env var, and add a complete _v2 scorer architecture_ reference section documenting None semantics (#263), binary intent (#261), refusal redesign (#260), component scores (#265), `correct_refusal` metric (#269), sub-composites + geometric mean (#268), per-stage Langfuse observations (#258), per-intent breakdown script (#256), and latency tail aggregates (#270).
- **`docs/adr/ADR-009-week-10-eval-scoring-strategy.md`** — Update status from _Proposed_ to _Accepted_. Documents Option D (Hybrid) as the decision, lists the evidence collected in Week 10 (all sub-issues closed, Langfuse LLM-as-a-Judge enabled per #264, Layer 2 IRR report generated, divergence report produced), and notes the custom scorer as the offline fallback.

## Test plan

- [x] `pytest eval/tests/test_qa_eval_scoring.py eval/tests/test_qa_eval_cohort_filter.py` — 80 passed, 0 failed (no code changes; documentation only)
- [x] Verified all cross-references in README point to correct issue numbers and function names present in `qa_scoring.py`
- [x] Verified env var defaults match `eval/_config.py` (`qa_latency_sla_seconds` default 15.0) and `qa_scoring.py` (`_DEFAULT_LATENCY_SLA_SECONDS = 15.0`)

Closes #272.