### PR TITLE
fix(test-debt): resolve 4 pre-existing test failures (#302)

### DIFF
--- a/enrichment/agent.py
+++ b/enrichment/agent.py
@@ -288,14 +288,13 @@ def _emit_enrichment_degraded(
     reason: str,
     extraction_note: str | None,
 ) -> None:
-    message = "Spam classification degraded; record continued with null spam fields."
     log.warning(
         "EnrichmentDegraded",
         posting_id=posting_id,
         normalized_job_id=normalized_job_id,
         reason=reason,
         extraction_note=extraction_note,
-        message=message,
+        detail="Spam classification degraded; record continued with null spam fields.",
     )
     if _alert_bus is None:
         return
@@ -372,7 +371,7 @@ def _check_soc_unclassified_rate(
         unclassified_count=unclassified_count,
         unclassified_rate=round(unclassified_rate, 4),
         threshold=threshold,
-        message=(
+        detail=(
             f"SOC unclassified rate {unclassified_rate:.1%} exceeds threshold "
             f"{threshold:.1%} for batch {batch_id}. "
             "Check dbo.socc population and LLM classification quality."

--- a/enrichment/agent.py
+++ b/enrichment/agent.py
@@ -316,7 +316,7 @@ def _emit_enrichment_degraded(
                     "overall_confidence",
                 ],
                 "extraction_note": extraction_note,
-                "message": message,
+                "message": "Spam classification degraded; record continued with null spam fields.",
             },
         )
         _alert_bus.publish(event)

--- a/ingestion/sources/scraper_adapter.py
+++ b/ingestion/sources/scraper_adapter.py
@@ -18,7 +18,7 @@ from ingestion.sources.base_adapter import SourceAdapter
 log = structlog.get_logger()
 
 _FALLBACK_SCRAPE = (
-    Path(__file__).parent.parent  # agents/
+    Path(__file__).parent.parent.parent  # repo root
     / "data"
     / "fixtures"
     / "fallback_scrape_sample.json"


### PR DESCRIPTION
## Summary

Fixes the remaining 4 of the 5 pre-existing test failures tracked in #302. The 5th (`test_env_override_emits_warning_once`) already passes at HEAD — it self-healed from an unrelated change.

- **`ingestion/sources/scraper_adapter.py`** — `_FALLBACK_SCRAPE` path was off by one `.parent`. `Path(__file__).parent.parent` resolved to `ingestion/` instead of the repo root, so `data/fixtures/fallback_scrape_sample.json` was never found and `_fetch_fixture` silently returned `[]`. Added one more `.parent` to reach the repo root.
- **`enrichment/agent.py`** — two `log.warning()` calls passed `message=` as a structlog keyword argument. Python's stdlib `LogRecord` reserves the key `"message"` and raises `KeyError: "Attempt to overwrite 'message' in LogRecord"` when structlog propagates it through. Renamed both to `detail=`.

## Test plan

- [x] All 5 originally-failing tests now pass: `pytest common/tests/test_config_loader.py::test_env_override_emits_warning_once ingestion/tests/test_scraper_adapter.py::TestScraperAdapter ingestion/tests/test_scraper_adapter.py::TestScraperAdapter tests/test_enrichment_agent.py::TestEnrichmentAgentBatchRecords::test_process_passes_none_session_when_db_unavailable -v` → **5 passed**
- [x] Full ingestion + enrichment unit suites: `pytest ingestion/ enrichment/tests/ -q` → **339 passed, 3 skipped**
- [x] No regressions in the broader suite (1,621 passed; remaining failures are pre-existing DB-connection tests requiring live Postgres)

Closes #302