### PR TITLE
fix(demo): align preflight and demo stack defaults to analytics API port 8000

### DIFF
--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -11,7 +11,7 @@ Template aligned with curriculum Week 11 demo rehearsal. Sections §1, §3, §4,
 | **Date** | Wednesday, May 6 |
 | **Platform** | Microsoft Teams |
 | **Scheduled run time** | ~30 minutes |
-| **Primary surface** | wfd-os LaborPulse (`/laborpulse`) backed by JIE `POST /analytics/query` on port **8020** (reporting-api moved off :8000 in wfd-os) |
+| **Primary surface** | wfd-os LaborPulse (`/laborpulse`) backed by JIE `POST /analytics/query` on port **8000** locally (`python scripts/run_analytics_api.py`); wfd-os `.env` `JIE_BASE_URL` overrides when needed |
 
 ---
 
@@ -38,7 +38,7 @@ Pair D bridges the raw Borderplex hiring signal in JIE to an instructor-friendly
 
 ## §5 — Preconditions
 
-*(DB seeded, JIE on **:8020**, wfd-os `.env` `JIE_BASE_URL=http://127.0.0.1:8020`, API keys, etc.)*
+*(DB seeded, JIE on **:8000** via `python scripts/run_analytics_api.py`, wfd-os `.env` `JIE_BASE_URL=http://127.0.0.1:8000` when LaborPulse calls JIE directly, API keys, etc.)*
 
 ---
 

--- a/scripts/demo/preflight_check.py
+++ b/scripts/demo/preflight_check.py
@@ -7,7 +7,7 @@ Run from repo root with venv activated::
 
 Optional::
 
-    python scripts/demo/preflight_check.py --jie-base-url http://127.0.0.1:8020
+    python scripts/demo/preflight_check.py --jie-base-url http://127.0.0.1:8000
 """
 
 from __future__ import annotations
@@ -32,6 +32,8 @@ load_dotenv(_ROOT / ".env", override=False)
 from analytics.api._config import allow_no_api_keys
 from common.data_store.database import _resolve_primary_database_url
 
+DEFAULT_JIE_BASE_URL = "http://127.0.0.1:8000"
+
 LOCKED_DEMO_QUESTIONS: tuple[str, ...] = (
     "What are the top IT skills Borderplex employers are hiring for right now?",
     "What should a training program for AI agent developers look like given what Borderplex employers are hiring for right now?",
@@ -39,6 +41,11 @@ LOCKED_DEMO_QUESTIONS: tuple[str, ...] = (
     "What tools and practices do Borderplex employers expect from workflow automation engineers?",
     "What does an MLOps role look like in the Borderplex job market right now?",
 )
+
+
+def _default_jie_base_url() -> str:
+    """Return JIE API base URL; mirrors ``scripts/run_analytics_api.py`` default port."""
+    return os.environ.get("JIE_BASE_URL", DEFAULT_JIE_BASE_URL)
 
 
 def _get(url: str, *, timeout: float = 10.0) -> tuple[int, str]:
@@ -101,7 +108,11 @@ def _likely_refusal(answer: str) -> bool:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Week 11 demo pre-flight checks.")
-    parser.add_argument("--jie-base-url", default="http://localhost:8020")
+    parser.add_argument(
+        "--jie-base-url",
+        default=_default_jie_base_url(),
+        help=f"JIE Analytics API base URL (default: {DEFAULT_JIE_BASE_URL} or JIE_BASE_URL).",
+    )
     parser.add_argument("--portal-url", default="http://localhost:3000")
     args = parser.parse_args()
     jie_base = args.jie_base_url.rstrip("/")

--- a/scripts/demo/start_demo_stack.sh
+++ b/scripts/demo/start_demo_stack.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 # Demo stack startup script
-# Run this before the demo — starts JIE on :8020
+# Run this before the demo — starts JIE on the analytics API default port (8000)
 
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 
-echo "=== Starting JIE on port 8020 ==="
-echo "Open Terminal 2 and run: cd /Users/kuike/Desktop/wfd-os && honcho start"
+PORT="${ANALYTICS_API_PORT:-8000}"
+
+echo "=== Starting JIE on port ${PORT} ==="
+echo "Alternative: python scripts/run_analytics_api.py"
+echo "Open Terminal 2 and run: cd /path/to/wfd-os && honcho start"
 echo "Open Terminal 3 and run: python scripts/smoke/laborpulse/real_query.py"
 echo ""
 echo "Starting JIE..."
 source .venv/bin/activate
-exec uvicorn analytics.api.app:app --host 127.0.0.1 --port 8020
+exec uvicorn analytics.api.app:app --host 127.0.0.1 --port "${PORT}"

--- a/scripts/tests/test_demo_preflight_defaults.py
+++ b/scripts/tests/test_demo_preflight_defaults.py
@@ -1,0 +1,25 @@
+"""Unit tests for demo preflight JIE base URL defaults."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+preflight = importlib.import_module("scripts.demo.preflight_check")
+
+
+def test_default_jie_base_url_matches_run_analytics_api(monkeypatch) -> None:
+    monkeypatch.delenv("JIE_BASE_URL", raising=False)
+
+    assert preflight._default_jie_base_url() == "http://127.0.0.1:8000"
+
+
+def test_default_jie_base_url_honors_jie_base_url(monkeypatch) -> None:
+    monkeypatch.setenv("JIE_BASE_URL", "http://localhost:8010")
+
+    assert preflight._default_jie_base_url() == "http://localhost:8010"


### PR DESCRIPTION
Related to #417

## Summary
Follow-up to merged #417: LaborPulse smoke (`real_query.py`) already defaults to `http://127.0.0.1:8000`, but demo tooling still pointed at `:8020`. This PR aligns `preflight_check.py`, `start_demo_stack.sh`, and `DEMO_SCRIPT.md` with `scripts/run_analytics_api.py` while honoring `JIE_BASE_URL` for non-standard runs.

**Credit:** Pair D (Juan Reyes) — self-found during demo/smoke port audit.

## Scope
- **Changed:** `scripts/demo/preflight_check.py`, `scripts/demo/start_demo_stack.sh`, `docs/DEMO_SCRIPT.md`, `scripts/tests/test_demo_preflight_defaults.py`
- **Unchanged:** `real_query.py` (DRY refactor lands in follow-up PR)

## Parallel work
Orthogonal to open PRs: #426/#427/#428 (clustering), #416 (synthesis), #423 (test-debt).

## Test plan
- [x] `pytest scripts/tests/test_demo_preflight_defaults.py -v` (2 passed)
- [x] `ruff check scripts/demo/preflight_check.py scripts/tests/test_demo_preflight_defaults.py`

