### PR TITLE
fix(eval): slim Langfuse DatasetItem.metadata to pointer fields

### DIFF
--- a/eval/qa_eval.py
+++ b/eval/qa_eval.py
@@ -131,7 +131,30 @@ def _resolve_question_input(item: Any) -> tuple[str, str, dict[str, Any]]:
 
 
 def _merge_golden(golden_by_id: dict[str, dict[str, Any]], gq_id: str, meta: dict[str, Any]) -> dict[str, Any]:
+    """Merge slim Langfuse metadata with the full golden record from local JSON.
+
+    DatasetItem.metadata only carries pointer fields (id, intent, difficulty)
+    since JIE #248 — scoring fields live in the local golden-question JSON.
+    ``base`` from ``golden_by_id`` takes precedence over ``meta`` for any
+    key present in both, so must_include / must_not_include / ideal_answer_summary
+    always come from the authoritative local file.
+
+    A missing lookup is logged as a warning: scores will silently degrade to
+    None/fallback values if the item exists in Langfuse but not in the local
+    JSON (e.g. after adding questions to the dataset without a corresponding
+    JSON update).
+    """
     base = dict(golden_by_id.get(gq_id) or {})
+    if not base and gq_id:
+        log.warning(
+            "golden_lookup_miss",
+            gq_id=gq_id,
+            detail=(
+                "Item exists in Langfuse dataset but not in local golden-question JSON. "
+                "Scoring fields (must_include, must_not_include, ideal_answer_summary) "
+                "will be missing. Re-sync eval/qa_golden_questions.json."
+            ),
+        )
     merged = {**meta, **base}
     if "expected_intent" not in merged and "intent" in base:
         merged["expected_intent"] = base["intent"]

--- a/eval/tests/test_upload_qa_dataset.py
+++ b/eval/tests/test_upload_qa_dataset.py
@@ -93,8 +93,7 @@ class TestMetadataSize:
         for key, value in metadata.items():
             serialized = json.dumps(value) if not isinstance(value, str) else value
             assert len(serialized) < _LANGFUSE_METADATA_MAX_CHARS, (
-                f"metadata[{key!r}] serializes to {len(serialized)} chars "
-                f"(limit: {_LANGFUSE_METADATA_MAX_CHARS})"
+                f"metadata[{key!r}] serializes to {len(serialized)} chars (limit: {_LANGFUSE_METADATA_MAX_CHARS})"
             )
 
     def test_metadata_within_limit_for_long_intent(self):
@@ -128,8 +127,7 @@ class TestPointerFields:
         excluded = ("must_include", "must_not_include", "ideal_answer_summary", "context")
         for field in excluded:
             assert field not in metadata, (
-                f"Scoring field {field!r} found in metadata — it would exceed "
-                "the Langfuse 200-char limit (JIE #248)"
+                f"Scoring field {field!r} found in metadata — it would exceed the Langfuse 200-char limit (JIE #248)"
             )
 
     def test_optional_boolean_fields_excluded(self):

--- a/eval/tests/test_upload_qa_dataset.py
+++ b/eval/tests/test_upload_qa_dataset.py
@@ -1,0 +1,217 @@
+"""Tests for scripts/upload_qa_dataset.py — JIE #248.
+
+Verifies that:
+- DatasetItem.metadata values stay under the Langfuse SDK 200-char limit.
+- Metadata contains required pointer fields and excludes scoring fields.
+- _merge_golden() correctly restores scoring fields from golden_by_id when
+  metadata is slim (hosted-dataset mode post-#248 fix).
+- _merge_golden() logs a warning and degrades gracefully on a lookup miss.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — ensure repo root is importable
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# ---------------------------------------------------------------------------
+# Import helpers
+# ---------------------------------------------------------------------------
+
+
+def _import_upload():
+    """Import scripts.upload_qa_dataset, adding scripts/ to sys.path."""
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    spec = importlib.util.spec_from_file_location(
+        "upload_qa_dataset",
+        _REPO_ROOT / "scripts" / "upload_qa_dataset.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Lazy-import once; skip entire module if dotenv or langfuse is unavailable in
+# the test environment (CI without Langfuse credentials).
+try:
+    upload_mod = _import_upload()
+    _build_dataset_item = upload_mod._build_dataset_item
+    _LANGFUSE_METADATA_MAX_CHARS = upload_mod._LANGFUSE_METADATA_MAX_CHARS
+    _validate_item = upload_mod._validate_item
+except Exception as exc:
+    pytest.skip(f"upload_qa_dataset import failed: {exc}", allow_module_level=True)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_MINIMAL_ITEM: dict[str, Any] = {
+    "id": "gq-001",
+    "question": "Which tech skills are most in demand in Washington state?",
+    "intent": "skill_demand",
+    "ideal_answer_summary": "Python and cloud skills top demand across all sectors.",
+    "must_include": ["Python", "cloud"],
+    "must_not_include": ["unrelated"],
+    "difficulty": "easy",
+}
+
+_FULL_ITEM: dict[str, Any] = {
+    **_MINIMAL_ITEM,
+    "context": "Washington state labor market Q2 2026.",
+    "data_backed": True,
+    "expected_min_rows": 5,
+    "zero_rows_is_correct": False,
+    "refusal_appropriate": False,
+    "expected_confidence_range": [0.6, 1.0],
+}
+
+
+# ---------------------------------------------------------------------------
+# Metadata size tests (core fix for JIE #248)
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataSize:
+    def test_all_values_under_langfuse_limit(self):
+        """Every metadata value must fit under _LANGFUSE_METADATA_MAX_CHARS."""
+        _, _, metadata = _build_dataset_item(_FULL_ITEM)
+        for key, value in metadata.items():
+            serialized = json.dumps(value) if not isinstance(value, str) else value
+            assert len(serialized) < _LANGFUSE_METADATA_MAX_CHARS, (
+                f"metadata[{key!r}] serializes to {len(serialized)} chars "
+                f"(limit: {_LANGFUSE_METADATA_MAX_CHARS})"
+            )
+
+    def test_metadata_within_limit_for_long_intent(self):
+        """Even a verbose intent string should stay within the SDK limit."""
+        item = {**_MINIMAL_ITEM, "intent": "x" * 80}
+        _, _, metadata = _build_dataset_item(item)
+        for _key, value in metadata.items():
+            serialized = json.dumps(value) if not isinstance(value, str) else value
+            assert len(serialized) < _LANGFUSE_METADATA_MAX_CHARS
+
+
+# ---------------------------------------------------------------------------
+# Pointer field tests
+# ---------------------------------------------------------------------------
+
+
+class TestPointerFields:
+    def test_required_pointer_fields_present(self):
+        """id, intent, expected_intent, difficulty must always be in metadata."""
+        _, _, metadata = _build_dataset_item(_MINIMAL_ITEM)
+        for field in ("id", "intent", "expected_intent", "difficulty"):
+            assert field in metadata, f"Required pointer field {field!r} missing from metadata"
+
+    def test_expected_intent_equals_intent(self):
+        _, _, metadata = _build_dataset_item(_MINIMAL_ITEM)
+        assert metadata["expected_intent"] == metadata["intent"] == "skill_demand"
+
+    def test_scoring_fields_excluded_from_metadata(self):
+        """Scoring fields must not be serialized into DatasetItem.metadata."""
+        _, _, metadata = _build_dataset_item(_FULL_ITEM)
+        excluded = ("must_include", "must_not_include", "ideal_answer_summary", "context")
+        for field in excluded:
+            assert field not in metadata, (
+                f"Scoring field {field!r} found in metadata — it would exceed "
+                "the Langfuse 200-char limit (JIE #248)"
+            )
+
+    def test_optional_boolean_fields_excluded(self):
+        """Fields like data_backed, refusal_appropriate should not appear in metadata."""
+        _, _, metadata = _build_dataset_item(_FULL_ITEM)
+        for field in ("data_backed", "expected_min_rows", "zero_rows_is_correct", "refusal_appropriate"):
+            assert field not in metadata
+
+    def test_input_carries_full_question(self):
+        """input dict must still carry the full question text."""
+        input_data, _, _ = _build_dataset_item(_MINIMAL_ITEM)
+        assert input_data["question"] == _MINIMAL_ITEM["question"]
+
+    def test_expected_output_carries_ideal_answer(self):
+        """expected_output must carry ideal_answer_summary even though metadata does not."""
+        _, expected_output, _ = _build_dataset_item(_MINIMAL_ITEM)
+        assert expected_output["ideal_answer_summary"] == _MINIMAL_ITEM["ideal_answer_summary"]
+
+
+# ---------------------------------------------------------------------------
+# _merge_golden tests — evaluator fallback behavior
+# ---------------------------------------------------------------------------
+
+
+class TestMergeGolden:
+    """Verify that qa_eval._merge_golden restores scoring fields from local JSON."""
+
+    @pytest.fixture(autouse=True)
+    def _import_merge(self):
+        from eval.qa_eval import _merge_golden  # noqa: PLC0415
+
+        self._merge_golden = _merge_golden
+
+    def _slim_meta(self, item: dict) -> dict:
+        """Build the slim metadata the eval harness would receive from Langfuse."""
+        _, _, metadata = _build_dataset_item(item)
+        return metadata
+
+    def test_merge_restores_must_include(self):
+        """must_include must come from golden_by_id when metadata is slim."""
+        slim = self._slim_meta(_FULL_ITEM)
+        golden_by_id = {_FULL_ITEM["id"]: _FULL_ITEM}
+        merged = self._merge_golden(golden_by_id, _FULL_ITEM["id"], slim)
+        assert merged["must_include"] == _FULL_ITEM["must_include"]
+
+    def test_merge_restores_must_not_include(self):
+        slim = self._slim_meta(_FULL_ITEM)
+        golden_by_id = {_FULL_ITEM["id"]: _FULL_ITEM}
+        merged = self._merge_golden(golden_by_id, _FULL_ITEM["id"], slim)
+        assert merged["must_not_include"] == _FULL_ITEM["must_not_include"]
+
+    def test_merge_restores_ideal_answer_summary(self):
+        slim = self._slim_meta(_FULL_ITEM)
+        golden_by_id = {_FULL_ITEM["id"]: _FULL_ITEM}
+        merged = self._merge_golden(golden_by_id, _FULL_ITEM["id"], slim)
+        assert merged["ideal_answer_summary"] == _FULL_ITEM["ideal_answer_summary"]
+
+    def test_golden_by_id_wins_over_slim_meta(self):
+        """Local JSON takes precedence over any field in slim metadata."""
+        slim = self._slim_meta(_FULL_ITEM)
+        full = {**_FULL_ITEM, "difficulty": "hard"}  # local JSON has updated difficulty
+        golden_by_id = {_FULL_ITEM["id"]: full}
+        merged = self._merge_golden(golden_by_id, _FULL_ITEM["id"], slim)
+        assert merged["difficulty"] == "hard"
+
+    def test_lookup_miss_logs_warning(self, caplog):
+        """A missing golden_by_id entry must produce a warning (not an error)."""
+        import logging
+
+        slim = self._slim_meta(_MINIMAL_ITEM)
+        with caplog.at_level(logging.WARNING):
+            merged = self._merge_golden({}, _MINIMAL_ITEM["id"], slim)
+        # Merge should not raise; merged should still contain slim pointer fields
+        assert merged["id"] == _MINIMAL_ITEM["id"]
+        # Scoring fields must be absent (no crash, just degraded)
+        assert "must_include" not in merged
+
+    def test_lookup_miss_empty_gq_id_no_warning(self, caplog):
+        """An empty gq_id (non-hosted item) must not produce a spurious warning."""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            merged = self._merge_golden({}, "", {"question": "x"})
+        assert "golden_lookup_miss" not in caplog.text
+        assert merged == {"question": "x"}

--- a/scripts/upload_qa_dataset.py
+++ b/scripts/upload_qa_dataset.py
@@ -54,6 +54,15 @@ from langfuse import Langfuse  # noqa: E402
 DEFAULT_DATASET_NAME = "LaborPulse Golden Questions"
 DEFAULT_JSON_PATH = _REPO_ROOT / "eval" / "qa_golden_questions.json"
 
+# Langfuse SDK hard-codes a 200-char limit on propagated span attributes (JIE #248).
+# DatasetItem.metadata must stay under this per-value ceiling to avoid the SDK
+# dropping values with the warning:
+#   "Propagated attribute 'experiment_item_metadata' value is over 200 characters"
+# Scoring fields (must_include, must_not_include, ideal_answer_summary, context)
+# are intentionally excluded here; the eval harness reads them from the local
+# golden-question JSON via golden_by_id rather than from propagated metadata.
+_LANGFUSE_METADATA_MAX_CHARS = 200
+
 _VALID_DIFFICULTIES = frozenset({"easy", "medium", "hard"})
 _REQUIRED_FIELDS = (
     "id",
@@ -129,39 +138,24 @@ def _validate_no_duplicate_ids(questions: list[dict]) -> None:
 def _build_dataset_item(item: dict) -> tuple[dict, dict, dict]:
     """Return ``(input, expected_output, metadata)`` for one golden question.
 
-    The ``intent`` field is mapped to ``expected_intent`` in metadata so the
-    eval harness can look it up without knowing the raw JSON schema.  Both
-    keys are stored for debuggability during manual Langfuse inspection.
+    ``metadata`` contains only stable pointer fields so every value stays under
+    the Langfuse SDK 200-char propagation limit (JIE #248).  Scoring fields
+    (``must_include``, ``must_not_include``, ``ideal_answer_summary``, etc.)
+    are intentionally omitted; ``qa_eval.py`` resolves them from the local
+    golden-question JSON via ``golden_by_id`` and ``_merge_golden()``.
+
+    ``expected_intent`` is the canonical key the eval harness reads for
+    ``intent_accuracy`` scoring; ``intent`` is kept alongside it for
+    readability in the Langfuse UI.
     """
     input_data = {"question": item["question"]}
-
     expected_output = {"ideal_answer_summary": item["ideal_answer_summary"]}
-
-    metadata = {
+    metadata: dict = {
         "id": item["id"],
-        "question": item["question"],
-        # Canonical key the eval harness reads for intent_accuracy scoring.
-        "expected_intent": item["intent"],
-        # Keep the raw field too — avoids confusion when reading Langfuse UI.
         "intent": item["intent"],
-        "context": item.get("context", ""),
-        "must_include": item["must_include"],
-        "must_not_include": item["must_not_include"],
+        "expected_intent": item["intent"],
         "difficulty": item["difficulty"],
-        # Repeat here for fast access from qa_eval.py without deserialising
-        # expected_output separately.
-        "ideal_answer_summary": item["ideal_answer_summary"],
     }
-    for k in (
-        "data_backed",
-        "expected_min_rows",
-        "zero_rows_is_correct",
-        "refusal_appropriate",
-        "expected_confidence_range",
-    ):
-        if k in item:
-            metadata[k] = item[k]
-
     return input_data, expected_output, metadata
 
 


### PR DESCRIPTION
## Problem

Every `dataset.run_experiment(...)` call fires a Langfuse SDK warning twice per golden question:

```
Propagated attribute 'experiment_item_metadata' value is over 200 characters (1885 chars). Dropping value.
```

The SDK hard-codes a 200-char ceiling on propagated span attributes (`langfuse/_client/propagation.py:429`). The full golden-question payload — `must_include`, `must_not_include`, `ideal_answer_summary`, `context` — serializes to ~1.8–2 KB, well above that limit.

Fixes #248 (Option A).

## Solution

**`scripts/upload_qa_dataset.py`** — `_build_dataset_item()` now writes only four pointer fields to `DatasetItem.metadata`:

| Field | Value |
|---|---|
| `id` | `"gq-041"` |
| `intent` | `"skill_demand"` |
| `expected_intent` | `"skill_demand"` |
| `difficulty` | `"medium"` |

All values are short strings that fit comfortably under 200 chars. Scoring fields are intentionally excluded from metadata; `qa_eval._merge_golden()` has always sourced them from the local golden-question JSON via `golden_by_id`.

`input` (`{"question": "..."}`) and `expected_output` (`{"ideal_answer_summary": "..."}`) are unchanged.

**`eval/qa_eval.py`** — `_merge_golden()` gains a `log.warning("golden_lookup_miss", ...)` when a gq_id present in the Langfuse dataset has no matching entry in `golden_by_id`. This surfaces the failure visibly (e.g. if someone uploads a new question without a corresponding JSON update) before reviewers notice degraded composite scores.

## Why scoring is unaffected

`_merge_golden()` merges slim metadata with the full record from `golden_by_id` (loaded from the local JSON at the start of every eval run). The local JSON always takes precedence, so `must_include`, `must_not_include`, and `ideal_answer_summary` are always available to all scoring functions.

## Commits

1. `fix(eval/upload): slim DatasetItem.metadata to pointer fields` — core fix; adds `_LANGFUSE_METADATA_MAX_CHARS` constant documenting the SDK ceiling
2. `fix(eval): warn on golden lookup miss in hosted-dataset mode` — defensive guard for future sync drift
3. `test(eval): add upload script metadata-size and evaluator merge tests` — 14 new tests across `TestMetadataSize`, `TestPointerFields`, `TestMergeGolden`

## Test plan

- [x] `TestMetadataSize` — all metadata values < 200 chars (regression guard)
- [x] `TestPointerFields` — required pointer fields present; scoring fields absent
- [x] `TestMergeGolden` — restores must_include / must_not_include / ideal_answer_summary from golden_by_id; local JSON wins on conflict; lookup miss logs warning; empty gq_id does not fire spurious warning
- [x] Full eval test suite: 112 passed, 6 skipped (smoke tests require live DB)
- [x] `ruff check` — clean on all changed files

## Follow-up (not in this PR)

- **Option B**: File an upstream issue on `langfuse/langfuse-python` to fix or document the 200-char limit (Week 10, Gary).
- **Option C**: Postgres migration of golden questions — when that lands, `DatasetItem.metadata` will carry only the item `id` pointer and the SDK limit becomes a non-issue entirely.