### PR TITLE
fix(eval/upload): set 60s timeout on Langfuse client

### DIFF
--- a/scripts/upload_qa_dataset.py
+++ b/scripts/upload_qa_dataset.py
@@ -170,7 +170,7 @@ def upload(
     dataset_name: str,
     dry_run: bool,
 ) -> None:
-    client: Langfuse | None = None if dry_run else Langfuse()
+    client: Langfuse | None = None if dry_run else Langfuse(timeout=60)
 
     if client is not None:
         # create_dataset is idempotent — safe to call on every upload.


### PR DESCRIPTION
## Problem

After merging #421 (slim metadata), running `upload_qa_dataset.py` against the self-hosted Langfuse at `langfuse.watechcoalition.org` failed immediately with `httpx.ReadTimeout` on the first `create_dataset()` call. 
The remote server responds in ~4 seconds per API call — the SDK default timeout is shorter.

## Fix

Pass `timeout=60` to the `Langfuse()` constructor. 60 seconds gives each request substantial headroom while still failing fast on genuine connectivity problems.

## Verified

All 90 golden questions uploaded successfully. Spot-checked `gq-001` via API:

```json
{
  "id": "gq-001",
  "intent": "disruption",
  "difficulty": "hard",
  "expected_intent": "disruption"
}
```

Slim pointer-only metadata confirmed live in the hosted dataset.