### PR TITLE
refactor(smoke): centralize locked demo questions and JIE base URL helper

### DIFF
--- a/scripts/demo/preflight_check.py
+++ b/scripts/demo/preflight_check.py
@@ -7,7 +7,7 @@ Run from repo root with venv activated::
 
 Optional::
 
-    python scripts/demo/preflight_check.py --jie-base-url http://127.0.0.1:8020
+    python scripts/demo/preflight_check.py --jie-base-url http://127.0.0.1:8000
 """
 
 from __future__ import annotations
@@ -31,13 +31,10 @@ load_dotenv(_ROOT / ".env", override=False)
 
 from analytics.api._config import allow_no_api_keys
 from common.data_store.database import _resolve_primary_database_url
-
-LOCKED_DEMO_QUESTIONS: tuple[str, ...] = (
-    "What are the top IT skills Borderplex employers are hiring for right now?",
-    "What should a training program for AI agent developers look like given what Borderplex employers are hiring for right now?",
-    "What should a training program for cybersecurity analysts look like given what Borderplex employers are hiring for right now?",
-    "What tools and practices do Borderplex employers expect from workflow automation engineers?",
-    "What does an MLOps role look like in the Borderplex job market right now?",
+from scripts.smoke.laborpulse._demo_common import (
+    LOCKED_DEMO_QUESTIONS,
+    default_jie_base_url,
+    likely_refusal,
 )
 
 
@@ -85,23 +82,16 @@ def _post_query(base: str, question: str, *, req_id: str) -> tuple[int, dict]:
 
 
 def _likely_refusal(answer: str) -> bool:
-    a = (answer or "").strip().lower()
-    if not a:
-        return True
-    prefixes = (
-        "i cannot",
-        "i can't",
-        "unable to",
-        "cannot answer",
-        "no data",
-        "not enough data",
-    )
-    return any(a.startswith(p) for p in prefixes)
+    return likely_refusal(answer)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Week 11 demo pre-flight checks.")
-    parser.add_argument("--jie-base-url", default="http://localhost:8020")
+    parser.add_argument(
+        "--jie-base-url",
+        default=default_jie_base_url(),
+        help="JIE Analytics API base URL (default from JIE_BASE_URL or http://127.0.0.1:8000).",
+    )
     parser.add_argument("--portal-url", default="http://localhost:3000")
     args = parser.parse_args()
     jie_base = args.jie_base_url.rstrip("/")

--- a/scripts/smoke/laborpulse/_demo_common.py
+++ b/scripts/smoke/laborpulse/_demo_common.py
@@ -1,0 +1,35 @@
+"""Shared constants and helpers for LaborPulse demo smoke and preflight scripts."""
+
+from __future__ import annotations
+
+import os
+
+LOCKED_DEMO_QUESTIONS: tuple[str, ...] = (
+    "What are the top IT skills Borderplex employers are hiring for right now?",
+    "What should a training program for AI agent developers look like given what Borderplex employers are hiring for right now?",
+    "What should a training program for cybersecurity analysts look like given what Borderplex employers are hiring for right now?",
+    "What tools and practices do Borderplex employers expect from workflow automation engineers?",
+    "What does an MLOps role look like in the Borderplex job market right now?",
+)
+
+DEFAULT_JIE_BASE_URL = "http://127.0.0.1:8000"
+
+
+def default_jie_base_url() -> str:
+    """Return JIE API base URL; mirrors ``scripts/run_analytics_api.py`` default port."""
+    return os.environ.get("JIE_BASE_URL", DEFAULT_JIE_BASE_URL)
+
+
+def likely_refusal(answer: str) -> bool:
+    a = (answer or "").strip().lower()
+    if not a:
+        return True
+    prefixes = (
+        "i cannot",
+        "i can't",
+        "unable to",
+        "cannot answer",
+        "no data",
+        "not enough data",
+    )
+    return any(a.startswith(p) for p in prefixes)

--- a/scripts/smoke/laborpulse/real_query.py
+++ b/scripts/smoke/laborpulse/real_query.py
@@ -33,15 +33,12 @@ _ROOT = Path(__file__).resolve().parents[3]
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
-LOCKED_DEMO_QUESTIONS: tuple[str, ...] = (
-    "What are the top IT skills Borderplex employers are hiring for right now?",
-    "What should a training program for AI agent developers look like given what Borderplex employers are hiring for right now?",
-    "What should a training program for cybersecurity analysts look like given what Borderplex employers are hiring for right now?",
-    "What tools and practices do Borderplex employers expect from workflow automation engineers?",
-    "What does an MLOps role look like in the Borderplex job market right now?",
+from scripts.smoke.laborpulse._demo_common import (  # noqa: E402
+    DEFAULT_JIE_BASE_URL,
+    LOCKED_DEMO_QUESTIONS,
+    default_jie_base_url,
+    likely_refusal,
 )
-
-DEFAULT_JIE_BASE_URL = "http://127.0.0.1:8000"
 
 
 def _headers(*, request_id: str | None = None) -> dict[str, str]:
@@ -76,36 +73,16 @@ def _post(base: str, question: str, *, req_id: str) -> tuple[int, dict]:
         return 0, {"error": str(e.reason)}
 
 
-def _likely_refusal(answer: str) -> bool:
-    a = (answer or "").strip().lower()
-    if not a:
-        return True
-    prefixes = (
-        "i cannot",
-        "i can't",
-        "unable to",
-        "cannot answer",
-        "no data",
-        "not enough data",
-    )
-    return any(a.startswith(p) for p in prefixes)
-
-
 def _default_base_url() -> str:
-    """Return the JIE API base URL used by the smoke script.
-
-    Mirrors ``scripts/run_analytics_api.py`` so the no-argument smoke command
-    targets the API port that local devs get by default, while still allowing
-    ``JIE_BASE_URL`` to override it for non-standard runs.
-    """
-    return os.environ.get("JIE_BASE_URL", DEFAULT_JIE_BASE_URL)
+    """Backward-compatible alias for tests and callers."""
+    return default_jie_base_url()
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Smoke the five locked LaborPulse demo questions.")
     parser.add_argument(
         "--base-url",
-        default=_default_base_url(),
+        default=default_jie_base_url(),
         help=f"JIE Analytics API base URL (default: {DEFAULT_JIE_BASE_URL} or JIE_BASE_URL).",
     )
     parser.add_argument(
@@ -145,10 +122,10 @@ def main() -> int:
             sql_gen = str(body.get("sql_generated") or "")
             if args.require_non_empty_sql and not sql_gen.strip():
                 err_parts.append("empty sql_generated")
-            if _likely_refusal(answer):
+            if likely_refusal(answer):
                 err_parts.append("answer looks like refusal or empty")
 
-        answer_ok = bool(status == 200 and answer.strip() and not _likely_refusal(answer))
+        answer_ok = bool(status == 200 and answer.strip() and not likely_refusal(answer))
         if args.require_non_empty_sql:
             answer_ok = answer_ok and bool(str(body.get("sql_generated") or "").strip())
 

--- a/scripts/tests/test_demo_shared_constants.py
+++ b/scripts/tests/test_demo_shared_constants.py
@@ -1,0 +1,29 @@
+"""Tests that demo smoke and preflight share one source of truth."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+real_query = importlib.import_module("scripts.smoke.laborpulse.real_query")
+preflight = importlib.import_module("scripts.demo.preflight_check")
+demo_common = importlib.import_module("scripts.smoke.laborpulse._demo_common")
+
+
+def test_locked_demo_questions_match_between_scripts() -> None:
+    assert real_query.LOCKED_DEMO_QUESTIONS == preflight.LOCKED_DEMO_QUESTIONS
+    assert real_query.LOCKED_DEMO_QUESTIONS == demo_common.LOCKED_DEMO_QUESTIONS
+    assert len(real_query.LOCKED_DEMO_QUESTIONS) == 5
+
+
+def test_default_jie_base_url_honors_env(monkeypatch) -> None:
+    monkeypatch.delenv("JIE_BASE_URL", raising=False)
+    assert demo_common.default_jie_base_url() == "http://127.0.0.1:8000"
+
+    monkeypatch.setenv("JIE_BASE_URL", "http://localhost:8010")
+    assert demo_common.default_jie_base_url() == "http://localhost:8010"


### PR DESCRIPTION
## Summary
`LOCKED_DEMO_QUESTIONS`, the JIE base URL default, and refusal heuristics were duplicated in `real_query.py` and `preflight_check.py`. This PR extracts a single module so IMP-034 demo questions stay in sync across smoke and preflight paths.

**Credit:** Pair D (Juan Reyes) — self-found during demo/smoke hygiene audit.

## Scope
- **Changed:** `scripts/smoke/laborpulse/_demo_common.py` (new), `real_query.py`, `preflight_check.py`, `scripts/tests/test_demo_shared_constants.py`
- **Unchanged:** API behavior, CLI flags, exit codes

## Before / After
| Before | After |
|--------|-------|
| Questions duplicated in `real_query.py` and `preflight_check.py` | Single `LOCKED_DEMO_QUESTIONS` in `_demo_common.py` |

## Parallel work
Orthogonal to #426/#427/#428 (clustering), #416 (synthesis), #423 (test-debt). Complements #429 (demo port defaults).

## Test plan
- [x] `pytest scripts/tests/test_laborpulse_real_query.py scripts/tests/test_demo_shared_constants.py -v` (4 passed)
- [x] `ruff check scripts/smoke/laborpulse/ scripts/demo/preflight_check.py scripts/tests/`

