### PR TITLE
fix: collapse CI/CD synonym group in skill comparison queries (#360)

### DIFF
--- a/analytics/query_engine/router.py
+++ b/analytics/query_engine/router.py
@@ -43,6 +43,11 @@ from analytics.query_engine.constants import (
     NO_DATA_SKILL_TAXONOMY_REFUSAL,
     SKILL_TAXONOMY_GATE_CONFIDENCE_CAP,
 )
+from analytics.query_engine.skill_synonyms import (
+    expand_skill_query_terms,
+    resolve_canonical_skill,
+    terms_share_synonym_group,
+)
 from analytics.tenant_scope import TenantAccess, get_tenant_access_for_pipeline
 from common.data_store.models import (
     CanonicalRole,
@@ -792,6 +797,34 @@ class QueryRouter:
                 error=str(exc),
                 confidence=confidence,
             )
+
+    @staticmethod
+    def _collapse_comparison_synonym_rows(
+        rows: list[dict[str, Any]],
+        *,
+        canonical: str,
+    ) -> list[dict[str, Any]]:
+        """Sum alias ``skill_demand_weekly`` rows per week under *canonical* label."""
+        by_week: dict[Any, dict[str, Any]] = {}
+        for row in rows:
+            week = row.get("week_start")
+            bucket = by_week.get(week)
+            if bucket is None:
+                bucket = {
+                    "skill_label": canonical,
+                    "week_start": week,
+                    "posting_count": 0,
+                    "employer_count": 0,
+                    "esco_uri": None,
+                }
+                by_week[week] = bucket
+            bucket["posting_count"] += int(row.get("posting_count") or 0)
+            bucket["employer_count"] += int(row.get("employer_count") or 0)
+            if bucket.get("esco_uri") is None and row.get("esco_uri"):
+                bucket["esco_uri"] = row.get("esco_uri")
+        collapsed = list(by_week.values())
+        collapsed.sort(key=lambda r: (r.get("week_start") is None, r.get("week_start")), reverse=True)
+        return collapsed
 
     @staticmethod
     def _ilike_or(column: Any, names: list[str], max_terms: int = 5) -> Any | None:
@@ -1751,8 +1784,12 @@ class QueryRouter:
         if not tenant.can_query_borderplex_skill_tables:
             return self._no_borderplex_market_aggregates(intent, confidence)
         if skill_names:
+            synonym_collapse = terms_share_synonym_group(skill_names)
+            query_terms = expand_skill_query_terms(skill_names) if synonym_collapse else skill_names
+            canonical_label = resolve_canonical_skill(skill_names[0]) if synonym_collapse else None
+
             t = SkillDemandWeekly
-            skill_filter = self._ilike_or(t.skill_label, skill_names)
+            skill_filter = self._ilike_or(t.skill_label, query_terms, max_terms=len(query_terms))
             stmt = (
                 select(
                     t.skill_label,
@@ -1767,8 +1804,38 @@ class QueryRouter:
             if skill_filter is not None:
                 stmt = stmt.where(skill_filter)
 
-            label = f"skill comparison — {' vs '.join(skill_names[:5])}"
+            if synonym_collapse and canonical_label:
+                label = f"skill comparison (synonym-collapsed) — {canonical_label} group"
+            else:
+                label = f"skill comparison — {' vs '.join(skill_names[:5])}"
             tables_used = ["skill_demand_weekly"]
+
+            result = self._execute(
+                session,
+                stmt,
+                intent=intent,
+                tables_used=tables_used,
+                query_label=label,
+                confidence=confidence,
+            )
+            if synonym_collapse and canonical_label and result.routed and result.rows:
+                collapsed = self._collapse_comparison_synonym_rows(
+                    result.rows,
+                    canonical=canonical_label,
+                )
+                return RouteResult(
+                    intent=result.intent,
+                    tables_used=result.tables_used,
+                    query_label=result.query_label,
+                    rows=collapsed,
+                    row_count=len(collapsed),
+                    is_partial=result.is_partial,
+                    routed=result.routed,
+                    error=result.error,
+                    confidence=result.confidence,
+                    empty_rows_refusal_reason=result.empty_rows_refusal_reason,
+                )
+            return result
         else:
             ss = SectorSummaryWeekly
             stmt = (

--- a/analytics/query_engine/skill_synonyms.py
+++ b/analytics/query_engine/skill_synonyms.py
@@ -1,0 +1,103 @@
+"""Query-time skill synonym groups for analytics Q&A (JIE #360).
+
+Equivalent labels in ``config/skill_synonyms.yaml`` are collapsed when routing
+skill-comparison queries against ``skill_demand_weekly``. Write-time extraction
+and aggregation are unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+
+from common.config_loader import load_yaml
+from common.text_normalization import normalize_label
+
+
+@dataclass(frozen=True)
+class SkillSynonymGroup:
+    canonical: str
+    aliases: frozenset[str]
+
+
+def normalize_skill_label(label: str) -> str:
+    """NFKC normalize, lowercase, collapse whitespace; slash/hyphen → space."""
+    text = normalize_label(label)
+    return re.sub(r"[-_/]+", " ", text).strip()
+
+
+@lru_cache(maxsize=1)
+def _load_groups() -> tuple[SkillSynonymGroup, ...]:
+    data = load_yaml("skill_synonyms")
+    raw = data.get("skill_synonyms") or {}
+    groups_raw = raw.get("groups") if isinstance(raw, dict) else None
+    if not isinstance(groups_raw, list):
+        return ()
+    out: list[SkillSynonymGroup] = []
+    for item in groups_raw:
+        if not isinstance(item, dict):
+            continue
+        canonical = str(item.get("canonical") or "").strip()
+        if not canonical:
+            continue
+        aliases_raw = item.get("aliases") or []
+        aliases = frozenset(str(a).strip() for a in aliases_raw if str(a).strip())
+        out.append(SkillSynonymGroup(canonical=canonical, aliases=aliases))
+    return tuple(out)
+
+
+@lru_cache(maxsize=1)
+def _alias_to_canonical() -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for group in _load_groups():
+        mapping[normalize_skill_label(group.canonical)] = group.canonical
+        for alias in group.aliases:
+            mapping[normalize_skill_label(alias)] = group.canonical
+    return mapping
+
+
+@lru_cache(maxsize=1)
+def _canonical_to_group_labels() -> dict[str, frozenset[str]]:
+    out: dict[str, frozenset[str]] = {}
+    for group in _load_groups():
+        labels = frozenset({group.canonical, *group.aliases})
+        out[group.canonical] = labels
+    return out
+
+
+def resolve_canonical_skill(label: str) -> str:
+    """Map alias → canonical; unknown labels pass through trimmed."""
+    key = normalize_skill_label(label)
+    if not key:
+        return str(label or "").strip()
+    return _alias_to_canonical().get(key, str(label).strip())
+
+
+def get_synonym_group_for_term(term: str) -> frozenset[str] | None:
+    """Return all labels in the synonym group for *term*, or ``None``."""
+    canonical = resolve_canonical_skill(term)
+    return _canonical_to_group_labels().get(canonical)
+
+
+def expand_skill_query_terms(terms: list[str]) -> list[str]:
+    """Expand user terms to all aliases in any matched synonym group."""
+    expanded: set[str] = set()
+    for term in terms:
+        group = get_synonym_group_for_term(term)
+        if group:
+            expanded.update(group)
+        elif term.strip():
+            expanded.add(term.strip())
+    return sorted(expanded)
+
+
+def terms_share_synonym_group(terms: list[str]) -> bool:
+    """True when ≥2 terms resolve to the same configured synonym canonical."""
+    if len(terms) < 2:
+        return False
+    canonicals = {resolve_canonical_skill(t) for t in terms if str(t).strip()}
+    if len(canonicals) != 1:
+        return False
+    canonical = next(iter(canonicals))
+    return canonical in _canonical_to_group_labels()

--- a/analytics/tests/test_router.py
+++ b/analytics/tests/test_router.py
@@ -616,6 +616,78 @@ class TestComparisonSkillSupplement:
         session.execute.assert_called_once()
 
 
+class TestComparisonSynonymCollapse:
+    """JIE #360 — query-time collapse of equivalent skill labels in comparison route."""
+
+    def test_synonym_comparison_collapses_counts_per_week(self) -> None:
+        from datetime import date
+
+        week = date(2026, 4, 6)
+        session = _make_session(
+            rows=[
+                _make_mock_row(
+                    skill_label="CI/CD",
+                    week_start=week,
+                    posting_count=15,
+                    employer_count=3,
+                    esco_uri=None,
+                ),
+                _make_mock_row(
+                    skill_label="Continuous Integration",
+                    week_start=week,
+                    posting_count=29,
+                    employer_count=5,
+                    esco_uri="http://esco.example/ci",
+                ),
+            ],
+            taxonomy_lower_matches=("continuous integration", "ci/cd"),
+        )
+        cls = _mk_classification(
+            "comparison",
+            skill_names=["CI/CD", "Continuous Integration"],
+        )
+        result = QueryRouter().route(cls, session)
+        assert result.routed is True
+        assert result.row_count == 1
+        assert result.rows[0]["skill_label"] == "Continuous Integration"
+        assert result.rows[0]["posting_count"] == 44
+        assert result.rows[0]["employer_count"] == 8
+        assert result.rows[0]["esco_uri"] == "http://esco.example/ci"
+        assert "synonym-collapsed" in result.query_label
+
+    def test_unrelated_skills_not_collapsed(self) -> None:
+        from datetime import date
+
+        week = date(2026, 4, 6)
+        session = _make_session(
+            rows=[
+                _make_mock_row(
+                    skill_label="Cloud Computing",
+                    week_start=week,
+                    posting_count=10,
+                    employer_count=2,
+                    esco_uri=None,
+                ),
+                _make_mock_row(
+                    skill_label="Cybersecurity",
+                    week_start=week,
+                    posting_count=20,
+                    employer_count=4,
+                    esco_uri=None,
+                ),
+            ],
+            taxonomy_lower_matches=("cloud computing", "cybersecurity"),
+        )
+        cls = _mk_classification(
+            "comparison",
+            skill_names=["Cloud Computing", "Cybersecurity"],
+        )
+        result = QueryRouter().route(cls, session)
+        assert result.routed is True
+        assert result.row_count == 2
+        assert "synonym-collapsed" not in result.query_label
+
+
 # ---------------------------------------------------------------------------
 # label_embedding role resolution (issue #229)
 # ---------------------------------------------------------------------------

--- a/analytics/tests/test_skill_synonyms.py
+++ b/analytics/tests/test_skill_synonyms.py
@@ -1,0 +1,28 @@
+"""Unit tests for analytics.query_engine.skill_synonyms (JIE #360)."""
+
+from __future__ import annotations
+
+from analytics.query_engine.skill_synonyms import (
+    expand_skill_query_terms,
+    resolve_canonical_skill,
+    terms_share_synonym_group,
+)
+
+
+def test_resolve_canonical_skill_ci_cd_and_continuous_integration() -> None:
+    assert resolve_canonical_skill("CI/CD") == resolve_canonical_skill("Continuous Integration")
+    assert resolve_canonical_skill("Continuous Integration") == "Continuous Integration"
+
+
+def test_terms_share_synonym_group_ci_variants() -> None:
+    assert terms_share_synonym_group(["CI/CD", "Continuous Integration"]) is True
+
+
+def test_terms_share_synonym_group_different_skills() -> None:
+    assert terms_share_synonym_group(["Cloud Computing", "Cybersecurity"]) is False
+
+
+def test_expand_skill_query_terms_includes_aliases() -> None:
+    expanded = expand_skill_query_terms(["CI/CD"])
+    assert "Continuous Integration" in expanded
+    assert "CI/CD" in expanded

--- a/config/skill_synonyms.yaml
+++ b/config/skill_synonyms.yaml
@@ -1,0 +1,10 @@
+# config/skill_synonyms.yaml — query-time skill synonym groups (JIE #360).
+# Loaded via load_yaml("skill_synonyms") → data["skill_synonyms"]["groups"].
+
+skill_synonyms:
+  groups:
+    - canonical: "Continuous Integration"
+      aliases:
+        - "CI/CD"
+        - "Continuous Integration and Continuous Deployment"
+        - "Continuous Integration/Continuous Deployment"

--- a/skills_extraction/extractors/taxonomy.py
+++ b/skills_extraction/extractors/taxonomy.py
@@ -9,6 +9,12 @@ strict 6-step resolution order:
   5. O*NET occupation code match
   6. Emit as raw_skill with esco_uri = null (Enrichment resolves in Phase 2)
 
+Documentation — equivalent skill labels (JIE #360):
+  Pre-configured synonym groups in ``config/skill_synonyms.yaml`` are collapsed
+  at **query time** in the analytics comparison router (``skill_demand_weekly``).
+  Write-time taxonomy linking in this module is unchanged; future work may add
+  write-time normalization during extraction or aggregation.
+
 Week 4 implementation (Angel + Fabian):
 - Set up ESCO digital skills store (Decision #36)
 - Build GenAI Extension Layer lookup table (10 skills → ESCO parent clusters)


### PR DESCRIPTION
Closes #360

## Summary
Adds query-time synonym collapse for the CI/CD ≡ Continuous Integration group in skill comparison routes. Config-driven via `config/skill_synonyms.yaml`; no changes to `skill_demand_weekly` aggregation or write-time extraction.

**Credit:** Issue spec by theGaryLarson; builds on taxonomy gate work from #349 (`_COMPARISON_SKILL_SUPPLEMENT`).

## Design choice
Query-time collapse (narrow scope) — existing aggregate rows work without re-running aggregate refresh. Write-time normalization deferred to a future PR.

## Collapsed-row rules
- `posting_count` / `employer_count`: summed across alias rows per week (v1 accepts possible over-count; no dedupe)
- `esco_uri`: first non-null from query result order

## Scope
- **Changed:** `_route_comparison` only
- **Unchanged:** `_route_trend`, `_route_curriculum`, and other skill-demand paths

## Parallel work
Related PRs: #426 (#362 role_family), #327 clustering closeout (separate branch).

## Test plan
- [x] `pytest analytics/tests/test_router.py analytics/tests/test_skill_synonyms.py -v` (105 passed)
- [x] `ruff check analytics/query_engine/ skills_extraction/extractors/taxonomy.py`
- [ ] Manual gq-060-style question post-merge (Gary)
- [ ] Regression: gq-052 Cloud Computing vs Cybersecurity unchanged