### PR TITLE
fix(grounding): exclude source_table from allowed grounding corpus

### DIFF
--- a/analytics/query_engine/grounding.py
+++ b/analytics/query_engine/grounding.py
@@ -52,8 +52,6 @@ def _build_allowed_corpus(bundle: EvidenceBundle) -> str:
             parts.append(str(f.supporting_count))
         if f.time_period:
             parts.append(f.time_period)
-        if f.source_table:
-            parts.append(f.source_table)
     return " ".join(parts).lower()
 
 

--- a/analytics/query_engine/tests/test_grounding.py
+++ b/analytics/query_engine/tests/test_grounding.py
@@ -1,0 +1,47 @@
+"""Tests for numeric grounding against EvidenceBundle."""
+
+from __future__ import annotations
+
+from analytics.query_engine.grounding import _build_allowed_corpus, verify_answer_grounding
+from analytics.query_engine.schemas import DataSufficiency, EvidenceBundle, EvidenceCitation
+
+
+def _bundle_with_table_source() -> EvidenceBundle:
+    return EvidenceBundle(
+        facts=[
+            EvidenceCitation(
+                citation_id="c1",
+                summary="Python skill demand: 42 postings in Borderplex last 90 days",
+                source_table="skill_demand_weekly",
+                supporting_count=42,
+                time_period="last 90 days",
+            )
+        ],
+        period_coverage="last 90 days",
+        sufficiency=DataSufficiency.ADEQUATE,
+    )
+
+
+def test_allowed_corpus_excludes_source_table() -> None:
+    corpus = _build_allowed_corpus(_bundle_with_table_source())
+
+    assert "skill_demand_weekly" not in corpus
+    assert "42" in corpus
+    assert "python" in corpus
+
+
+def test_grounding_accepts_summary_numbers() -> None:
+    bundle = _bundle_with_table_source()
+    result = verify_answer_grounding("Python appears in 42 postings.", bundle)
+
+    assert result.ok is True
+    assert result.unsupported_tokens == ()
+
+
+def test_grounding_rejects_hallucinated_numbers() -> None:
+    bundle = _bundle_with_table_source()
+    result = verify_answer_grounding("Python appears in 9,999 postings.", bundle)
+
+    assert result.ok is False
+    assert result.reason_code == "numeric_not_in_evidence"
+    assert result.unsupported_tokens


### PR DESCRIPTION
Related to #354

## Summary
`_build_allowed_corpus()` appended `source_table` (e.g. `skill_demand_weekly`) into the grounding validation corpus. That leaks internal schema tokens into the allowed-text set. This PR builds the corpus from user-facing fact fields only (summary, counts, periods).

**Credit:** Pair D (Juan Reyes) — self-found during Q&A hygiene audit.

## Scope
- **Changed:** `analytics/query_engine/grounding.py`, `analytics/query_engine/tests/test_grounding.py`
- **Unchanged:** `synthesis.py` (#416 owns synthesis prompt / citeable_facts_json)

## Design choice
Narrow fix on the grounding path only — complements #416 without overlapping its synthesis changes.

## Parallel work
Orthogonal to #426/#427/#428 (clustering), #416 (synthesis table leak), #423 (test-debt).

## Test plan
- [x] `pytest analytics/query_engine/tests/test_grounding.py -v` (3 passed)
- [x] `ruff check analytics/query_engine/grounding.py analytics/query_engine/tests/test_grounding.py`

